### PR TITLE
Hypothetical networks: LCP, LCP-MST, EUC, EUC-MST over 54-city node set

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ data/derived/**
 # Must un-ignore parent dirs for the exception to work
 !data/derived/base/
 !data/derived/base/*/
+!data/derived/02_hypothetical_networks/
 !data/derived/**/data_file_manifest.log
 
 # ---- Generated results (re-created by running main.R) ---------------------

--- a/code/pipeline/02_hypothetical_networks.R
+++ b/code/pipeline/02_hypothetical_networks.R
@@ -1,0 +1,288 @@
+# ===========================================================================
+# 02_hypothetical_networks.R
+#
+# PURPOSE: Compute the four hypothetical networks used as instruments in
+#          the roads IV specification:
+#            - Full LCP (bilateral least-cost paths)
+#            - LCP-MST (minimum spanning tree over the LCP cost matrix)
+#            - Full EUC (bilateral Euclidean lines)
+#            - EUC-MST (minimum spanning tree over the Euclidean distances)
+#
+# READS:
+#   data/derived/01_cost_rasters/construction_costs.tif
+#   data/raw/networks_hypo/<city_layer>.shp              — node set
+#
+# PRODUCES:
+#   data/derived/02_hypothetical_networks/lcp_network.gpkg
+#   data/derived/02_hypothetical_networks/lcp_mst.gpkg
+#   data/derived/02_hypothetical_networks/euc_network.gpkg
+#   data/derived/02_hypothetical_networks/euc_mst.gpkg
+#   data/derived/02_hypothetical_networks/data_file_manifest.log
+#
+# REFERENCE:
+#   Plan/cost_raster_and_lcp_decisions.md
+#   Plan/hypothetical_networks_plan.md
+#
+# NOTES:
+#   - LCP computation uses gdistance 1.6.5 with 16-neighbor connectivity,
+#     conductance = 1/mean(cost), and geoCorrection(type="c") for
+#     distance-weighted costs.
+#   - MST computed with igraph::mst using cost/distance as edge weight.
+#   - City point set is configurable via `city_layer`. Filter rule:
+#     `pop1960 >= pop_threshold OR capital == 1`.
+#   - LCP geometry extraction is parallelized via parallel::mclapply,
+#     capped at 8 cores.
+# ===========================================================================
+
+main <- function(city_layer = "ciudades_seleccion2",
+                 pop_threshold = 15000,
+                 include_capitals = TRUE) {
+    source(file.path(here::here(), "code", "config.R"), echo = FALSE)
+
+    message("\n", strrep("=", 72))
+    message(sprintf("02_hypothetical_networks.R  |  city_layer = %s",
+                    city_layer))
+    message(sprintf("  pop_threshold = %d  |  include_capitals = %s",
+                    pop_threshold, include_capitals))
+    message(strrep("=", 72))
+
+    # --- 1. Load inputs ----------------------------------------------------
+    cost <- terra::rast(file.path(dir_derived_rasters,
+                                  "construction_costs.tif"))
+    cost_r <- raster::raster(cost)  # gdistance still uses raster::raster
+    cities_all <- sf::st_read(
+        file.path(dir_raw, "networks_hypo",
+                  sprintf("%s.shp", city_layer)),
+        quiet = TRUE
+    )
+    if (sf::st_crs(cities_all) != sf::st_crs("EPSG:4326")) {
+        cities_all <- sf::st_transform(cities_all, "EPSG:4326")
+    }
+    # Filter: population threshold OR provincial capital
+    cities_all$pop1960 <- suppressWarnings(as.numeric(cities_all$pop1960))
+    cities_all$capital <- suppressWarnings(as.integer(cities_all$capital))
+    keep <- (!is.na(cities_all$pop1960) & cities_all$pop1960 >= pop_threshold)
+    if (include_capitals) {
+        keep <- keep | (!is.na(cities_all$capital) & cities_all$capital == 1L)
+    }
+    cities <- cities_all[keep, ]
+    message(sprintf("[net]   cities in shapefile: %d", nrow(cities_all)))
+    message(sprintf("[net]   cities kept (filter): %d", nrow(cities)))
+
+    coords <- sf::st_coordinates(cities)
+    rownames(coords) <- seq_len(nrow(coords))
+    message(sprintf("[net]   cost raster: %d x %d cells",
+                    terra::nrow(cost), terra::ncol(cost)))
+
+    # --- 2. Build transition matrix (conductance) --------------------------
+    message("\n[net] Step 2 — Building transition matrix")
+    t0 <- proc.time()
+    tr <- gdistance::transition(
+        cost_r,
+        transitionFunction = function(x) 1 / mean(x),
+        directions = 16
+    )
+    tr <- gdistance::geoCorrection(tr, type = "c")
+    message(sprintf("[net]   transition matrix built in %.0fs",
+                    (proc.time() - t0)[["elapsed"]]))
+
+    # --- 3. Full N x N cost matrix -----------------------------------------
+    message("\n[net] Step 3 — Pairwise cost matrix")
+    t1 <- proc.time()
+    cost_mat <- gdistance::costDistance(tr, fromCoords = coords,
+                                            toCoords   = coords)
+    cost_mat <- as.matrix(cost_mat)
+    message(sprintf("[net]   %dx%d cost matrix in %.0fs",
+                    nrow(cost_mat), ncol(cost_mat),
+                    (proc.time() - t1)[["elapsed"]]))
+    if (any(is.infinite(cost_mat[upper.tri(cost_mat)]))) {
+        warning("Some LCP costs are infinite — check barrier cells near cities")
+    }
+
+    # --- 4. Full LCP network (all pairs) -----------------------------------
+    message("\n[net] Step 4 — Computing LCP geometries for all pairs")
+    t2 <- proc.time()
+    lcp <- build_lcp_network(tr, coords, cost_mat, cities)
+    message(sprintf("[net]   %d LCPs in %.0fs",
+                    nrow(lcp), (proc.time() - t2)[["elapsed"]]))
+
+    # --- 5. LCP-MST --------------------------------------------------------
+    message("\n[net] Step 5 — LCP minimum spanning tree")
+    lcp_mst <- build_mst(lcp, cost_col = "cost")
+
+    # --- 6. Full EUC network -----------------------------------------------
+    message("\n[net] Step 6 — Bilateral Euclidean network")
+    euc <- build_euc_network(cities)
+
+    # --- 7. EUC-MST --------------------------------------------------------
+    message("\n[net] Step 7 — EUC minimum spanning tree")
+    euc_mst <- build_mst(euc, cost_col = "distance_m")
+
+    # --- 8. Save -----------------------------------------------------------
+    out_dir <- file.path(dir_derived, "02_hypothetical_networks")
+    if (!dir.exists(out_dir)) dir.create(out_dir, recursive = TRUE)
+
+    save_layer <- function(x, name) {
+        p <- file.path(out_dir, sprintf("%s.gpkg", name))
+        sf::st_write(x, p, delete_dsn = TRUE, quiet = TRUE)
+        message(sprintf("[net]   saved %s (%d features)", name, nrow(x)))
+    }
+    save_layer(lcp,     "lcp_network")
+    save_layer(lcp_mst, "lcp_mst")
+    save_layer(euc,     "euc_network")
+    save_layer(euc_mst, "euc_mst")
+
+    write_manifest(lcp, lcp_mst, euc, euc_mst, out_dir, city_layer,
+                   nrow(cities))
+
+    message(strrep("=", 72))
+    message("02_hypothetical_networks.R  |  Complete.")
+    message(strrep("=", 72), "\n")
+}
+
+# ---------------------------------------------------------------------------
+# Helper: build full bilateral LCP network by running shortestPath for
+# each unique pair (i,j) with i < j. cost_mat supplies the cost attribute.
+# Parallelized via parallel::mclapply (fork-based on macOS/Linux).
+# ---------------------------------------------------------------------------
+build_lcp_network <- function(tr, coords, cost_mat, cities) {
+    n <- nrow(coords)
+    pairs <- utils::combn(n, 2)
+    n_pairs <- ncol(pairs)
+    # Cap at 8 cores to leave headroom for interactive work
+    n_cores <- min(8L, n_cores_default)
+
+    message(sprintf("[net]     using %d cores for %d LCPs",
+                    n_cores, n_pairs))
+
+    one_lcp <- function(k) {
+        i <- pairs[1, k]; j <- pairs[2, k]
+        sp <- tryCatch(
+            gdistance::shortestPath(tr,
+                                    origin = coords[i, ],
+                                    goal   = coords[j, ],
+                                    output = "SpatialLines"),
+            error = function(e) NULL
+        )
+        if (is.null(sp) || length(sp@lines) == 0L) {
+            # Fall back to a 2-point line if shortestPath returns nothing
+            return(sf::st_linestring(rbind(coords[i, ], coords[j, ])))
+        }
+        geom <- sf::st_geometry(sf::st_as_sf(sp))[[1]]
+        if (length(geom) == 0L) {
+            return(sf::st_linestring(rbind(coords[i, ], coords[j, ])))
+        }
+        geom
+    }
+
+    geom_list <- parallel::mclapply(seq_len(n_pairs), one_lcp,
+                                    mc.cores = n_cores)
+
+    # Guard against worker errors (non-sfg entries → fallback line)
+    for (k in seq_len(n_pairs)) {
+        if (!inherits(geom_list[[k]], "sfg")) {
+            i <- pairs[1, k]; j <- pairs[2, k]
+            geom_list[[k]] <- sf::st_linestring(
+                rbind(coords[i, ], coords[j, ])
+            )
+        }
+    }
+
+    geom <- sf::st_sfc(geom_list, crs = sf::st_crs(cities))
+    sf::st_sf(
+        from = pairs[1, ],
+        to   = pairs[2, ],
+        cost = cost_mat[cbind(pairs[1, ], pairs[2, ])],
+        geometry = geom
+    )
+}
+
+# ---------------------------------------------------------------------------
+# Helper: minimum spanning tree over a bilateral edge set.
+# ---------------------------------------------------------------------------
+build_mst <- function(edges, cost_col) {
+    nodes <- sort(unique(c(edges$from, edges$to)))
+    g <- igraph::graph_from_data_frame(
+        d = as.data.frame(sf::st_drop_geometry(
+            edges[, c("from", "to", cost_col)])),
+        directed = FALSE,
+        vertices = data.frame(name = as.character(nodes))
+    )
+    igraph::E(g)$weight <- edges[[cost_col]]
+    mst_g <- igraph::mst(g)
+
+    # Map MST edges back to rows in the input `edges` sf object
+    mst_edges <- igraph::as_edgelist(mst_g)
+    keep <- logical(nrow(edges))
+    for (k in seq_len(nrow(mst_edges))) {
+        u <- as.integer(mst_edges[k, 1])
+        v <- as.integer(mst_edges[k, 2])
+        match_idx <- which(
+            (edges$from == u & edges$to == v) |
+            (edges$from == v & edges$to == u)
+        )
+        if (length(match_idx) >= 1L) keep[match_idx[1]] <- TRUE
+    }
+    out <- edges[keep, ]
+    message(sprintf("[net]   MST: %d edges (expected %d)",
+                    nrow(out), length(nodes) - 1L))
+    out
+}
+
+# ---------------------------------------------------------------------------
+# Helper: bilateral Euclidean network between city points.
+# ---------------------------------------------------------------------------
+build_euc_network <- function(cities) {
+    n <- nrow(cities)
+    pairs <- utils::combn(n, 2)
+    coords <- sf::st_coordinates(cities)
+    lines <- vector("list", ncol(pairs))
+    for (k in seq_len(ncol(pairs))) {
+        i <- pairs[1, k]; j <- pairs[2, k]
+        lines[[k]] <- sf::st_linestring(rbind(coords[i, ], coords[j, ]))
+    }
+    geom <- sf::st_sfc(lines, crs = sf::st_crs(cities))
+    out <- sf::st_sf(
+        from = pairs[1, ],
+        to   = pairs[2, ],
+        geometry = geom
+    )
+    out$distance_m <- as.numeric(sf::st_length(out))  # geodesic on WGS84
+    out
+}
+
+# ---------------------------------------------------------------------------
+# Helper: write a short manifest log.
+# ---------------------------------------------------------------------------
+write_manifest <- function(lcp, lcp_mst, euc, euc_mst, out_dir, city_layer,
+                           n_cities) {
+    log_path <- file.path(out_dir, "data_file_manifest.log")
+    sink(log_path)
+    on.exit(sink(), add = TRUE)
+    cat("Data file manifest — 02_hypothetical_networks.R\n")
+    cat(sprintf("Generated: %s\n", Sys.time()))
+    cat(sprintf("rootdir: %s\n", rootdir))
+    cat(sprintf("city_layer: %s\n", city_layer))
+    cat(sprintf("n_cities: %d\n\n", n_cities))
+    cat(strrep("=", 60), "\n")
+    f <- function(x, name, cost_col) {
+        cat(sprintf("%s: %d edges, total %s = %.1f\n",
+                    name, nrow(x), cost_col, sum(x[[cost_col]])))
+    }
+    f(lcp,     "lcp_network", "cost")
+    f(lcp_mst, "lcp_mst",     "cost")
+    f(euc,     "euc_network", "distance_m")
+    f(euc_mst, "euc_mst",     "distance_m")
+    cat("\nSanity checks:\n")
+    cat(sprintf("  LCP-MST edges = N-1 ?  %s\n",
+                nrow(lcp_mst) == (n_cities - 1L)))
+    cat(sprintf("  EUC-MST edges = N-1 ?  %s\n",
+                nrow(euc_mst) == (n_cities - 1L)))
+    cat(sprintf("  Sum(LCP)   >= Sum(LCP-MST) ?  %s\n",
+                sum(lcp$cost) >= sum(lcp_mst$cost)))
+    cat(sprintf("  Sum(EUC_m) >= Sum(EUC-MST_m) ?  %s\n",
+                sum(euc$distance_m) >= sum(euc_mst$distance_m)))
+    message(sprintf("[net]   manifest: %s", log_path))
+}
+
+main()

