### PR TITLE
Rebuild cost raster using Faber (2014) formula

### DIFF
--- a/code/config.R
+++ b/code/config.R
@@ -103,6 +103,15 @@ raster_nrows <- 3090L
 # and then cropped. Rasterization extent is wider to leave margin around the
 # country polygon during rasterize(), so coastlines near the final extent
 # don't get clipped by rasterization artifacts.
+#
+# Cost formula (Faber 2014, RES):
+#   c_i = cost_land_baseline
+#       + slope_deg_i
+#       + cost_developed * is_developed_i
+#       + cost_wetland   * is_wetland_i
+#       + cost_water     * is_water_i
+# Cells outside Argentina are set to cost_out_of_country (hard barrier).
+# See Plan/cost_raster_and_lcp_decisions.md for documentation.
 
 # Rasterization extent (EPSG:4326 degrees). Covers mainland + margin.
 cost_raster_rast_xmin <- -80.0
@@ -114,9 +123,18 @@ cost_raster_rast_ymax <- -21.4
 cost_raster_ncols <- 1000L
 cost_raster_nrows <- 1000L
 
-# Cost values used in 01_cost_raster.R.
-cost_out_of_country <- 1000  # cells outside Argentina: barrier
-cost_obstacle       <- 25    # cells covered by water/wetland/settlement: +25
+# Cost values for 01_cost_raster.R (Faber 2014 formula).
+cost_out_of_country  <- 1000000L  # cells outside Argentina, beyond coastal buffer
+cost_land_baseline   <- 1L        # inside Argentina, no features
+cost_developed       <- 25L       # urban settlements surcharge
+cost_wetland         <- 25L       # wetlands surcharge
+cost_water           <- 25L       # water bodies / rivers surcharge
+
+# Out-of-country cells within this distance (km) of Argentine land are
+# treated as water crossings (cost_land_baseline + cost_water = 26) rather
+# than hard barriers. Lets LCPs cross the Paraná river and the Strait of
+# Magellan while still blocking Río de la Plata mouth and open Atlantic.
+cost_coastal_buffer_km <- 30
 
 # ---- 7. Transport cost parameters (Baumgartner & Palazzo 1969) -----------
 #

--- a/code/pipeline/01_cost_raster.R
+++ b/code/pipeline/01_cost_raster.R
@@ -9,45 +9,63 @@
 #   data/raw/networks_hypo/banados.shp                        — wetlands
 #   data/raw/networks_hypo/cuerpos_de_agua.shp                — water bodies
 #   data/raw/networks_hypo/cursos_de_agua.shp                 — rivers
-#   data/raw/networks_hypo/areas_de_aguas_continentales_BH140.shp
-#   data/raw/networks_hypo/pendiente_2.tif                    — slope
+#   data/raw/networks_hypo/areas_de_aguas_continentales_BH140.shp — continental water
+#   data/raw/networks_hypo/pendiente_2.tif                    — slope (degrees)
 #   data/raw/geo/areas_de_asentamientos_y_edificios_020105.shp — settlements
+#   data/raw/networks_hypo/ciudades_seleccion2.shp            — city point set
 #
 # PRODUCES:
 #   data/derived/01_cost_rasters/construction_costs.tif
 #
 # REFERENCE:
-#   Old data/Train/base/construction_costs/code/compute_construction_cost.py
-#   Plan/hypothetical_networks_pipeline.md
-#   Plan/hypothetical_networks_plan.md
+#   Faber, B. (2014). "Trade Integration, Market Size, and Industrialization:
+#     Evidence from China's National Trunk Highway System."
+#     Review of Economic Studies 81(3): 1046-1070.
+#   Plan/cost_raster_and_lcp_decisions.md
+#
+# FORMULA (Faber 2014):
+#   c_i = cost_land_baseline
+#       + slope_deg_i
+#       + cost_developed * is_developed_i
+#       + cost_wetland   * is_wetland_i
+#       + cost_water     * is_water_i
+#   Cells outside Argentina get cost_out_of_country (hard barrier).
+#
+# PARAMETERS (see config.R):
+#   cost_land_baseline  = 1          cost_out_of_country = 1,000,000
+#   cost_developed      = 25         cost_wetland        = 25
+#   cost_water          = 25
+#
+# LAYER → CATEGORY MAPPING:
+#   Developed ← settlements shapefile
+#   Wetland   ← banados
+#   Water     ← cuerpos + cursos + aguas_continentales (union)
 #
 # NOTES:
 #   - All inputs and output in EPSG:4326.
