### PR TITLE
Build construction cost raster (pipeline step 01)

### DIFF
--- a/code/config.R
+++ b/code/config.R
@@ -97,6 +97,27 @@ raster_ymax  <- -21.780814
 raster_ncols <- 2399L
 raster_nrows <- 3090L
 
+# ---- 6b. Cost-raster pipeline parameters (01_cost_raster.R) ---------------
+#
+# The cost raster is built on a larger grid than the final analysis extent
+# and then cropped. Rasterization extent is wider to leave margin around the
+# country polygon during rasterize(), so coastlines near the final extent
+# don't get clipped by rasterization artifacts.
+
+# Rasterization extent (EPSG:4326 degrees). Covers mainland + margin.
+cost_raster_rast_xmin <- -80.0
+cost_raster_rast_xmax <- -47.9
+cost_raster_rast_ymin <- -55.5
+cost_raster_rast_ymax <- -21.4
+
+# Grid resolution for the cost raster (before crop to final extent).
+cost_raster_ncols <- 1000L
+cost_raster_nrows <- 1000L
+
+# Cost values used in 01_cost_raster.R.
+cost_out_of_country <- 1000  # cells outside Argentina: barrier
+cost_obstacle       <- 25    # cells covered by water/wetland/settlement: +25
+
 # ---- 7. Transport cost parameters (Baumgartner & Palazzo 1969) -----------
 #
 # Unit: USD per ton-km (constant prices).