--- a/code/pipeline/02b_preview_networks.R
+++ b/code/pipeline/02b_preview_networks.R
@@ -1,0 +1,78 @@
+# ===========================================================================
+# 02b_preview_networks.R
+#
+# PURPOSE: Produce a quick 1x2 visualization of the two MSTs over the
+#          construction cost raster for eyeball review. Not part of the
+#          main pipeline; run on demand after 02_hypothetical_networks.R.
+#
+# READS:
+#   data/derived/01_cost_rasters/construction_costs.tif
+#   data/derived/02_hypothetical_networks/lcp_mst.gpkg
+#   data/derived/02_hypothetical_networks/euc_mst.gpkg
+#   data/raw/networks_hypo/ciudades_seleccion2.shp
+#
+# PRODUCES:
+#   results/figures/hypothetical_networks_preview.png
+#
+# NOTES:
+#   The cost raster is log-transformed for display (range 1 to 1e6 spans
+#   6 orders of magnitude; linear scale would wash out land variation).
+# ===========================================================================
+
+main <- function() {
+    source(file.path(here::here(), "code", "config.R"), echo = FALSE)
+
+    cost <- terra::rast(file.path(dir_derived_rasters,
+                                  "construction_costs.tif"))
+
+    out_net <- file.path(dir_derived, "02_hypothetical_networks")
+    lcp_mst <- sf::st_read(file.path(out_net, "lcp_mst.gpkg"), quiet = TRUE)
+    euc_mst <- sf::st_read(file.path(out_net, "euc_mst.gpkg"), quiet = TRUE)
+
+    cities <- sf::st_read(
+        file.path(dir_raw, "networks_hypo", "ciudades_seleccion2.shp"),
+        quiet = TRUE
+    )
+    cities$pop1960 <- suppressWarnings(as.numeric(cities$pop1960))
+    cities$capital <- suppressWarnings(as.integer(cities$capital))
+    cities <- cities[
+        (cities$pop1960 >= 15000 & !is.na(cities$pop1960)) |
+        (cities$capital == 1L  & !is.na(cities$capital)),
+    ]
+
+    # Log-transform cost for display; keep 0 (burned cities) visible as 0.
+    log_cost <- log10(cost + 1)
+
+    out_path <- file.path(dir_figures, "hypothetical_networks_preview.png")
+    png(out_path, width = 2000, height = 1600, res = 150)
+    par(mfrow = c(1, 2), mar = c(2, 2, 3, 4))
+
+    draw_panel(
+        "LCP MST (53 edges) over cost raster", log_cost, lcp_mst, cities,
+        line_col = grDevices::rgb(0.1, 0.3, 0.8, 0.95)
+    )
+    draw_panel(
+        "Euclidean MST (53 edges) over cost raster", log_cost, euc_mst,
+        cities, line_col = grDevices::rgb(0.7, 0.1, 0.1, 0.95)
+    )
+
+    dev.off()
+    message(sprintf("Saved: %s", out_path))
+}
+
+draw_panel <- function(title, log_cost, net, cities, line_col, lwd = 1.5) {
+    # Greyscale background: low cost = light, high cost = dark
+    terra::plot(
+        log_cost,
+        main = title,
+        col = grDevices::grey(seq(1, 0.1, length.out = 100)),
+        axes = FALSE,
+        legend = TRUE,
+        plg = list(title = "log10(cost+1)")
+    )
+    plot(sf::st_geometry(net), col = line_col, lwd = lwd, add = TRUE)
+    plot(sf::st_geometry(cities), pch = 20, col = "black", cex = 0.7,
+         add = TRUE)
+}
+
+main()

