### PR TITLE
Intersect hypothetical networks with districts → per-district km

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,7 @@ data/derived/**
 !data/derived/base/
 !data/derived/base/*/
 !data/derived/02_hypothetical_networks/
-!data/derived/**/data_file_manifest.log
+!data/derived/**/data_file_manifest*.log
 
 # ---- Generated results (re-created by running main.R) ---------------------
 results/tables/**

--- a/code/base/networks/clean_hypo_networks.R
+++ b/code/base/networks/clean_hypo_networks.R
@@ -1,0 +1,165 @@
+# ===========================================================================
+# clean_hypo_networks.R
+#
+# PURPOSE: Intersect the four hypothetical network shapefiles (LCP, LCP-MST,
+#          EUC, EUC-MST) with district boundaries to compute per-district
+#          km totals. Produces the instrument variables for the
+#          estimation panel.
+#
+# READS:
+#   data/derived/02_hypothetical_networks/lcp_network.gpkg
+#   data/derived/02_hypothetical_networks/lcp_mst.gpkg
+#   data/derived/02_hypothetical_networks/euc_network.gpkg
+#   data/derived/02_hypothetical_networks/euc_mst.gpkg
+#   data/raw/geo/geo2_ar1970_2010.shp
+#
+# PRODUCES:
+#   data/derived/base/networks/hypo_networks_by_district.parquet
+#       Key: geolev2. Variables: hypo_LCP_kms, hypo_LCP_MST_kms,
+#                                hypo_EUC_kms, hypo_EUC_MST_kms.
+#   data/derived/base/networks/data_file_manifest_hypo.log
+#
+# REFERENCE:
+#   code/base/networks/clean_roads.R  (same intersection pattern)
+#   Plan/cost_raster_and_lcp_decisions.md
+#   Plan/hypothetical_networks_plan.md
+#
+# NOTES:
+#   - Districts with no network coverage get 0, not NA.
+#   - Lengths computed via sf::st_length() with s2 geometry (geodesic).
+# ===========================================================================
+
+main <- function() {
+
+    source(file.path(here::here(), "code", "config.R"), echo = FALSE)
+    source(file.path(dir_code, "base", "utils.R"), echo = FALSE)
+
+    message("\n", strrep("=", 72))
+    message("clean_hypo_networks.R  |  Hypothetical networks → district km")
+    message(strrep("=", 72))
+
+    districts <- load_districts()
+
+    net_dir <- file.path(dir_derived, "02_hypothetical_networks")
+    networks <- list(
+        hypo_LCP_kms     = "lcp_network.gpkg",
+        hypo_LCP_MST_kms = "lcp_mst.gpkg",
+        hypo_EUC_kms     = "euc_network.gpkg",
+        hypo_EUC_MST_kms = "euc_mst.gpkg"
+    )
+
+    result <- data.frame(geolev2 = districts$geolev2,
+                         stringsAsFactors = FALSE)
+
+    for (var_name in names(networks)) {
+        message(sprintf("\n[hypo] Intersecting %s", var_name))
+        net_path <- file.path(net_dir, networks[[var_name]])
+        if (!file.exists(net_path)) {
+            stop(sprintf("Network file not found: %s", net_path))
+        }
+        km_by_district <- intersect_and_collapse(net_path, districts)
+        km_by_district <- setNames(km_by_district,
+                                   c("geolev2", var_name))
+        result <- merge(result, km_by_district, by = "geolev2",
+                        all.x = TRUE)
+        result[[var_name]][is.na(result[[var_name]])] <- 0
+    }
+
+    save_output(result)
+
+    message(strrep("=", 72))
+    message("clean_hypo_networks.R  |  Complete.")
+    message(strrep("=", 72), "\n")
+}
+
+# ---------------------------------------------------------------------------
+# Helper: load district shapefile
+# ---------------------------------------------------------------------------
+load_districts <- function() {
+    message("\n[hypo] Loading district shapefile")
+
+    shp_path <- file.path(dir_raw_geo, "geo2_ar1970_2010.shp")
+    if (!file.exists(shp_path)) stop("District shapefile not found")
+
+    d <- sf::st_read(shp_path, quiet = TRUE)
+    d <- sf::st_make_valid(d)
+    names(d)[names(d) == "GEOLEVEL2"] <- "geolev2"
+    d$geolev2 <- sub("^0+", "", as.character(d$geolev2))
+    d <- d[!sf::st_is_empty(d), ]
+    d <- d[!(d$geolev2 %in% geolev2_exclude), ]
+
+    message(sprintf("[hypo]   Loaded %d districts", nrow(d)))
+    d
+}
+
+# ---------------------------------------------------------------------------
+# Helper: intersect a single network with districts and collapse.
+# Returns a data.frame with columns geolev2 and total_km.
+# ---------------------------------------------------------------------------
+intersect_and_collapse <- function(net_path, districts) {
+    net <- sf::st_read(net_path, quiet = TRUE)
+    net <- sf::st_make_valid(net)
+
+    if (sf::st_crs(net) != sf::st_crs(districts)) {
+        net <- sf::st_transform(net, sf::st_crs(districts))
+    }
+
+    clipped <- suppressWarnings(
+        sf::st_intersection(net, districts[, c("geolev2", "geometry")])
+    )
+    clipped$length_km <- as.numeric(sf::st_length(clipped)) / 1000
+
+    df <- sf::st_drop_geometry(clipped)
+    agg <- aggregate(length_km ~ geolev2, data = df, FUN = sum)
+
+    message(sprintf("[hypo]   %d edges → %d districts, total %.0f km",
+                    nrow(net), nrow(agg), sum(agg$length_km)))
+    agg
+}
+
+# ---------------------------------------------------------------------------
+# Helper: save output with manifest
+# ---------------------------------------------------------------------------
+save_output <- function(result) {
+    message("\n[hypo] Validating and saving")
+
+    out_dir <- dir_derived_networks
+    if (!dir.exists(out_dir)) dir.create(out_dir, recursive = TRUE)
+
+    result <- result[order(result$geolev2), ]
+    stopifnot(!any(duplicated(result$geolev2)))
+    stopifnot(!any(is.na(result$geolev2)))
+    message("[hypo]   Key (geolev2) is unique and non-missing: OK")
+    message(sprintf("[hypo]   Districts: %d", nrow(result)))
+
+    out_path <- file.path(out_dir, "hypo_networks_by_district.parquet")
+    arrow::write_parquet(result, out_path)
+    message(sprintf("[hypo]   Saved: %s (%d rows, %d cols)",
+                    out_path, nrow(result), ncol(result)))
+
+    log_path <- file.path(out_dir, "data_file_manifest_hypo.log")
+    sink(log_path)
+    on.exit(sink(), add = TRUE)
+    cat("Data file manifest — clean_hypo_networks.R\n")
+    cat(sprintf("Generated: %s\n", Sys.time()))
+    cat(sprintf("rootdir: %s\n\n", rootdir))
+    cat(strrep("=", 60), "\n")
+    cat("FILE: hypo_networks_by_district.parquet\n")
+    cat(strrep("=", 60), "\n")
+    cat(sprintf("Rows: %d\nColumns: %d\nKey: geolev2\n",
+                nrow(result), ncol(result)))
+    cat("\nSummary of variables:\n")
+    for (v in names(result)) {
+        if (v == "geolev2") next
+        vals <- result[[v]]
+        cat(sprintf("  %-20s mean=%.2f  sd=%.2f  min=%.2f  max=%.2f  n_pos=%d\n",
+                    v, mean(vals), sd(vals), min(vals), max(vals),
+                    sum(vals > 0)))
+    }
+    message(sprintf("[hypo]   Manifest: %s", log_path))
+}
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+main()

--- a/data/derived/base/networks/data_file_manifest_hypo.log
+++ b/data/derived/base/networks/data_file_manifest_hypo.log
@@ -1,0 +1,16 @@
+Data file manifest — clean_hypo_networks.R
+Generated: 2026-05-09 00:12:15.223544
+rootdir: /Users/diegogp/Desktop/Diego/Trains/new_repo
+
+============================================================ 
+FILE: hypo_networks_by_district.parquet
+============================================================ 
+Rows: 312
+Columns: 5
+Key: geolev2
+
+Summary of variables:
+  hypo_LCP_kms         mean=5182.73  sd=8414.44  min=0.00  max=79355.97  n_pos=224
+  hypo_LCP_MST_kms     mean=36.77  sd=62.59  min=0.00  max=301.49  n_pos=143
+  hypo_EUC_kms         mean=3990.51  sd=5780.14  min=0.00  max=56972.82  n_pos=285
+  hypo_EUC_MST_kms     mean=22.52  sd=44.63  min=0.00  max=372.70  n_pos=126

--- a/logs/clean_hypo_networks.log
+++ b/logs/clean_hypo_networks.log
@@ -1,0 +1,50 @@
+
+R version 4.5.1 (2025-06-13) -- "Great Square Root"
+Copyright (C) 2025 The R Foundation for Statistical Computing
+Platform: aarch64-apple-darwin20
+
+R is free software and comes with ABSOLUTELY NO WARRANTY.
+You are welcome to redistribute it under certain conditions.
+Type 'license()' or 'licence()' for distribution details.
+
+R is a collaborative project with many contributors.
+Type 'contributors()' for more information and
+'citation()' on how to cite R or R packages in publications.
+
+Type 'demo()' for some demos, 'help()' for on-line help, or
+'help.start()' for an HTML browser interface to help.
+Type 'q()' to quit R.
+
+> source(file.path(here::here(), "code", "base", "networks", "clean_hypo_networks.R"))
+[config.R] rootdir = /Users/diegogp/Desktop/Diego/Trains/new_repo
+[config.R] Configuration loaded successfully.
+
+========================================================================
+clean_hypo_networks.R  |  Hypothetical networks → district km
+========================================================================
+
+[hypo] Loading district shapefile
+[hypo]   Loaded 312 districts
+
+[hypo] Intersecting hypo_LCP_kms
+[hypo]   1431 edges → 224 districts, total 1617011 km
+
+[hypo] Intersecting hypo_LCP_MST_kms
+[hypo]   53 edges → 143 districts, total 11474 km
+
+[hypo] Intersecting hypo_EUC_kms
+[hypo]   1431 edges → 285 districts, total 1245039 km
+
+[hypo] Intersecting hypo_EUC_MST_kms
+[hypo]   53 edges → 126 districts, total 7025 km
+
+[hypo] Validating and saving
+[hypo]   Key (geolev2) is unique and non-missing: OK
+[hypo]   Districts: 312
+[hypo]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/base/networks/hypo_networks_by_district.parquet (312 rows, 5 cols)
+[hypo]   Manifest: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/base/networks/data_file_manifest_hypo.log
+========================================================================
+clean_hypo_networks.R  |  Complete.
+========================================================================
+
+> 


### PR DESCRIPTION
## Summary

Final PR of the hypothetical networks sequence. Intersects the 4 network shapefiles from PR #16 with district boundaries and produces `hypo_networks_by_district.parquet` — 312 districts × 4 km variables for the estimation panel.

Closes #17

## Context

Third and final PR for the hypothetical networks pipeline (see `Plan/hypothetical_networks_plan.md`). Completes the chain: cost raster (PR #15) → LCP/MST networks (PR #16) → per-district km for panel construction (this PR).

Issue: https://github.com/diegogentilepassaro/bimodal-transport-argentina/issues/17

## Changes

- `code/base/networks/clean_hypo_networks.R` — new. Loads district shapefile, iterates over 4 networks, intersects each with districts, collapses to geolev2-keyed totals, joins into a wide table, validates, saves.
- `data/derived/base/networks/data_file_manifest_hypo.log` — new manifest for the 4 km variables.
- `logs/clean_hypo_networks.log` — run log.
- `.gitignore` — widened the manifest exception from `data_file_manifest.log` to `data_file_manifest*.log` so the hypo manifest is tracked alongside the existing roads manifest in `base/networks/`.

## Design Decisions

- **Same pattern as `clean_roads.R`**: `sf::st_intersection()` then `aggregate()` by geolev2. Uses s2 geodesic lengths via `sf::st_length()` / 1000.
- **Districts with no network coverage get 0, not NA.** All 312 districts appear in the output regardless of whether any edge passes through them — simpler for downstream panel merges.
- **Two manifests in the same directory** (`data_file_manifest.log` for roads, `data_file_manifest_hypo.log` for hypo). Could merge into one but keeping them separate mirrors the script separation.

## Reference Code

- `code/base/networks/clean_roads.R` — same intersection pattern, directly adapted.
- `Old data/Train/derived/networks_to_districts/code/networks_to_districts.py` — old QGIS pipeline, reference only.
- `Plan/cost_raster_and_lcp_decisions.md` — documents the networks construction.

## Validation

- Script ran successfully: YES (~30s)
- Output: 312 rows, 5 columns (geolev2 + 4 km variables), key unique and non-missing

### Edge coverage

| Variable | Districts with positive km | Total km |
|----------|---------------------------:|---------:|
| `hypo_LCP_kms` | 224 / 312 | 1,617,011 |
| `hypo_LCP_MST_kms` | 143 / 312 | 11,474 |
| `hypo_EUC_kms` | 285 / 312 | 1,245,039 |
| `hypo_EUC_MST_kms` | 126 / 312 | 7,025 |

### Intersection sanity

EUC MST: 7,939 km (from PR #16 manifest) → 7,025 km after intersection. The ~12% difference (~900 km) is the length of EUC edges passing through cells not covered by any district polygon (water, out-of-country). Expected: district totals should only include edge portions that land on district land.

## Known Limitations

- **Out-of-district edge portions are dropped silently.** If you care about total "network exposure" across all land (not just districts in the sample), the intersected totals underestimate. For the panel-construction use case this is correct: we only assign km to districts in the sample.
- **MST edge count doesnt determine district count.** An MST with 53 edges can touch 126–143 districts (one edge crossing 2–3 districts). This is fine but worth knowing when reasoning about instrument strength.

**Risk level**: LOW.
**Human should focus on**: whether the 12% shrinkage between pre- and post-intersection EUC MST totals is acceptable, or whether we want to reassign out-of-district edge portions somehow (e.g., allocate proportionally to nearest district). My lean: leave as-is. The 900 km is mostly Strait of Magellan and Río de la Plata mouth water — not attributable to any specific district.