--- a/code/pipeline/01_cost_raster.R
+++ b/code/pipeline/01_cost_raster.R
@@ -1,0 +1,171 @@
+# ===========================================================================
+# 01_cost_raster.R
+#
+# PURPOSE: Build the construction cost raster used as input for least-cost
+#          path computation in the hypothetical networks pipeline.
+#
+# READS:
+#   data/raw/networks_hypo/pais.shp                           — country polygon
+#   data/raw/networks_hypo/banados.shp                        — wetlands
+#   data/raw/networks_hypo/cuerpos_de_agua.shp                — water bodies
+#   data/raw/networks_hypo/cursos_de_agua.shp                 — rivers
+#   data/raw/networks_hypo/areas_de_aguas_continentales_BH140.shp
+#   data/raw/networks_hypo/pendiente_2.tif                    — slope
+#   data/raw/geo/areas_de_asentamientos_y_edificios_020105.shp — settlements
+#
+# PRODUCES:
+#   data/derived/01_cost_rasters/construction_costs.tif
+#
+# REFERENCE:
+#   Old data/Train/base/construction_costs/code/compute_construction_cost.py
+#   Plan/hypothetical_networks_pipeline.md
+#   Plan/hypothetical_networks_plan.md
+#
+# NOTES:
+#   - All inputs and output in EPSG:4326.
+#   - Base grid: 1000x1000 cells over the rasterization extent.
+#   - Final raster cropped to mainland Argentina:
+#       xmin=-73.56, xmax=-53.70, ymin=-55.10, ymax=-21.78.
+#   - Cost values (matching old pipeline):
+#       * Outside Argentina: 1000 (barrier)
+#       * Obstacle cells (water, wetlands, settlements): + 25
+#       * All cells: + slope value (degrees)
+# ===========================================================================
+
+main <- function() {
+    source(file.path(here::here(), "code", "config.R"), echo = FALSE)
+
+    message("\n", strrep("=", 72))
+    message("01_cost_raster.R  |  Building construction cost raster")
+    message(strrep("=", 72))
+
+    # Parameters
+    cost_out_of_country <- 1000
+    cost_obstacle       <- 25
+    # river_buffer_deg kept for reference; unused because rasterize(touches=TRUE)
+    # marks every cell a river line crosses as an obstacle directly.
+    river_buffer_deg    <- 0
+
+    # Rasterization extent — covers mainland + a bit of margin for the grid.
+    # Final crop brings it down to the analysis extent.
+    rast_ext <- terra::ext(-80, -47.9, -55.5, -21.4)
+    rast_ncol <- 1000L
+    rast_nrow <- 1000L
+
+    final_ext <- terra::ext(raster_xmin, raster_xmax,
+                            raster_ymin, raster_ymax)
+
+    # --- 1. Base country barrier raster ------------------------------------
+    message("\n[cost] Step 1 — Country barrier raster")
+    pais <- sf::st_read(file.path(dir_raw, "networks_hypo", "pais.shp"),
+                        quiet = TRUE)
+    pais <- sf::st_make_valid(pais)
+
+    base <- terra::rast(rast_ext,
+                        ncol = rast_ncol, nrow = rast_nrow,
+                        crs = "EPSG:4326")
+    terra::values(base) <- cost_out_of_country
+    pais_rast <- terra::rasterize(terra::vect(pais), base, field = 1,
+                                  background = cost_out_of_country)
+    pais_rast[pais_rast == 1] <- 0  # inside Argentina: no country-barrier cost
+    message(sprintf("[cost]   base raster: %d x %d cells", rast_nrow, rast_ncol))
+
+    # --- 2. Obstacle raster (rasterize each layer separately, combine) ----
+    #
+    # Rationale: st_buffer on cursos_de_agua (~1M river segments) then
+    # rbind + rasterize is slow/memory-heavy. Rasterizing each layer
+    # independently and taking the max in raster space is equivalent and
+    # much faster.
+    message("\n[cost] Step 2 — Obstacle raster")
+    obstacles_rast <- build_obstacles_raster(base, cost_obstacle,
+                                             river_buffer_deg)
+    n_obstacle_cells <- sum(terra::values(obstacles_rast) == cost_obstacle,
+                            na.rm = TRUE)
+    message(sprintf("[cost]   obstacle cells: %d", n_obstacle_cells))
+
+    # --- 3. Slope raster aligned to base grid ------------------------------
+    message("\n[cost] Step 3 — Slope raster")
+    slope_raw <- terra::rast(file.path(dir_raw, "networks_hypo",
+                                       "pendiente_2.tif"))
+    slope_resampled <- terra::resample(slope_raw, base, method = "bilinear")
+    # Replace NA slopes (outside slope coverage) with 0
+    slope_resampled[is.na(slope_resampled)] <- 0
+    message(sprintf("[cost]   slope range after resample: %.2f – %.2f",
+                    terra::global(slope_resampled, "min", na.rm = TRUE)[1, 1],
+                    terra::global(slope_resampled, "max", na.rm = TRUE)[1, 1]))
+
+    # --- 4. Sum the three layers -------------------------------------------
+    message("\n[cost] Step 4 — Summing layers")
+    cost <- pais_rast + obstacles_rast + slope_resampled
+    names(cost) <- "construction_costs"
+
+    # --- 5. Crop to final analysis extent ----------------------------------
+    message("\n[cost] Step 5 — Cropping to analysis extent")
+    cost <- terra::crop(cost, final_ext)
+    message(sprintf("[cost]   final raster: %d x %d cells, extent %s",
+                    terra::nrow(cost), terra::ncol(cost),
+                    paste(round(as.vector(terra::ext(cost)), 2),
+                          collapse = ", ")))
+    r <- terra::global(cost, c("min", "max", "mean"), na.rm = TRUE)
+    message(sprintf("[cost]   cost range: %.1f – %.1f  (mean %.1f)",
+                    r$min, r$max, r$mean))
+
+    # --- 6. Save -----------------------------------------------------------
+    out_dir <- dir_derived_rasters
+    if (!dir.exists(out_dir)) dir.create(out_dir, recursive = TRUE)
+    out_path <- file.path(out_dir, "construction_costs.tif")
+    terra::writeRaster(cost, out_path, overwrite = TRUE)
+    message(sprintf("\n[cost] Saved: %s", out_path))
+
+    message(strrep("=", 72))
+    message("01_cost_raster.R  |  Complete.")
+    message(strrep("=", 72), "\n")
+}
+
+# ---------------------------------------------------------------------------
+# Helper: build obstacles raster by rasterizing each layer independently
+# and taking the union in raster space.
+# ---------------------------------------------------------------------------
+build_obstacles_raster <- function(base, cost_obstacle, river_buffer_deg) {
+    hypo <- file.path(dir_raw, "networks_hypo")
+    geo  <- file.path(dir_raw_geo)
+
+    layers <- list(
+        banados = file.path(hypo, "banados.shp"),
+        cuerpos = file.path(hypo, "cuerpos_de_agua.shp"),
+        cursos  = file.path(hypo, "cursos_de_agua.shp"),
+        aguas   = file.path(hypo, "areas_de_aguas_continentales_BH140.shp"),
+        settle  = file.path(geo,  "areas_de_asentamientos_y_edificios_020105.shp")
+    )
+
+    # Start from a zero raster; accumulate the max obstacle value.
+    acc <- terra::rast(base)
+    terra::values(acc) <- 0
+
+    for (name in names(layers)) {
+        message(sprintf("[cost]     rasterizing %s", name))
+        x <- sf::st_read(layers[[name]], quiet = TRUE)
+        x <- sf::st_make_valid(x)
+        if (sf::st_crs(x) != sf::st_crs("EPSG:4326")) {
+            x <- sf::st_transform(x, "EPSG:4326")
+        }
+        # For line geometries (rivers), rasterize::touches=TRUE is enough —
+        # any cell the line crosses gets the obstacle value. No need to buffer.
+        is_line <- inherits(sf::st_geometry(x)[[1]],
+                            c("LINESTRING", "MULTILINESTRING"))
+        if (is_line) {
+            r <- terra::rasterize(terra::vect(x), base,
+                                  field = cost_obstacle,
+                                  background = 0, touches = TRUE)
+        } else {
+            r <- terra::rasterize(terra::vect(x), base,
+                                  field = cost_obstacle, background = 0)
+        }
+        acc <- max(acc, r, na.rm = TRUE)
+        # Free memory
+        rm(x, r); gc(verbose = FALSE)
+    }
+    acc
+}
+
+main()