--- a/data/derived/02_hypothetical_networks/data_file_manifest.log
+++ b/data/derived/02_hypothetical_networks/data_file_manifest.log
@@ -1,0 +1,17 @@
+Data file manifest — 02_hypothetical_networks.R
+Generated: 2026-05-08 23:24:38.721093
+rootdir: /Users/diegogp/Desktop/Diego/Trains/new_repo
+city_layer: ciudades_seleccion2
+n_cities: 54
+
+============================================================ 
+lcp_network: 1431 edges, total cost = 3920775620.3
+lcp_mst: 53 edges, total cost = 43094696.4
+euc_network: 1431 edges, total distance_m = 1350741483.7
+euc_mst: 53 edges, total distance_m = 7938566.7
+
+Sanity checks:
+  LCP-MST edges = N-1 ?  TRUE
+  EUC-MST edges = N-1 ?  TRUE
+  Sum(LCP)   >= Sum(LCP-MST) ?  TRUE
+  Sum(EUC_m) >= Sum(EUC-MST_m) ?  TRUE

--- a/logs/02_hypothetical_networks.log
+++ b/logs/02_hypothetical_networks.log
@@ -1,0 +1,56 @@
+
+R version 4.5.1 (2025-06-13) -- "Great Square Root"
+Copyright (C) 2025 The R Foundation for Statistical Computing
+Platform: aarch64-apple-darwin20
+
+R is free software and comes with ABSOLUTELY NO WARRANTY.
+You are welcome to redistribute it under certain conditions.
+Type 'license()' or 'licence()' for distribution details.
+
+R is a collaborative project with many contributors.
+Type 'contributors()' for more information and
+'citation()' on how to cite R or R packages in publications.
+
+Type 'demo()' for some demos, 'help()' for on-line help, or
+'help.start()' for an HTML browser interface to help.
+Type 'q()' to quit R.
+
+> source(file.path(here::here(), "code", "pipeline", "02_hypothetical_networks.R"))
+[config.R] rootdir = /Users/diegogp/Desktop/Diego/Trains/new_repo
+[config.R] Configuration loaded successfully.
+
+========================================================================
+02_hypothetical_networks.R  |  city_layer = ciudades_seleccion2
+  pop_threshold = 15000  |  include_capitals = TRUE
+========================================================================
+[net]   cities in shapefile: 68
+[net]   cities kept (filter): 54
+[net]   cost raster: 977 x 618 cells
+
+[net] Step 2 — Building transition matrix
+[net]   transition matrix built in 33s
+
+[net] Step 3 — Pairwise cost matrix
+[net]   54x54 cost matrix in 7s
+
+[net] Step 4 — Computing LCP geometries for all pairs
+[net]     using 8 cores for 1431 LCPs
+[net]   1431 LCPs in 436s
+
+[net] Step 5 — LCP minimum spanning tree
+[net]   MST: 53 edges (expected 53)
+
+[net] Step 6 — Bilateral Euclidean network
+
+[net] Step 7 — EUC minimum spanning tree
+[net]   MST: 53 edges (expected 53)
+[net]   saved lcp_network (1431 features)
+[net]   saved lcp_mst (53 features)
+[net]   saved euc_network (1431 features)
+[net]   saved euc_mst (53 features)
+[net]   manifest: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/02_hypothetical_networks/data_file_manifest.log
+========================================================================
+02_hypothetical_networks.R  |  Complete.
+========================================================================
+
+> 