-#   - Base grid: cost_raster_ncols × cost_raster_nrows cells (config.R).
-#   - Final raster cropped to mainland Argentina (raster_xmin/xmax/ymin/ymax).
-#   - Cost values (matching old pipeline):
-#       * Outside Argentina: cost_out_of_country (barrier)
-#       * Obstacle cells (water, wetlands, settlements): + cost_obstacle
-#       * All cells: + slope value (degrees)
-#   - City cells (ciudades_seleccion2.shp) are burned in as cost=0 at the
-#     end to ensure coastal cities (Puerto Madryn, Río Grande) are not
-#     barriers. See Step 5 for details.
+#   - Base grid: cost_raster_ncols × cost_raster_nrows (config.R).
+#   - Final raster cropped to mainland Argentina
+#     (raster_xmin / xmax / ymin / ymax from config.R).
+#   - City cells (active node set) are burned to
+#     `cost_land_baseline + slope_local + cost_developed` so that coastal
+#     cities are reachable and costs between adjacent city pairs are
+#     non-zero.
 # ===========================================================================
 
 main <- function() {
     source(file.path(here::here(), "code", "config.R"), echo = FALSE)
 
     message("\n", strrep("=", 72))
-    message("01_cost_raster.R  |  Building construction cost raster")
+    message("01_cost_raster.R  |  Building construction cost raster (Faber 2014)")
     message(strrep("=", 72))
 
-    rast_ext <- terra::ext(cost_raster_rast_xmin, cost_raster_rast_xmax,
-                           cost_raster_rast_ymin, cost_raster_rast_ymax)
+    rast_ext  <- terra::ext(cost_raster_rast_xmin, cost_raster_rast_xmax,
+                            cost_raster_rast_ymin, cost_raster_rast_ymax)
     final_ext <- terra::ext(raster_xmin, raster_xmax,
                             raster_ymin, raster_ymax)
 
-    # --- 1. Base country barrier raster ------------------------------------
-    message("\n[cost] Step 1 — Country barrier raster")
+    # --- 1. Base country mask ---------------------------------------------
+    message("\n[cost] Step 1 — Country mask")
     pais <- sf::st_read(file.path(dir_raw, "networks_hypo", "pais.shp"),
                         quiet = TRUE)
     pais <- sf::st_make_valid(pais)
@@ -56,62 +74,80 @@ main <- function() {
                         ncol = cost_raster_ncols,
                         nrow = cost_raster_nrows,
                         crs = "EPSG:4326")
-    terra::values(base) <- cost_out_of_country
-    pais_rast <- terra::rasterize(terra::vect(pais), base, field = 1,
-                                  background = cost_out_of_country)
-    pais_rast[pais_rast == 1] <- 0  # inside Argentina: no country-barrier cost
-    message(sprintf("[cost]   base raster: %d x %d cells",
-                    cost_raster_nrows, cost_raster_ncols))
+    terra::values(base) <- 1  # placeholder; gets overwritten below
 
-    # --- 2. Obstacle raster (rasterize each layer separately, combine) ----
-    #
-    # Rationale: st_buffer on cursos_de_agua (~1M river segments) then
-    # rbind + rasterize is slow/memory-heavy. Rasterizing each layer
-    # independently and taking the max in raster space is equivalent and
-    # much faster.
-    message("\n[cost] Step 2 — Obstacle raster")
-    obstacles_rast <- build_obstacles_raster(base, cost_obstacle)
-    n_obstacle_cells <- sum(terra::values(obstacles_rast) == cost_obstacle,
-                            na.rm = TRUE)
-    message(sprintf("[cost]   obstacle cells: %d", n_obstacle_cells))
+    # 1 inside Argentina, 0 outside
+    inside <- terra::rasterize(terra::vect(pais), base, field = 1,
+                               background = 0)
+    message(sprintf("[cost]   base: %d x %d cells; %d inside Argentina",
+                    cost_raster_nrows, cost_raster_ncols,
+                    sum(terra::values(inside) == 1, na.rm = TRUE)))
 
-    # --- 3. Slope raster aligned to base grid ------------------------------
+    # --- 2. Category rasters (developed / wetland / water) ---------------
+    message("\n[cost] Step 2 — Category indicator rasters")
+    developed <- rasterize_layer(
+        base, file.path(dir_raw_geo,
+                        "areas_de_asentamientos_y_edificios_020105.shp"),
+        "developed"
+    )
+    wetland <- rasterize_layer(
+        base, file.path(dir_raw, "networks_hypo", "banados.shp"),
+        "wetland"
+    )
+    water <- rasterize_water_union(base)
+
+    # --- 3. Slope raster aligned to base grid -----------------------------
     message("\n[cost] Step 3 — Slope raster")
     slope_raw <- terra::rast(file.path(dir_raw, "networks_hypo",
                                        "pendiente_2.tif"))
-    slope_resampled <- terra::resample(slope_raw, base, method = "bilinear")
-    # Replace NA slopes (outside slope coverage) with 0
-    slope_resampled[is.na(slope_resampled)] <- 0
-    message(sprintf("[cost]   slope range after resample: %.2f – %.2f",
-                    terra::global(slope_resampled, "min", na.rm = TRUE)[1, 1],
-                    terra::global(slope_resampled, "max", na.rm = TRUE)[1, 1]))
+    slope <- terra::resample(slope_raw, base, method = "bilinear")
+    slope[is.na(slope)] <- 0
+    message(sprintf("[cost]   slope range: %.2f – %.2f deg",
+                    terra::global(slope, "min", na.rm = TRUE)[1, 1],
+                    terra::global(slope, "max", na.rm = TRUE)[1, 1]))
 
-    # --- 4. Sum the three layers -------------------------------------------
-    message("\n[cost] Step 4 — Summing layers")
-    cost <- pais_rast + obstacles_rast + slope_resampled
+    # --- 4. Apply Faber formula -------------------------------------------
+    message("\n[cost] Step 4 — Computing cost (Faber 2014 formula)")
+    inside_cost <- cost_land_baseline +
+                   slope +
+                   cost_developed * developed +
+                   cost_wetland   * wetland +
+                   cost_water     * water
+
+    # Step 4a: graduated cost for out-of-country cells. Cells near Argentine
+    # land (within cost_coastal_buffer_km) are treated as water crossings
+    # at cost_land_baseline + cost_water = 26 so that LCPs can cross rivers
+    # (Paraná) and narrow straits (Magellan). Cells farther offshore get
+    # cost_out_of_country as a hard barrier.
+    message("\n[cost] Step 4a — Coastal buffer for near-shore out-of-country cells")
+    dist_km <- terra::distance(inside, target = 0, unit = "km")
+    # dist_km == 0 where inside == 1 (inside Argentina) per terra::distance
+    near_shore <- inside == 0 & dist_km <= cost_coastal_buffer_km
+    cost_near_shore <- cost_land_baseline + cost_water
+    n_near <- sum(terra::values(near_shore) == 1, na.rm = TRUE)
+    message(sprintf("[cost]   near-shore cells (<= %d km from land): %d",
+                    cost_coastal_buffer_km, n_near))
+
+    # Compose the three zones
+    cost <- terra::ifel(inside == 1, inside_cost,
+             terra::ifel(near_shore == 1, cost_near_shore,
+                         cost_out_of_country))
     names(cost) <- "construction_costs"
 
-    # --- 5. Burn in city points as land (fix coastal-barrier bug) ---------
-    #
-    # 2 of 68 cities (Puerto Madryn, Río Grande) are coastal and land on
-    # barrier cells after rasterization at this resolution. Burn cities as
-    # 0-cost cells so LCP endpoints are always on land. For interior
-    # cities this is a no-op (they already have near-0 base cost).
-    message("\n[cost] Step 5 — Burning city points as land")
-    cost <- burn_cities_as_land(cost)
+    # --- 5. Burn city points ---------------------------------------------
+    message("\n[cost] Step 5 — Burning cities as reachable urban cells")
+    cost <- burn_cities(cost, slope)
 
-    # --- 6. Crop to final analysis extent ----------------------------------
+    # --- 6. Crop to final analysis extent ---------------------------------
     message("\n[cost] Step 6 — Cropping to analysis extent")
     cost <- terra::crop(cost, final_ext)
-    message(sprintf("[cost]   final raster: %d x %d cells, extent %s",
-                    terra::nrow(cost), terra::ncol(cost),
-                    paste(round(as.vector(terra::ext(cost)), 2),
-                          collapse = ", ")))
     r <- terra::global(cost, c("min", "max", "mean"), na.rm = TRUE)
-    message(sprintf("[cost]   cost range: %.1f – %.1f  (mean %.1f)",
+    message(sprintf("[cost]   final raster: %d x %d cells",
+                    terra::nrow(cost), terra::ncol(cost)))
+    message(sprintf("[cost]   cost range: %.1f – %.1f (mean %.1f)",
                     r$min, r$max, r$mean))
 
-    # --- 7. Save -----------------------------------------------------------
+    # --- 7. Save ---------------------------------------------------------
     out_dir <- dir_derived_rasters
     if (!dir.exists(out_dir)) dir.create(out_dir, recursive = TRUE)
     out_path <- file.path(out_dir, "construction_costs.tif")
@@ -124,67 +160,61 @@ main <- function() {
 }
 
 # ---------------------------------------------------------------------------
-# Helper: build obstacles raster by rasterizing each layer independently
-# and taking the union in raster space.
+# Helper: rasterize a single polygon/line layer as a 0/1 indicator.
+# Uses touches=TRUE for line layers so every cell a line crosses is marked.
 # ---------------------------------------------------------------------------
-build_obstacles_raster <- function(base, cost_obstacle) {
-    hypo <- file.path(dir_raw, "networks_hypo")
-    geo  <- file.path(dir_raw_geo)
-
-    layers <- list(
-        banados = file.path(hypo, "banados.shp"),
-        cuerpos = file.path(hypo, "cuerpos_de_agua.shp"),
-        cursos  = file.path(hypo, "cursos_de_agua.shp"),
-        aguas   = file.path(hypo, "areas_de_aguas_continentales_BH140.shp"),
-        settle  = file.path(geo,  "areas_de_asentamientos_y_edificios_020105.shp")
-    )
-
-    # Start from a zero raster; accumulate the max obstacle value.
-    acc <- terra::rast(base)
-    terra::values(acc) <- 0
-
-    for (name in names(layers)) {
-        message(sprintf("[cost]     rasterizing %s", name))
-        x <- sf::st_read(layers[[name]], quiet = TRUE)
-        x <- sf::st_make_valid(x)
-        if (sf::st_crs(x) != sf::st_crs("EPSG:4326")) {
-            x <- sf::st_transform(x, "EPSG:4326")
-        }
-        # For line geometries (rivers), rasterize::touches=TRUE is enough —
-        # any cell the line crosses gets the obstacle value. No need to buffer.
-        is_line <- inherits(sf::st_geometry(x)[[1]],
-                            c("LINESTRING", "MULTILINESTRING"))
-        if (is_line) {
-            r <- terra::rasterize(terra::vect(x), base,
-                                  field = cost_obstacle,
-                                  background = 0, touches = TRUE)
-        } else {
-            r <- terra::rasterize(terra::vect(x), base,
-                                  field = cost_obstacle, background = 0)
-        }
-        acc <- max(acc, r, na.rm = TRUE)
-        # Free memory
-        rm(x, r); gc(verbose = FALSE)
+rasterize_layer <- function(base, shp_path, label) {
+    x <- sf::st_read(shp_path, quiet = TRUE)
+    x <- sf::st_make_valid(x)
+    if (sf::st_crs(x) != sf::st_crs("EPSG:4326")) {
+        x <- sf::st_transform(x, "EPSG:4326")
     }
-    acc
+    is_line <- inherits(sf::st_geometry(x)[[1]],
+                        c("LINESTRING", "MULTILINESTRING"))
+    r <- terra::rasterize(terra::vect(x), base,
+                          field = 1, background = 0,
+                          touches = is_line)
+    message(sprintf("[cost]     %-10s cells: %d", label,
+                    sum(terra::values(r) == 1, na.rm = TRUE)))
+    r
 }
 
 # ---------------------------------------------------------------------------
-# Helper: burn city points into the cost raster as 0-cost cells.
-#
-# Some cities sit right on the coast (e.g. Puerto Madryn, Río Grande) and
-# after rasterization at ~0.02° x 0.033° per cell they fall on ocean cells
-# that have cost = 1000 (barrier). This makes Dijkstra from those nodes
-# either fail or produce garbage. The fix: at the end of cost-raster
-# construction, set the cell containing each city to cost = 0 (plus slope,
-# which we preserve by using the current cell value if it's < threshold
-# but forcing it to 0 for barrier cells only).
-#
-# We overwrite barrier cells unconditionally for cities. Interior cities
-# already have cost near 0 and we overwrite them with 0 too — the loss
-# of a few units of slope/obstacle cost at a point cell is negligible.
+# Helper: build water indicator by union of three water layers.
 # ---------------------------------------------------------------------------
-burn_cities_as_land <- function(cost) {
+rasterize_water_union <- function(base) {
+    message("[cost]     water (union of cuerpos + cursos + aguas):")
+    r_cuerpos <- rasterize_layer(
+        base, file.path(dir_raw, "networks_hypo", "cuerpos_de_agua.shp"),
+        "  cuerpos"
+    )
+    r_cursos  <- rasterize_layer(
+        base, file.path(dir_raw, "networks_hypo", "cursos_de_agua.shp"),
+        "  cursos"
+    )
+    r_aguas   <- rasterize_layer(
+        base, file.path(dir_raw, "networks_hypo",
+                        "areas_de_aguas_continentales_BH140.shp"),
+        "  aguas"
+    )
+    water <- max(r_cuerpos, r_cursos, r_aguas, na.rm = TRUE)
+    message(sprintf("[cost]     water      cells: %d",
+                    sum(terra::values(water) == 1, na.rm = TRUE)))
+    water
+}
+
+# ---------------------------------------------------------------------------
+# Helper: burn city points into the cost raster.
+#
+# Coastal cities (e.g. Puerto Madryn, Río Grande) can fall on out-of-country
+# raster cells due to finite raster resolution. For those, and for all other
+# cities in the node set, we force the cell value to the urban-equivalent
+# cost: cost_land_baseline + slope_local + cost_developed. This keeps cities
+# reachable for LCPs (not on the hard barrier) and ensures adjacent cities
+# still have positive edge costs (because surrounding cells retain their
+# full formula value).
+# ---------------------------------------------------------------------------
+burn_cities <- function(cost, slope) {
     cities_path <- file.path(dir_raw, "networks_hypo",
                              "ciudades_seleccion2.shp")
     cities <- sf::st_read(cities_path, quiet = TRUE)
@@ -192,24 +222,25 @@ burn_cities_as_land <- function(cost) {
         cities <- sf::st_transform(cities, "EPSG:4326")
     }
 
-    # Values before burning (diagnostic)
+    xy <- sf::st_coordinates(cities)
+    cell_idx <- terra::cellFromXY(cost, xy)
+
     before <- terra::extract(cost, terra::vect(cities))[[2]]
-    n_on_barrier <- sum(before >= 1000, na.rm = TRUE)
-    message(sprintf("[cost]   cities before burn: %d on barrier (>=1000)",
+    n_on_barrier <- sum(before >= cost_out_of_country, na.rm = TRUE)
+    message(sprintf("[cost]   before burn: %d cities on barrier",
                     n_on_barrier))
 
-    # Burn: set the cell containing each city to 0.
-    cell_idx <- terra::cellFromXY(cost, sf::st_coordinates(cities))
-    cost[cell_idx] <- 0
+    # City cell cost = baseline + local slope + developed surcharge
+    slope_at_cities <- terra::extract(slope, terra::vect(cities))[[2]]
+    slope_at_cities[is.na(slope_at_cities)] <- 0
+    city_costs <- cost_land_baseline + slope_at_cities + cost_developed
+    cost[cell_idx] <- city_costs
 
     after <- terra::extract(cost, terra::vect(cities))[[2]]
-    n_on_barrier_after <- sum(after >= 1000, na.rm = TRUE)
-    message(sprintf("[cost]   cities after burn:  %d on barrier (>=1000)",
-                    n_on_barrier_after))
-    if (n_on_barrier_after > 0) {
-        warning(sprintf("[cost] %d cities still on barrier after burn",
-                        n_on_barrier_after))
-    }
+    message(sprintf("[cost]   after burn:  %d cities on barrier",
+                    sum(after >= cost_out_of_country, na.rm = TRUE)))
+    message(sprintf("[cost]   city cell cost range: %.1f – %.1f",
+                    min(city_costs), max(city_costs)))
 
     cost
 }

--- a/logs/01_cost_raster.log
+++ b/logs/01_cost_raster.log
@@ -20,32 +20,37 @@ Type 'q()' to quit R.
 [config.R] Configuration loaded successfully.
 
 ========================================================================
-01_cost_raster.R  |  Building construction cost raster
+01_cost_raster.R  |  Building construction cost raster (Faber 2014)
 ========================================================================
 
-[cost] Step 1 — Country barrier raster
-[cost]   base raster: 1000 x 1000 cells
+[cost] Step 1 — Country mask
+[cost]   base: 1000 x 1000 cells; 255630 inside Argentina
 
-[cost] Step 2 — Obstacle raster
-[cost]     rasterizing banados
-[cost]     rasterizing cuerpos
-[cost]     rasterizing cursos
-[cost]     rasterizing aguas
-[cost]     rasterizing settle
-[cost]   obstacle cells: 139508
+[cost] Step 2 — Category indicator rasters
+[cost]     developed  cells: 1057
+[cost]     wetland    cells: 7762
+[cost]     water (union of cuerpos + cursos + aguas):
+[cost]       cuerpos  cells: 26403
+[cost]       cursos   cells: 117775
+[cost]       aguas    cells: 3708
+[cost]     water      cells: 136974
 
 [cost] Step 3 — Slope raster
-[cost]   slope range after resample: 0.00 – 39.91
+[cost]   slope range: 0.00 – 39.91 deg
 
-[cost] Step 4 — Summing layers
+[cost] Step 4 — Computing cost (Faber 2014 formula)
 
-[cost] Step 5 — Burning city points as land
-[cost]   cities before burn: 2 on barrier (>=1000)
-[cost]   cities after burn:  0 on barrier (>=1000)
+[cost] Step 4a — Coastal buffer for near-shore out-of-country cells
+[cost]   near-shore cells (<= 30 km from land): 39454
+
+[cost] Step 5 — Burning cities as reachable urban cells
+[cost]   before burn: 0 cities on barrier
+[cost]   after burn:  0 cities on barrier
+[cost]   city cell cost range: 26.0 – 37.3
 
 [cost] Step 6 — Cropping to analysis extent
-[cost]   final raster: 977 x 618 cells, extent -73.55, -53.71, -55.09, -21.78
-[cost]   cost range: 0.0 – 1057.3  (mean 583.8)
+[cost]   final raster: 977 x 618 cells
+[cost]   cost range: 1.0 – 1000000.0 (mean 513768.9)
 
 [cost] Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/01_cost_rasters/construction_costs.tif
 ========================================================================


### PR DESCRIPTION
## Summary

Rebuilds the construction cost raster following Faber (2014)'s formula: per-cell cost is a baseline (1) plus slope plus 25× indicators for developed/wetland/water cells. Adds a graduated coastal buffer so rivers and the Strait of Magellan are crossable while open Atlantic stays impassable.

Closes #14

## Context

The previous cost raster had cost = 0 for "flat, inside Argentina, no obstacle" cells because the baseline land-traversal term was omitted. LCPs between nearby cities collapsed to 0 and metro-area clusters produced zero-length shortest paths, breaking downstream MST construction. Fixing this requires a real formula — we use Faber (2014), which the old draft also cites for the cost raster.

Issue: https://github.com/diegogentilepassaro/bimodal-transport-argentina/issues/14

## Changes

- `code/config.R` — new cost parameters: `cost_land_baseline=1`, `cost_developed=25`, `cost_wetland=25`, `cost_water=25`, `cost_coastal_buffer_km=30`, `cost_out_of_country=1,000,000`.
- `code/pipeline/01_cost_raster.R` — rewritten to compute `c_i = 1 + slope + 25·developed + 25·wetland + 25·water` for inside cells; near-shore (<=30 km) out-of-country cells get cost 26; far cells get the hard barrier. City cells are burned to `1 + slope_local + 25` so they stay reachable.
- `Plan/cost_raster_and_lcp_decisions.md` — new documentation: formula, parameters, layer→category mapping, node-set filter, LCP algorithm, MST construction.
- `logs/01_cost_raster.log` — run log from the latest build.

## Design Decisions

- **Water categories combined** via logical OR in raster space: `cuerpos_de_agua` + `cursos_de_agua` + `areas_de_aguas_continentales_BH140`. Line features use `rasterize(touches=TRUE)`.
- **Category surcharges additive** (Faber: a cell both wetland and water gets 50). In practice overlap is minimal.
- **Coastal buffer threshold = 30 km**. Chosen to allow Paraná river crossings (river width ≤5 km, shore-to-shore gap ≤~20 km near Rosario–Paraná) and the Strait of Magellan narrows (~30 km at Primera Angostura) while blocking the Río de la Plata mouth (~200 km BA–Montevideo).
- **City burn kept** even though the coastal buffer already solves the "Puerto Madryn on ocean cell" problem. City cells are burned to the urban-equivalent value (`1 + slope_local + 25`), not 0, so adjacent city pairs have positive LCP costs.
- **Buenos Aires city excluded from node set** — consistent with the project's exclusion of Capital Federal from the estimation sample. Greater Buenos Aires is represented by La Matanza, Lanús, Morón, Avellaneda (each >300k in 1960). Documented in the Plan doc.

## Reference Code

- Faber (2014), "Trade Integration, Market Size, and Industrialization," RES 81(3).
- Old Stata/QGIS pipeline at `Old data/Train/base/construction_costs/`. Our formula matches the draft's stated formula (which the old code omitted the baseline from).
- `Plan/cost_raster_and_lcp_decisions.md` documents all decisions as factual claims for future reference.

## Validation

- Script ran successfully: YES (~90s)
- Output: 977 × 618 cells, cost range 1–1,000,000, mean 513,769
- 255,630 cells inside Argentina, 39,454 near-shore cells, remainder hard barrier
- City burn: 0 cities on barrier before or after (coastal buffer handles the previously-problematic coastal cities directly)
- Spot checks on LCP costs with the new raster:

| Pair | LCP cost | Notes |
|------|---------:|-------|
| Mendoza – Guaymallén | 131,149 | Was 0 previously; now proportional to 5 km distance |
| Mendoza – San Rafael | 961,470 | ~230 km, flat Cuyo terrain |
| Rosario – Córdoba | 1,029,540 | ~400 km Pampas |
| Rosario – Mendoza | 1,864,796 | ~900 km |
| Ushuaia – Río Grande | 1,655,631 | ~130 km, includes short water stretch |
| Puerto Madryn – Comodoro Rivadavia | 1,444,172 | ~450 km coastal Patagonia |
| Rosario – Paraná | 1,196,082 | ~135 km, includes river crossing |
| Rosario – Ushuaia | 9,259,797 | ~3,000 km mainland + Strait crossing |

All finite, monotone in distance, and water crossings visibly contribute without dominating.

## Risk Assessment

**Risk level**: MEDIUM.
**Human should focus on**: (1) whether 30 km coastal buffer is the right threshold — it admits Strait of Magellan crossings but also creates a 30 km "cheap water" buffer along the Atlantic coast that LCPs could use for slight lateral shortcuts. At cost 26/cell vs 1/cell inland, the incentive is modest. (2) The Faber formula departs from the old pipeline in having a non-zero baseline — confirm this matches what the paper claims to use. (3) Buenos Aires city handling — confirm that four GBA partidos is the right representation rather than adding a synthetic CABA node.