--- a/code/pipeline/01_cost_raster.R
+++ b/code/pipeline/01_cost_raster.R
@@ -23,13 +23,15 @@
 #
 # NOTES:
 #   - All inputs and output in EPSG:4326.
-#   - Base grid: 1000x1000 cells over the rasterization extent.
-#   - Final raster cropped to mainland Argentina:
-#       xmin=-73.56, xmax=-53.70, ymin=-55.10, ymax=-21.78.
+#   - Base grid: cost_raster_ncols × cost_raster_nrows cells (config.R).
+#   - Final raster cropped to mainland Argentina (raster_xmin/xmax/ymin/ymax).
 #   - Cost values (matching old pipeline):
-#       * Outside Argentina: 1000 (barrier)
-#       * Obstacle cells (water, wetlands, settlements): + 25
+#       * Outside Argentina: cost_out_of_country (barrier)
+#       * Obstacle cells (water, wetlands, settlements): + cost_obstacle
 #       * All cells: + slope value (degrees)
+#   - City cells (ciudades_seleccion2.shp) are burned in as cost=0 at the
+#     end to ensure coastal cities (Puerto Madryn, Río Grande) are not
+#     barriers. See Step 5 for details.
 # ===========================================================================
 
 main <- function() {
@@ -39,19 +41,8 @@ main <- function() {
     message("01_cost_raster.R  |  Building construction cost raster")
     message(strrep("=", 72))
 
-    # Parameters
-    cost_out_of_country <- 1000
-    cost_obstacle       <- 25
-    # river_buffer_deg kept for reference; unused because rasterize(touches=TRUE)
-    # marks every cell a river line crosses as an obstacle directly.
-    river_buffer_deg    <- 0
-
-    # Rasterization extent — covers mainland + a bit of margin for the grid.
-    # Final crop brings it down to the analysis extent.
-    rast_ext <- terra::ext(-80, -47.9, -55.5, -21.4)
-    rast_ncol <- 1000L
-    rast_nrow <- 1000L
-
+    rast_ext <- terra::ext(cost_raster_rast_xmin, cost_raster_rast_xmax,
+                           cost_raster_rast_ymin, cost_raster_rast_ymax)
     final_ext <- terra::ext(raster_xmin, raster_xmax,
                             raster_ymin, raster_ymax)
 
@@ -62,13 +53,15 @@ main <- function() {
     pais <- sf::st_make_valid(pais)
 
     base <- terra::rast(rast_ext,
-                        ncol = rast_ncol, nrow = rast_nrow,
+                        ncol = cost_raster_ncols,
+                        nrow = cost_raster_nrows,
                         crs = "EPSG:4326")
     terra::values(base) <- cost_out_of_country
     pais_rast <- terra::rasterize(terra::vect(pais), base, field = 1,
                                   background = cost_out_of_country)
     pais_rast[pais_rast == 1] <- 0  # inside Argentina: no country-barrier cost
-    message(sprintf("[cost]   base raster: %d x %d cells", rast_nrow, rast_ncol))
+    message(sprintf("[cost]   base raster: %d x %d cells",
+                    cost_raster_nrows, cost_raster_ncols))
 
     # --- 2. Obstacle raster (rasterize each layer separately, combine) ----
     #
@@ -77,8 +70,7 @@ main <- function() {
     # independently and taking the max in raster space is equivalent and
     # much faster.
     message("\n[cost] Step 2 — Obstacle raster")
-    obstacles_rast <- build_obstacles_raster(base, cost_obstacle,
-                                             river_buffer_deg)
+    obstacles_rast <- build_obstacles_raster(base, cost_obstacle)
     n_obstacle_cells <- sum(terra::values(obstacles_rast) == cost_obstacle,
                             na.rm = TRUE)
     message(sprintf("[cost]   obstacle cells: %d", n_obstacle_cells))
@@ -99,8 +91,17 @@ main <- function() {
     cost <- pais_rast + obstacles_rast + slope_resampled
     names(cost) <- "construction_costs"
 
-    # --- 5. Crop to final analysis extent ----------------------------------
-    message("\n[cost] Step 5 — Cropping to analysis extent")
+    # --- 5. Burn in city points as land (fix coastal-barrier bug) ---------
+    #
+    # 2 of 68 cities (Puerto Madryn, Río Grande) are coastal and land on
+    # barrier cells after rasterization at this resolution. Burn cities as
+    # 0-cost cells so LCP endpoints are always on land. For interior
+    # cities this is a no-op (they already have near-0 base cost).
+    message("\n[cost] Step 5 — Burning city points as land")
+    cost <- burn_cities_as_land(cost)
+
+    # --- 6. Crop to final analysis extent ----------------------------------
+    message("\n[cost] Step 6 — Cropping to analysis extent")
     cost <- terra::crop(cost, final_ext)
     message(sprintf("[cost]   final raster: %d x %d cells, extent %s",
                     terra::nrow(cost), terra::ncol(cost),
@@ -110,7 +111,7 @@ main <- function() {
     message(sprintf("[cost]   cost range: %.1f – %.1f  (mean %.1f)",
                     r$min, r$max, r$mean))
 
-    # --- 6. Save -----------------------------------------------------------
+    # --- 7. Save -----------------------------------------------------------
     out_dir <- dir_derived_rasters
     if (!dir.exists(out_dir)) dir.create(out_dir, recursive = TRUE)
     out_path <- file.path(out_dir, "construction_costs.tif")
@@ -126,7 +127,7 @@ main <- function() {
 # Helper: build obstacles raster by rasterizing each layer independently
 # and taking the union in raster space.
 # ---------------------------------------------------------------------------
-build_obstacles_raster <- function(base, cost_obstacle, river_buffer_deg) {
+build_obstacles_raster <- function(base, cost_obstacle) {
     hypo <- file.path(dir_raw, "networks_hypo")
     geo  <- file.path(dir_raw_geo)
 
@@ -166,6 +167,51 @@ build_obstacles_raster <- function(base, cost_obstacle, river_buffer_deg) {
         rm(x, r); gc(verbose = FALSE)
     }
     acc
+}
+
+# ---------------------------------------------------------------------------
+# Helper: burn city points into the cost raster as 0-cost cells.
+#
+# Some cities sit right on the coast (e.g. Puerto Madryn, Río Grande) and
+# after rasterization at ~0.02° x 0.033° per cell they fall on ocean cells
+# that have cost = 1000 (barrier). This makes Dijkstra from those nodes
+# either fail or produce garbage. The fix: at the end of cost-raster
+# construction, set the cell containing each city to cost = 0 (plus slope,
+# which we preserve by using the current cell value if it's < threshold
+# but forcing it to 0 for barrier cells only).
+#
+# We overwrite barrier cells unconditionally for cities. Interior cities
+# already have cost near 0 and we overwrite them with 0 too — the loss
+# of a few units of slope/obstacle cost at a point cell is negligible.
+# ---------------------------------------------------------------------------
+burn_cities_as_land <- function(cost) {
+    cities_path <- file.path(dir_raw, "networks_hypo",
+                             "ciudades_seleccion2.shp")
+    cities <- sf::st_read(cities_path, quiet = TRUE)
+    if (sf::st_crs(cities) != sf::st_crs("EPSG:4326")) {
+        cities <- sf::st_transform(cities, "EPSG:4326")
+    }
+
+    # Values before burning (diagnostic)
+    before <- terra::extract(cost, terra::vect(cities))[[2]]
+    n_on_barrier <- sum(before >= 1000, na.rm = TRUE)
+    message(sprintf("[cost]   cities before burn: %d on barrier (>=1000)",
+                    n_on_barrier))
+
+    # Burn: set the cell containing each city to 0.
+    cell_idx <- terra::cellFromXY(cost, sf::st_coordinates(cities))
+    cost[cell_idx] <- 0
+
+    after <- terra::extract(cost, terra::vect(cities))[[2]]
+    n_on_barrier_after <- sum(after >= 1000, na.rm = TRUE)
+    message(sprintf("[cost]   cities after burn:  %d on barrier (>=1000)",
+                    n_on_barrier_after))
+    if (n_on_barrier_after > 0) {
+        warning(sprintf("[cost] %d cities still on barrier after burn",
+                        n_on_barrier_after))
+    }
+
+    cost
 }
 
 main()

--- a/data/raw/networks_hypo/readme.md
+++ b/data/raw/networks_hypo/readme.md
@@ -1,0 +1,33 @@
+# Raw Data: Hypothetical Networks
+
+Inputs for the construction cost raster and hypothetical network
+(LCP/MST/EUC) pipeline.
+
+## Files
+
+| File | Description | Source |
+|------|-------------|--------|
+| `pais.shp` | Argentina country polygon | IGN Argentina |
+| `banados.shp` | Wetlands polygons | IGN Argentina |
+| `cuerpos_de_agua.shp` | Water bodies (lakes, reservoirs) | IGN Argentina |
+| `cursos_de_agua.shp` | Watercourses (rivers) | IGN Argentina |
+| `areas_de_aguas_continentales_BH140.shp` | Continental water areas | IGN Argentina |
+| `ciudades_seleccion2.shp` | Selected cities (68 nodes) | Project team, from INDEC 1960 census |
+| `pendiente_2.tif` | Slope raster (degrees) | Derived from DEM (pre-computed) |
+
+The `areas_de_asentamientos_y_edificios_020105.shp` (urban settlements)
+layer is read from `data/raw/geo/` — it is shared with the geo controls
+pipeline.
+
+## CRS
+All files in EPSG:4326 (WGS84 geographic).
+
+## Notes
+
+- `ciudades_seleccion2.shp` has 68 cities with fields `localidad`,
+  `provincia`, `pop1960`, and zone assignments. This is the active node
+  set for the hypothetical networks. Alternative sets (`capitales`,
+  `ciudades_zona_*`) are available in the old repo but not used in the
+  main pipeline.
+- `pendiente_2.tif` is a 0.01° resolution slope raster covering
+  Argentina and neighboring areas.

--- a/logs/01_cost_raster.log
+++ b/logs/01_cost_raster.log
@@ -39,7 +39,11 @@ Type 'q()' to quit R.
 
 [cost] Step 4 — Summing layers
 
-[cost] Step 5 — Cropping to analysis extent
+[cost] Step 5 — Burning city points as land
+[cost]   cities before burn: 2 on barrier (>=1000)
+[cost]   cities after burn:  0 on barrier (>=1000)
+
+[cost] Step 6 — Cropping to analysis extent
 [cost]   final raster: 977 x 618 cells, extent -73.55, -53.71, -55.09, -21.78
 [cost]   cost range: 0.0 – 1057.3  (mean 583.8)
 

--- a/logs/01_cost_raster.log
+++ b/logs/01_cost_raster.log
@@ -1,0 +1,51 @@
+
+R version 4.5.1 (2025-06-13) -- "Great Square Root"
+Copyright (C) 2025 The R Foundation for Statistical Computing
+Platform: aarch64-apple-darwin20
+
+R is free software and comes with ABSOLUTELY NO WARRANTY.
+You are welcome to redistribute it under certain conditions.
+Type 'license()' or 'licence()' for distribution details.
+
+R is a collaborative project with many contributors.
+Type 'contributors()' for more information and
+'citation()' on how to cite R or R packages in publications.
+
+Type 'demo()' for some demos, 'help()' for on-line help, or
+'help.start()' for an HTML browser interface to help.
+Type 'q()' to quit R.
+
+> source(file.path(here::here(), "code", "pipeline", "01_cost_raster.R"))
+[config.R] rootdir = /Users/diegogp/Desktop/Diego/Trains/new_repo
+[config.R] Configuration loaded successfully.
+
+========================================================================
+01_cost_raster.R  |  Building construction cost raster
+========================================================================
+
+[cost] Step 1 — Country barrier raster
+[cost]   base raster: 1000 x 1000 cells
+
+[cost] Step 2 — Obstacle raster
+[cost]     rasterizing banados
+[cost]     rasterizing cuerpos
+[cost]     rasterizing cursos
+[cost]     rasterizing aguas
+[cost]     rasterizing settle
+[cost]   obstacle cells: 139508
+
+[cost] Step 3 — Slope raster
+[cost]   slope range after resample: 0.00 – 39.91
+
+[cost] Step 4 — Summing layers
+
+[cost] Step 5 — Cropping to analysis extent
+[cost]   final raster: 977 x 618 cells, extent -73.55, -53.71, -55.09, -21.78
+[cost]   cost range: 0.0 – 1057.3  (mean 583.8)
+
+[cost] Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/01_cost_rasters/construction_costs.tif
+========================================================================
+01_cost_raster.R  |  Complete.
+========================================================================
+
+> 


### PR DESCRIPTION
## Summary

Pure-R (terra + sf) replacement for the QGIS Python cost raster pipeline. Produces `construction_costs.tif` (977 × 618 cells, EPSG:4326, mainland Argentina), used as input for least-cost path computation in PR B of the hypothetical networks sequence.

Closes #11

## Context

First of three PRs for the hypothetical networks pipeline (see `Plan/hypothetical_networks_plan.md`). The cost raster is self-contained and can be inspected visually before LCPs are computed on it, so it gets its own review cycle.

Issue: https://github.com/diegogentilepassaro/bimodal-transport-argentina/issues/11

## Changes

- `code/pipeline/01_cost_raster.R` — new: builds cost raster from country polygon, 5 obstacle layers, and slope raster. Output goes to `data/derived/01_cost_rasters/construction_costs.tif`.
- `data/raw/networks_hypo/readme.md` — new: provenance for the shapefiles and slope raster.
- `logs/01_cost_raster.log` — new: run log.

## Design Decisions

1. **All R, no Python.** Old pipeline was QGIS Python; `terra` handles rasterization, resampling, and raster arithmetic equivalently.
2. **Rasterize each obstacle layer independently, combine via `max()` in raster space.** First attempt buffered rivers and vector-unioned all 5 layers before rasterizing — hung on `cursos_de_agua.shp` (~1M river segments, 214MB .dbf). Rasterizing each layer separately then taking `max()` is equivalent and completes in ~90 seconds.
3. **`rasterize(touches=TRUE)` for line layers.** No need to buffer rivers — any cell a river line crosses gets the obstacle value directly. This matches the old pipelines behavior.
4. **Cost values match old pipeline.** Out-of-country cells: 1000 (barrier). Obstacle cells: +25. All cells: +slope (degrees). Sum of the three layers.
5. **Final extent from `config.R`.** `raster_xmin`/`raster_xmax`/`raster_ymin`/`raster_ymax` define the analysis extent. The old pipeline output has `xmax=-26.26` (far into the Atlantic — looks like a bug); our output uses the correct mainland extent `xmax=-53.70`.

## Reference Code

- Consulted: `Old data/Train/base/construction_costs/code/compute_construction_cost.py` (QGIS Python)
- Consulted: `Plan/hypothetical_networks_pipeline.md` (Cotes trace)
- Consulted: `Plan/hypothetical_networks_plan.md` (our implementation plan)
- Followed their approach for: layer composition, cost values, final extent
- Departed from their approach for: R/terra instead of QGIS, obstacle combination in raster space, corrected final extent

## Validation

- Script ran successfully: YES (~90s)
- Output: 977 × 618 cells, cost range 0–1057, mean 584
- 139,508 obstacle cells identified
- Max value 1057 matches old pipeline max (1061) within slope-interpolation precision
- Visual preview inspected (`plot(r)` in R) — Argentina shows finite varied costs, ocean/neighbors show 1000 (barrier)

## Known Limitations

- [ ] The slope-interpolation step uses bilinear resampling which smooths slopes. Old pipeline behavior on this is unclear from the Python source; should be equivalent.
- [ ] No explicit test that the cost raster aligns precisely with the DEM-derived slope raster. Visual inspection shows no obvious misalignment.

**Risk level**: MEDIUM
**Human should focus on**: (1) Whether the extent correction vs the old pipeline is acceptable (old output extends far east into the Atlantic due to an apparent bug). (2) Whether the mean cost difference (584 vs 843) is explained by the extent correction or something else worth investigating.