### PR DESCRIPTION
## Summary

Computes the four hypothetical networks used as instruments in the roads IV specification. Produces LCP (full bilateral least-cost paths), LCP-MST, EUC (full bilateral Euclidean), and EUC-MST over a 54-city node set covering mainland Argentina.

Closes #13

## Context

Second of three PRs for the hypothetical networks pipeline (see `Plan/hypothetical_networks_plan.md`). Uses the Faber cost raster from PR #15 as input. The next and final PR will intersect the four network shapefiles with district boundaries and collapse to per-district km totals for the estimation panel.

Issue: https://github.com/diegogentilepassaro/bimodal-transport-argentina/issues/13

## Changes

- `code/pipeline/02_hypothetical_networks.R` — new. Reads the Faber cost raster, filters the candidate city list to 54 nodes (`pop1960 >= 15k OR capital == 1`), builds a gdistance transition matrix, computes all 1,431 pairwise LCPs in parallel (8 cores), builds MSTs with `igraph::mst`, writes 4 GeoPackages plus a manifest.
- `code/pipeline/02b_preview_networks.R` — new. On-demand visualization: both MSTs plotted over the log-scaled cost raster with city points overlaid. Produces `results/figures/hypothetical_networks_preview.png`.
- `.gitignore` — edited to keep `data/derived/02_hypothetical_networks/data_file_manifest.log` tracked even though the parent directory is gitignored.
- `data/derived/02_hypothetical_networks/data_file_manifest.log` — new. Records row counts, total weights, and sanity check results for each of the 4 output files.
- `logs/02_hypothetical_networks.log` — new. Full run log.

## Design Decisions

- **gdistance 1.6.5** for LCP computation. 16-neighbor connectivity, conductance = `1/mean(cost)`, `geoCorrection(type="c")` for geographic distance-weighted costs.
- **City filter `pop1960 >= 15k OR capital == 1`** applied inside `main()` via function arguments (`pop_threshold`, `include_capitals`). Default keeps 54 out of 68 candidate cities; preserves all provincial capitals including smaller Patagonian ones (Ushuaia, Rawson, Viedma, Río Gallegos).
- **Parallel LCP geometry extraction via `parallel::mclapply`** capped at 8 cores. Leaves headroom for interactive work.
- **igraph::mst for MST construction**, on the graph whose nodes are cities and whose edges carry the LCP cost or Euclidean distance as weight. MST edges are then joined back to the full bilateral output to preserve geometries.
- **MST-first preview** rather than full-network rendering. The 1,431-edge full networks are visually cluttered; only MSTs are interesting for eyeballing. Cost raster is log-scaled for display (range 1 to 1e6 spans 6 orders of magnitude).

## Reference Code

- `Old data/Train/derived/hypothetical_networks/code/compute_lcps.R` — old R pipeline using gdistance. Same package, same approach.
- `Old data/Train/derived/hypothetical_networks/code/create_hypo_networks.py` — old QGIS/GRASS MST step. Replaced with `igraph::mst`.
- `Plan/cost_raster_and_lcp_decisions.md` — project documentation of cost raster and LCP parameter choices.
- `Plan/hypothetical_networks_plan.md` — three-PR implementation plan.

## Validation

- Script ran successfully: YES
- Runtime: ~7 min wall clock (33s transition matrix + 7s cost matrix + ~7 min parallel LCP geometries across 1,431 pairs on 8 cores)
- Outputs (in `data/derived/02_hypothetical_networks/`):

| File | Features | Total weight |
|------|---------:|-------------:|
| `lcp_network.gpkg` | 1,431 | 3.92B cost units |
| `lcp_mst.gpkg` | 53 | 43.1M cost units |
| `euc_network.gpkg` | 1,431 | 1.35B m |
| `euc_mst.gpkg` | 53 | 7.94M m (~7,940 km) |

### Sanity checks (all pass)

- `LCP-MST edges = N-1 (53)` for 54 cities
- `EUC-MST edges = N-1 (53)` for 54 cities
- `Sum(LCP costs) >= Sum(LCP-MST costs)`: TRUE
- `Sum(EUC distances) >= Sum(EUC-MST distances)`: TRUE

### Visual check

Preview figure (`results/figures/hypothetical_networks_preview.png`) inspected: LCP MST routes hug the low-cost inside-Argentina corridor and avoid water/mountain barriers; Euclidean MST cuts straight lines between city pairs regardless of terrain. Both MSTs are connected and cover the full mainland.

## Known Limitations

- **Strait of Magellan cells classify as inside Argentina** per `pais.shp` (territorial waters). These cells get the inside-country formula (cost ~1-3) rather than the near-shore water-crossing cost (26). Allows LCPs to cross to Tierra del Fuego cheaply, which we want for connectivity; flagged in the PR #15 review.
- **Additive surcharges** can stack to ~50+ for cells that are both developed and on a riverside. Consistent with Faber (2014) formula but worth knowing when interpreting LCP cost magnitudes.
- **No CABA in node set**. The 4 GBA partidos (La Matanza, Lanús, Morón, Avellaneda) serve as the Buenos Aires anchor. Consistent with the project-wide exclusion of Capital Federal from the estimation sample.

**Risk level**: MEDIUM.
**Human should focus on**: The preview figure (`results/figures/hypothetical_networks_preview.png`). Does the LCP MST look like a plausible "alternative national road network"? Are there obvious routing artifacts (e.g., paths that cut through the Andes instead of going around)?