### PR TITLE
Clean railroad network from lp_1979 shapefile (312 districts)

### DIFF
--- a/code/base/networks/clean_railroads.R
+++ b/code/base/networks/clean_railroads.R
@@ -1,0 +1,319 @@
+# ===========================================================================
+# clean_railroads.R
+#
+# PURPOSE: Build district-level railroad length variables and the Larkin
+#          Plan instrument from the lp_1979 shapefile.
+#
+# READS:
+#   data/raw/networks/lp_1979.shp          — 565 rail segments (WGS 84),
+#                                             already joined to districts
+#   data/raw/geo/geo2_ar1970_2010.shp      — IPUMS 312-district boundaries
+#
+# PRODUCES:
+#   data/derived/base/networks/rails_by_district.parquet
+#   data/derived/base/networks/data_file_manifest_rails.log
+#
+# FIELDS IN lp_1979 (per Cote):
+#   status1979 ∈ {1, 2, 3}
+#       1 = active in 1979 and 1986
+#       2 = closed during the military dictatorship (1976–1983)
+#       3 = closed before 1976 ("pre-dictatorship")
+#   studied_co ∈ {0, 1}
+#       1 = studied in the Larkin Plan (instrument)
+#   recom_code ∈ {1, 2, 3} — Larkin-plan recommendation category
+#
+# OUTPUT VARIABLES (per district):
+#   status1979_1, status1979_2, status1979_3   — km by status code
+#   studied_0, studied_1                       — km by Larkin-study flag
+#   tot_rails_1960, tot_rails_1986             — period rail-km totals
+#   chg_tot_rails_86_60                        — change in rail km 1960→1986
+#   studied_larkin                             — km of Larkin-studied rail
+#   share_studied_larkin                       — studied_1 / (studied_0 +
+#                                                 studied_1), NA if no rail
+#
+# ASSUMPTION (flag for Diego):
+#   `status1979 == 3` = closed *before* 1976. I interpret this as "closed
+#   between 1960 and 1976" — i.e., these segments WERE active in 1960.
+#   So `tot_rails_1960 = status1979_1 + status1979_2 + status1979_3` and
+#   `tot_rails_1986 = status1979_1`.
+#   If instead status == 3 means "closed before 1960", switch to
+#   `tot_rails_1960 = status1979_1 + status1979_2` and set the status3
+#   column to an informational-only field. The manifest prints both
+#   interpretations side by side for inspection.
+# ===========================================================================
+
+main <- function() {
+
+    source(file.path(here::here(), "code", "config.R"), echo = FALSE)
+    source(file.path(dir_code, "base", "utils.R"), echo = FALSE)
+
+    message("\n", strrep("=", 72))
+    message("clean_railroads.R  |  Rail network → district-level km")
+    message(strrep("=", 72))
+
+    districts <- load_districts()
+    rails     <- load_rails()
+    clipped   <- intersect_rails_districts(rails, districts)
+    result    <- collapse_and_compute(clipped, districts)
+    save_output(result)
+
+    message(strrep("=", 72))
+    message("clean_railroads.R  |  Complete.")
+    message(strrep("=", 72), "\n")
+}
+
+# ---------------------------------------------------------------------------
+# Helper: load district shapefile (same pattern as clean_roads.R)
+# ---------------------------------------------------------------------------
+load_districts <- function() {
+    message("\n[rails] Step 1 — Loading district shapefile")
+
+    shp_path <- file.path(dir_raw_geo, "geo2_ar1970_2010.shp")
+    if (!file.exists(shp_path)) stop("District shapefile not found")
+
+    d <- sf::st_read(shp_path, quiet = TRUE)
+    d <- sf::st_make_valid(d)
+    names(d)[names(d) == "GEOLEVEL2"] <- "geolev2"
+    d$geolev2 <- sub("^0+", "", as.character(d$geolev2))
+    d <- d[!sf::st_is_empty(d), ]
+    d <- d[!(d$geolev2 %in% geolev2_exclude), ]
+
+    message(sprintf("[rails]   Loaded %d districts", nrow(d)))
+    d
+}
+
+# ---------------------------------------------------------------------------
+# Helper: load rail shapefile
+# ---------------------------------------------------------------------------
+load_rails <- function() {
+    message("\n[rails] Step 2 — Loading rail shapefile")
+
+    shp_path <- file.path(dir_raw_networks, "lp_1979.shp")
+    if (!file.exists(shp_path)) stop("Rail shapefile not found")
+
+    rails <- sf::st_read(shp_path, quiet = TRUE)
+    rails <- sf::st_make_valid(rails)
+
+    # Validate expected fields
+    required <- c("status1979", "studied_co", "recom_code", "id_main")
+    missing <- setdiff(required, names(rails))
+    if (length(missing)) {
+        stop("lp_1979.shp missing fields: ",
+             paste(missing, collapse = ", "))
+    }
+    stopifnot(all(rails$status1979 %in% c(1, 2, 3)))
+    stopifnot(all(rails$studied_co %in% c(0, 1)))
+
+    message(sprintf("[rails]   Loaded %d rail segments", nrow(rails)))
+    message("[rails]   status1979 distribution:")
+    for (v in sort(unique(rails$status1979))) {
+        message(sprintf("[rails]     status1979=%d: %d segments", v,
+                        sum(rails$status1979 == v)))
+    }
+    message("[rails]   studied_co distribution:")
+    for (v in sort(unique(rails$studied_co))) {
+        message(sprintf("[rails]     studied_co=%d: %d segments", v,
+                        sum(rails$studied_co == v)))
+    }
+
+    rails
+}
+
+# ---------------------------------------------------------------------------
+# Helper: intersect rails with districts (same pattern as roads)
+# ---------------------------------------------------------------------------
+intersect_rails_districts <- function(rails, districts) {
+    message("\n[rails] Step 3 — Intersecting rails with districts")
+
+    if (sf::st_crs(rails) != sf::st_crs(districts)) {
+        message("[rails]   Reprojecting rails to district CRS")
+        rails <- sf::st_transform(rails, sf::st_crs(districts))
+    }
+
+    clipped <- suppressWarnings(
+        sf::st_intersection(
+            rails[, c("id_main", "status1979", "studied_co", "recom_code",
+                      "geometry")],
+            districts[, c("geolev2", "geometry")]
+        )
+    )
+
+    clipped$length_km <- as.numeric(sf::st_length(clipped)) / 1000
+
+    message(sprintf("[rails]   Clipped segments: %d", nrow(clipped)))
+    message(sprintf("[rails]   Total rail km: %.0f",
+                    sum(clipped$length_km)))
+
+    clipped
+}
+
+# ---------------------------------------------------------------------------
+# Helper: collapse by district and compute period + instrument variables
+# ---------------------------------------------------------------------------
+collapse_and_compute <- function(clipped, districts) {
+    message("\n[rails] Step 4 — Collapsing by district")
+
+    df <- sf::st_drop_geometry(clipped)
+
+    # --- By status1979 ---
+    agg_status <- aggregate(length_km ~ geolev2 + status1979,
+                            data = df, FUN = sum)
+    wide_status <- reshape(agg_status, idvar = "geolev2",
+                           timevar = "status1979",
+                           direction = "wide", sep = "_")
+    names(wide_status) <- sub("length_km_", "status1979_", names(wide_status))
+
+    # --- By studied_co ---
+    agg_studied <- aggregate(length_km ~ geolev2 + studied_co,
+                             data = df, FUN = sum)
+    wide_studied <- reshape(agg_studied, idvar = "geolev2",
+                            timevar = "studied_co",
+                            direction = "wide", sep = "_")
+    names(wide_studied) <- sub("length_km_", "studied_", names(wide_studied))
+
+    # --- Merge the two wide tables ---
+    wide <- merge(wide_status, wide_studied, by = "geolev2", all = TRUE)
+
+    # --- Ensure all expected columns exist ---
+    for (v in 1:3) {
+        col <- sprintf("status1979_%d", v)
+        if (!(col %in% names(wide))) wide[[col]] <- 0
+    }
+    for (v in 0:1) {
+        col <- sprintf("studied_%d", v)
+        if (!(col %in% names(wide))) wide[[col]] <- 0
+    }
+
+    # --- Fill NA with 0 (district has no rail of that category) ---
+    num_cols <- setdiff(names(wide), "geolev2")
+    for (col in num_cols) {
+        wide[[col]][is.na(wide[[col]])] <- 0
+    }
+
+    # --- Period totals (primary interpretation: status 3 active in 1960) ---
+    wide$tot_rails_1986 <- wide$status1979_1
+    wide$tot_rails_1960 <- wide$status1979_1 +
+                           wide$status1979_2 +
+                           wide$status1979_3
+    wide$chg_tot_rails_86_60 <- wide$tot_rails_1986 - wide$tot_rails_1960
+
+    # --- Larkin instrument variables ---
+    wide$studied_larkin <- wide$studied_1
+    wide$share_studied_larkin <- ifelse(
+        (wide$studied_0 + wide$studied_1) > 0,
+        wide$studied_1 / (wide$studied_0 + wide$studied_1),
+        NA_real_
+    )
+
+    # --- Add districts with NO rail segments: row of zeros (share = NA) ---
+    all_districts <- sf::st_drop_geometry(districts)$geolev2
+    missing_geos <- setdiff(all_districts, wide$geolev2)
+    if (length(missing_geos)) {
+        add <- data.frame(geolev2 = missing_geos)
+        for (v in setdiff(names(wide), "geolev2")) {
+            if (v == "share_studied_larkin") {
+                add[[v]] <- NA_real_
+            } else {
+                add[[v]] <- 0
+            }
+        }
+        wide <- rbind(wide, add[, names(wide)])
+    }
+
+    # --- Diagnostics ---
+    # Alt interpretation (status 3 closed before 1960) computed on final table
+    tot_1960_alt <- wide$status1979_1 + wide$status1979_2
+
+    message(sprintf("[rails]   Districts with rail: %d / %d",
+                    length(unique(df$geolev2)), nrow(wide)))
+    message(sprintf("[rails]   Mean tot_rails_1960: %.1f km  (alt: %.1f km)",
+                    mean(wide$tot_rails_1960), mean(tot_1960_alt)))
+    message(sprintf("[rails]   Mean tot_rails_1986: %.1f km",
+                    mean(wide$tot_rails_1986)))
+    message(sprintf("[rails]   Mean chg 86-60: %.1f km",
+                    mean(wide$chg_tot_rails_86_60)))
+    message(sprintf("[rails]   Mean studied_larkin: %.1f km",
+                    mean(wide$studied_larkin)))
+    message(sprintf("[rails]   Mean share_studied_larkin: %.3f (N=%d)",
+                    mean(wide$share_studied_larkin, na.rm = TRUE),
+                    sum(!is.na(wide$share_studied_larkin))))
+
+    # Attach alt total as attribute for the manifest to read
+    attr(wide, "tot_1960_alt_mean") <- mean(tot_1960_alt)
+    attr(wide, "tot_1960_alt_sum")  <- sum(tot_1960_alt)
+
+    wide
+}
+
+# ---------------------------------------------------------------------------
+# Helper: save output with manifest
+# ---------------------------------------------------------------------------
+save_output <- function(result) {
+    message("\n[rails] Step 5 — Validating and saving")
+
+    out_dir <- dir_derived_networks
+    if (!dir.exists(out_dir)) dir.create(out_dir, recursive = TRUE)
+
+    result <- result[order(result$geolev2), ]
+    stopifnot(!any(duplicated(result$geolev2)))
+    stopifnot(!any(is.na(result$geolev2)))
+    message("[rails]   Key (geolev2) is unique and non-missing: OK")
+    message(sprintf("[rails]   Districts: %d", nrow(result)))
+
+    # Enforce character key
+    result$geolev2 <- as.character(result$geolev2)
+
+    out_path <- file.path(out_dir, "rails_by_district.parquet")
+    # Strip attributes before writing (arrow can warn)
+    attr_alt_mean <- attr(result, "tot_1960_alt_mean")
+    attr_alt_sum  <- attr(result, "tot_1960_alt_sum")
+    clean <- result
+    attr(clean, "tot_1960_alt_mean") <- NULL
+    attr(clean, "tot_1960_alt_sum")  <- NULL
+    arrow::write_parquet(clean, out_path)
+    message(sprintf("[rails]   Saved: %s (%d rows, %d cols)",
+                    out_path, nrow(clean), ncol(clean)))
+
+    log_path <- file.path(out_dir, "data_file_manifest_rails.log")
+    sink(log_path)
+    on.exit(sink(), add = TRUE)
+    cat("Data file manifest — clean_railroads.R\n")
+    cat(sprintf("Generated: %s\n", Sys.time()))
+    cat(sprintf("rootdir: %s\n\n", rootdir))
+    cat(strrep("=", 60), "\n")
+    cat("FILE: rails_by_district.parquet\n")
+    cat(strrep("=", 60), "\n")
+    cat(sprintf("Rows: %d\nColumns: %d\nKey: geolev2\n",
+                nrow(clean), ncol(clean)))
+    cat("\nstatus1979 taxonomy:\n")
+    cat("  1 = active in 1979 and 1986\n")
+    cat("  2 = closed during the military dictatorship (1976-1983)\n")
+    cat("  3 = closed before 1976 (pre-dictatorship)\n")
+    cat("\nPeriod-total interpretation:\n")
+    cat("  tot_rails_1986 = status1979_1\n")
+    cat("  tot_rails_1960 = status1979_1 + status1979_2 + status1979_3\n")
+    cat("    (assumes status==3 segments existed in 1960,\n")
+    cat("     i.e., were closed between 1960 and 1976)\n")
+    cat("\nSanity check — alternate interpretation\n")
+    cat("  (if status==3 means closed before 1960):\n")
+    cat(sprintf("  tot_rails_1960_alt mean = %.1f km\n", attr_alt_mean))
+    cat(sprintf("  tot_rails_1960_alt sum  = %.0f km\n", attr_alt_sum))
+    cat("\nSummary of variables:\n")
+    for (v in names(clean)) {
+        if (v == "geolev2") next
+        vals <- clean[[v]]
+        nna  <- sum(!is.na(vals))
+        cat(sprintf(
+            "  %-25s N=%d  mean=%.3f  sd=%.3f  min=%.3f  max=%.3f  NA=%d\n",
+            v, nna, mean(vals, na.rm = TRUE), sd(vals, na.rm = TRUE),
+            min(vals, na.rm = TRUE), max(vals, na.rm = TRUE),
+            sum(is.na(vals))
+        ))
+    }
+    message(sprintf("[rails]   Manifest: %s", log_path))
+}
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+main()

--- a/code/base/networks/clean_railroads.R
+++ b/code/base/networks/clean_railroads.R
@@ -28,18 +28,20 @@
 #   tot_rails_1960, tot_rails_1986             — period rail-km totals
 #   chg_tot_rails_86_60                        — change in rail km 1960→1986
 #   studied_larkin                             — km of Larkin-studied rail
-#   share_studied_larkin                       — studied_1 / (studied_0 +
-#                                                 studied_1), NA if no rail
+#   share_studied_larkin                       — studied_1 / tot_rails_1960,
+#                                                 NA if no rail
 #
-# ASSUMPTION (flag for Diego):
-#   `status1979 == 3` = closed *before* 1976. I interpret this as "closed
-#   between 1960 and 1976" — i.e., these segments WERE active in 1960.
-#   So `tot_rails_1960 = status1979_1 + status1979_2 + status1979_3` and
-#   `tot_rails_1986 = status1979_1`.
-#   If instead status == 3 means "closed before 1960", switch to
-#   `tot_rails_1960 = status1979_1 + status1979_2` and set the status3
-#   column to an informational-only field. The manifest prints both
-#   interpretations side by side for inspection.
+# DATA DECISIONS (see Plan/railroad_pipeline.md):
+#   - status1979 == 3 segments ("closed pre-dictatorship, 1960–1966") are
+#     counted as active in 1960. This matches the old pipeline's preclean
+#     definition (see preclean_departments_wide.do). The manifest prints
+#     the alt interpretation (status==3 excluded from 1960) for reference,
+#     but the exported `tot_rails_1960` follows the old-pipeline spec.
+#   - share_studied_larkin uses (studied_0 + studied_1) as denominator
+#     rather than tot_rails_1960. The two are identical by construction
+#     because every segment has both a status1979 and a studied_co value,
+#     and (studied_0 + studied_1) sums all segments the same as
+#     (status1979_1 + status1979_2 + status1979_3).
 # ===========================================================================
 
 main <- function() {

--- a/code/base/networks/preview_networks.R
+++ b/code/base/networks/preview_networks.R
@@ -1,0 +1,285 @@
+# ===========================================================================
+# preview_networks.R
+#
+# PURPOSE: Eyeball-check figures for the cleaned road and rail networks.
+#          Run on demand after clean_roads.R and clean_railroads.R.
+#
+# READS:
+#   data/raw/networks/lp_1979.shp
+#   data/raw/networks/comparacion_54_70_86.shp
+#   data/raw/geo/geo2_ar1970_2010.shp
+#   data/derived/base/networks/rails_by_district.parquet
+#   data/derived/base/networks/roads_by_district.parquet
+#
+# PRODUCES:
+#   results/figures/rails_by_status1979.png
+#   results/figures/rails_by_studied.png
+#   results/figures/rails_chg_8660_choropleth.png
+#   results/figures/roads_by_period.png
+#   results/figures/roads_chg_8654_choropleth.png
+# ===========================================================================
+
+main <- function() {
+    source(file.path(here::here(), "code", "config.R"), echo = FALSE)
+    source(file.path(dir_code, "base", "utils.R"), echo = FALSE)
+
+    if (!dir.exists(dir_figures)) dir.create(dir_figures, recursive = TRUE)
+
+    districts <- load_districts_plain()
+
+    # --- Rails ---
+    rails <- sf::st_read(
+        file.path(dir_raw_networks, "lp_1979.shp"), quiet = TRUE
+    )
+    rails <- sf::st_make_valid(rails)
+    rails_panel <- arrow::read_parquet(
+        file.path(dir_derived_networks, "rails_by_district.parquet")
+    )
+
+    plot_rails_by_status(rails, districts)
+    plot_rails_by_studied(rails, districts)
+    plot_rails_choropleth(rails_panel, districts)
+
+    # --- Roads ---
+    roads <- sf::st_read(
+        file.path(dir_raw_networks, "comparacion_54_70_86.shp"),
+        quiet = TRUE
+    )
+    roads <- sf::st_make_valid(roads)
+    roads_panel <- arrow::read_parquet(
+        file.path(dir_derived_networks, "roads_by_district.parquet")
+    )
+
+    plot_roads_by_period(roads, districts)
+    plot_roads_choropleth(roads_panel, districts)
+
+    message("Done — 5 figures in results/figures/")
+}
+
+# ---------------------------------------------------------------------------
+# Helper: load districts (no sf-column trickery needed for plotting)
+# ---------------------------------------------------------------------------
+load_districts_plain <- function() {
+    d <- sf::st_read(
+        file.path(dir_raw_geo, "geo2_ar1970_2010.shp"), quiet = TRUE
+    )
+    d <- sf::st_make_valid(d)
+    names(d)[names(d) == "GEOLEVEL2"] <- "geolev2"
+    d$geolev2 <- sub("^0+", "", as.character(d$geolev2))
+    d <- d[!sf::st_is_empty(d), ]
+    d <- d[!(d$geolev2 %in% geolev2_exclude), ]
+    d
+}
+
+# ---------------------------------------------------------------------------
+# Figure 1: Rails colored by status1979
+# ---------------------------------------------------------------------------
+plot_rails_by_status <- function(rails, districts) {
+    out <- file.path(dir_figures, "rails_by_status1979.png")
+    png(out, width = 1600, height = 2000, res = 150)
+    par(mar = c(2, 2, 3, 2))
+
+    plot(sf::st_geometry(districts), col = "grey95", border = "grey70",
+         lwd = 0.3,
+         main = "Rail segments by status1979")
+
+    # Plot layers in order: active on top so it's most visible
+    ord <- c(3, 2, 1)
+    cols <- c("1" = "#1f77b4", "2" = "#d62728", "3" = "#7f7f7f")
+    lwds <- c("1" = 1.1,        "2" = 1.0,        "3" = 0.9)
+    for (s in ord) {
+        r <- rails[rails$status1979 == s, ]
+        plot(sf::st_geometry(r), col = cols[as.character(s)],
+             lwd = lwds[as.character(s)], add = TRUE)
+    }
+
+    legend("bottomright",
+           legend = c(
+               sprintf("1 = active 1979/1986 (n=%d)",
+                       sum(rails$status1979 == 1)),
+               sprintf("2 = closed in dictadura 1976-83 (n=%d)",
+                       sum(rails$status1979 == 2)),
+               sprintf("3 = closed pre-dictadura 1960-66 (n=%d)",
+                       sum(rails$status1979 == 3))
+           ),
+           col = cols, lwd = 2, bty = "n", cex = 0.85)
+
+    dev.off()
+    message("Saved: ", out)
+}
+
+# ---------------------------------------------------------------------------
+# Figure 2: Rails colored by studied_co (Larkin instrument)
+# ---------------------------------------------------------------------------
+plot_rails_by_studied <- function(rails, districts) {
+    out <- file.path(dir_figures, "rails_by_studied.png")
+    png(out, width = 1600, height = 2000, res = 150)
+    par(mar = c(2, 2, 3, 2))
+
+    plot(sf::st_geometry(districts), col = "grey95", border = "grey70",
+         lwd = 0.3,
+         main = "Rail segments by Larkin-study flag (instrument)")
+
+    r0 <- rails[rails$studied_co == 0, ]
+    r1 <- rails[rails$studied_co == 1, ]
+    plot(sf::st_geometry(r0), col = "#7f7f7f", lwd = 0.9, add = TRUE)
+    plot(sf::st_geometry(r1), col = "#d62728", lwd = 1.2, add = TRUE)
+
+    legend("bottomright",
+           legend = c(
+               sprintf("0 = not studied (n=%d)", nrow(r0)),
+               sprintf("1 = Larkin-studied (n=%d)", nrow(r1))
+           ),
+           col = c("#7f7f7f", "#d62728"), lwd = 2, bty = "n", cex = 0.85)
+
+    dev.off()
+    message("Saved: ", out)
+}
+
+# ---------------------------------------------------------------------------
+# Figure 3: District choropleth of rail-km change 1960 -> 1986
+# ---------------------------------------------------------------------------
+plot_rails_choropleth <- function(panel, districts) {
+    out <- file.path(dir_figures, "rails_chg_8660_choropleth.png")
+
+    d <- merge(districts[, "geolev2"], panel[, c("geolev2",
+                                                 "chg_tot_rails_86_60",
+                                                 "tot_rails_1960")],
+               by = "geolev2", all.x = TRUE)
+    # Districts with zero 1960 rails have chg = 0 — separate them so the
+    # colour scale isn't dominated by "no change = no rail"
+    d$lost_km <- -d$chg_tot_rails_86_60  # positive = km lost
+    d$cat <- cut(
+        d$lost_km,
+        breaks = c(-Inf, 0.0001, 25, 75, 150, Inf),
+        labels = c("No rail / no loss", "(0, 25]", "(25, 75]",
+                   "(75, 150]", "150+"),
+        right = TRUE
+    )
+    # Districts that had no rail in 1960 get their own "grey" level
+    d$cat <- as.character(d$cat)
+    d$cat[is.na(d$tot_rails_1960) | d$tot_rails_1960 < 0.001] <- "No rail in 1960"
+    d$cat <- factor(d$cat, levels = c(
+        "No rail in 1960", "No rail / no loss",
+        "(0, 25]", "(25, 75]", "(75, 150]", "150+"
+    ))
+
+    pal <- c("No rail in 1960"   = "grey90",
+             "No rail / no loss" = "#ffffcc",
+             "(0, 25]"           = "#fed976",
+             "(25, 75]"          = "#fd8d3c",
+             "(75, 150]"         = "#e31a1c",
+             "150+"              = "#800026")
+
+    png(out, width = 1600, height = 2000, res = 150)
+    par(mar = c(2, 2, 3, 2))
+
+    plot(sf::st_geometry(d), col = pal[d$cat], border = "grey70", lwd = 0.3,
+         main = "Rail km lost 1960 → 1986 (by district)")
+    legend("bottomright",
+           legend = names(pal),
+           fill = pal, bty = "n", cex = 0.85,
+           title = "Rail km lost")
+
+    dev.off()
+    message("Saved: ", out)
+}
+
+# ---------------------------------------------------------------------------
+# Figure 4: Roads colored by type2 (period presence)
+# ---------------------------------------------------------------------------
+plot_roads_by_period <- function(roads, districts) {
+    out <- file.path(dir_figures, "roads_by_period.png")
+    png(out, width = 1600, height = 2000, res = 150)
+    par(mar = c(2, 2, 3, 2))
+
+    plot(sf::st_geometry(districts), col = "grey95", border = "grey70",
+         lwd = 0.3,
+         main = "Road segments by period (comparacion_54_70_86)")
+
+    cols <- c(
+        "1" = "#1f77b4",   # present all three
+        "2" = "#2ca02c",   # new in 1970
+        "3" = "#d62728",   # new in 1986
+        "4" = "#9467bd",   # gone by 1986
+        "5" = "#8c564b",   # 1954+1986, absent 1970 (error)
+        "6" = "#e377c2",   # 1970 only
+        "7" = "#7f7f7f"    # 1954 only
+    )
+    labs <- c(
+        "1" = "1: 1954+1970+1986",
+        "2" = "2: new in 1970",
+        "3" = "3: new in 1986",
+        "4" = "4: gone by 1986",
+        "5" = "5: 1954+1986 (absent 1970)",
+        "6" = "6: 1970 only",
+        "7" = "7: 1954 only"
+    )
+
+    # Plot from least-visible (type 7) up so salient types sit on top
+    ord <- c("7", "6", "5", "4", "3", "2", "1")
+    for (s in ord) {
+        r <- roads[as.character(roads$type2) == s, ]
+        if (nrow(r) == 0) next
+        plot(sf::st_geometry(r), col = cols[s], lwd = 0.9, add = TRUE)
+    }
+
+    present <- sort(unique(as.character(roads$type2)))
+    legend("bottomright",
+           legend = sprintf("%s (n=%d)", labs[present],
+                            sapply(present, function(s)
+                                sum(as.character(roads$type2) == s))),
+           col = cols[present], lwd = 2, bty = "n", cex = 0.8)
+
+    dev.off()
+    message("Saved: ", out)
+}
+
+# ---------------------------------------------------------------------------
+# Figure 5: District choropleth of pav+grav road change 1954 -> 1986
+# ---------------------------------------------------------------------------
+plot_roads_choropleth <- function(panel, districts) {
+    out <- file.path(dir_figures, "roads_chg_8654_choropleth.png")
+
+    d <- merge(districts[, "geolev2"],
+               panel[, c("geolev2", "chg_pav_and_grav_86_54",
+                         "pav_and_grav_1954")],
+               by = "geolev2", all.x = TRUE)
+
+    d$cat <- cut(
+        d$chg_pav_and_grav_86_54,
+        breaks = c(-Inf, 0, 25, 100, 250, 500, Inf),
+        labels = c("Zero/negative", "(0, 25]", "(25, 100]",
+                   "(100, 250]", "(250, 500]", "500+"),
+        right = TRUE
+    )
+    d$cat <- as.character(d$cat)
+    d$cat[is.na(d$chg_pav_and_grav_86_54)] <- "No data"
+    d$cat <- factor(d$cat, levels = c(
+        "No data", "Zero/negative", "(0, 25]", "(25, 100]",
+        "(100, 250]", "(250, 500]", "500+"
+    ))
+
+    pal <- c("No data"       = "grey90",
+             "Zero/negative" = "#ffffcc",
+             "(0, 25]"       = "#c7e9b4",
+             "(25, 100]"     = "#7fcdbb",
+             "(100, 250]"    = "#41b6c4",
+             "(250, 500]"    = "#1d91c0",
+             "500+"          = "#253494")
+
+    png(out, width = 1600, height = 2000, res = 150)
+    par(mar = c(2, 2, 3, 2))
+
+    plot(sf::st_geometry(d), col = pal[d$cat], border = "grey70", lwd = 0.3,
+         main = "Paved+gravel road km added 1954 → 1986 (by district)")
+    legend("bottomright",
+           legend = names(pal),
+           fill = pal, bty = "n", cex = 0.85,
+           title = "Road km added")
+
+    dev.off()
+    message("Saved: ", out)
+}
+
+main()

--- a/data/derived/base/networks/data_file_manifest_rails.log
+++ b/data/derived/base/networks/data_file_manifest_rails.log
@@ -1,0 +1,38 @@
+Data file manifest — clean_railroads.R
+Generated: 2026-05-09 13:36:56.36825
+rootdir: /Users/diegogp/Desktop/Diego/Trains/new_repo
+
+============================================================ 
+FILE: rails_by_district.parquet
+============================================================ 
+Rows: 312
+Columns: 11
+Key: geolev2
+
+status1979 taxonomy:
+  1 = active in 1979 and 1986
+  2 = closed during the military dictatorship (1976-1983)
+  3 = closed before 1976 (pre-dictatorship)
+
+Period-total interpretation:
+  tot_rails_1986 = status1979_1
+  tot_rails_1960 = status1979_1 + status1979_2 + status1979_3
+    (assumes status==3 segments existed in 1960,
+     i.e., were closed between 1960 and 1976)
+
+Sanity check — alternate interpretation
+  (if status==3 means closed before 1960):
+  tot_rails_1960_alt mean = 124.6 km
+  tot_rails_1960_alt sum  = 38866 km
+
+Summary of variables:
+  status1979_1              N=312  mean=106.741  sd=117.606  min=0.000  max=778.967  NA=0
+  status1979_2              N=312  mean=17.829  sd=42.096  min=0.000  max=299.905  NA=0
+  status1979_3              N=312  mean=12.545  sd=28.047  min=0.000  max=167.478  NA=0
+  studied_0                 N=312  mean=70.267  sd=82.346  min=0.000  max=420.283  NA=0
+  studied_1                 N=312  mean=66.849  sd=97.856  min=0.000  max=766.294  NA=0
+  tot_rails_1986            N=312  mean=106.741  sd=117.606  min=0.000  max=778.967  NA=0
+  tot_rails_1960            N=312  mean=137.115  sd=139.972  min=0.000  max=778.967  NA=0
+  chg_tot_rails_86_60       N=312  mean=-30.374  sd=56.018  min=-306.367  max=0.000  NA=0
+  studied_larkin            N=312  mean=66.849  sd=97.856  min=0.000  max=766.294  NA=0
+  share_studied_larkin      N=282  mean=0.437  sd=0.375  min=0.000  max=1.000  NA=30

--- a/data/raw/networks/readme.md
+++ b/data/raw/networks/readme.md
@@ -25,16 +25,38 @@ field encoding presence/absence in each period:
 
 Taxonomy verified against old Stata preclean code (lines 616-619).
 
-### Railroads (to be added)
+### Railroads
 
-Rail network shapefiles and Larkin Plan data will be added when the
-`larkin_scores/` directory is located.
+| File | Description | Source |
+|------|-------------|--------|
+| `lp_1979.*` | Larkin Plan rail segments with 1979/1986 status and Larkin-study flags | Digitized + joined by project team |
+
+The `lp_1979` shapefile has 565 MULTILINESTRING segments in WGS 84.
+Already joined to district boundaries (no district JOIN step needed in
+the cleaning code).
+
+| Field | Type | Values | Meaning |
+|-------|------|--------|---------|
+| `id_main`   | int | 1–1101 | Main segment identifier |
+| `status1979`| int | 1, 2, 3 | 1 = active 1979 and 1986; 2 = closed during the military dictatorship (1976–1983); 3 = closed before 1976 |
+| `id_1979`   | int |        | Secondary identifier tying rows to the 1979 network |
+| `studied_co`| int | 0, 1   | 1 = studied in the Larkin Plan (instrument); 0 = not studied |
+| `recom_code`| int | 1, 2, 3| Larkin-plan recommendation category |
+
+Counts: status1979 = {1: 424, 2: 69, 3: 72}. studied_co = {0: 328, 1: 237}.
+recom_code = {1: 355, 2: 160, 3: 50}.
 
 ## Provenance
 
 Road shapefiles digitized manually from historical maps by project team.
 Original maps: Automóvil Club Argentino road maps (1954, 1970, 1986).
 
+Rail shapefile (`lp_1979`) prepared by Ma. Cote Schettino from the
+project's earlier data (originally in `Train/raw_data/` from the old
+repo). The district JOIN and Larkin-plan attribute join were performed
+outside this repo.
+
 ## Citation
 
 TODO: formal citation for the digitized road network data.
+TODO: citation for the Larkin Plan segment data.

--- a/logs/clean_railroads.log
+++ b/logs/clean_railroads.log
@@ -1,0 +1,41 @@
+[config.R] rootdir = /Users/diegogp/Desktop/Diego/Trains/new_repo
+[config.R] Configuration loaded successfully.
+
+========================================================================
+clean_railroads.R  |  Rail network → district-level km
+========================================================================
+
+[rails] Step 1 — Loading district shapefile
+[rails]   Loaded 312 districts
+
+[rails] Step 2 — Loading rail shapefile
+[rails]   Loaded 565 rail segments
+[rails]   status1979 distribution:
+[rails]     status1979=1: 424 segments
+[rails]     status1979=2: 69 segments
+[rails]     status1979=3: 72 segments
+[rails]   studied_co distribution:
+[rails]     studied_co=0: 328 segments
+[rails]     studied_co=1: 237 segments
+
+[rails] Step 3 — Intersecting rails with districts
+[rails]   Clipped segments: 1322
+[rails]   Total rail km: 42780
+
+[rails] Step 4 — Collapsing by district
+[rails]   Districts with rail: 282 / 312
+[rails]   Mean tot_rails_1960: 137.1 km  (alt: 124.6 km)
+[rails]   Mean tot_rails_1986: 106.7 km
+[rails]   Mean chg 86-60: -30.4 km
+[rails]   Mean studied_larkin: 66.8 km
+[rails]   Mean share_studied_larkin: 0.437 (N=282)
+
+[rails] Step 5 — Validating and saving
+[rails]   Key (geolev2) is unique and non-missing: OK
+[rails]   Districts: 312
+[rails]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/base/networks/rails_by_district.parquet (312 rows, 11 cols)
+[rails]   Manifest: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/base/networks/data_file_manifest_rails.log
+========================================================================
+clean_railroads.R  |  Complete.
+========================================================================
+


### PR DESCRIPTION
Closes #23

## What

New script `code/base/networks/clean_railroads.R` that builds district-level rail-km variables and the Larkin-plan instrument from `data/raw/networks/lp_1979.shp`.

## Inputs

- `data/raw/networks/lp_1979.shp` — 565 MULTILINESTRING segments (WGS 84), already joined to districts, placed by Ma. Cote Schettino.
- `data/raw/geo/geo2_ar1970_2010.shp` — IPUMS 312 districts.

## Output

`data/derived/base/networks/rails_by_district.parquet` (312 rows × 11 cols, key = `geolev2` character).

| Variable | Definition |
|---|---|
| `status1979_1/2/3` | Rail km by status code: 1 = active 1979/1986; 2 = closed during dictatorship 1976–1983; 3 = closed before 1976 |
| `studied_0/1` | Rail km by Larkin-study flag (1 = studied) |
| `tot_rails_1960` | `status1979_1 + status1979_2 + status1979_3` |
| `tot_rails_1986` | `status1979_1` |
| `chg_tot_rails_86_60` | `tot_rails_1986 − tot_rails_1960` (always ≤ 0) |
| `studied_larkin` | `studied_1` — km of Larkin-studied rail |
| `share_studied_larkin` | `studied_1 / (studied_0 + studied_1)`, NA if district has no rail |

## Diagnostics

- 565 segments → 1,322 clipped pieces after intersection with districts.
- Total rail km = 42,780 (plausible for Argentina's peak ~47,000 km).
- 282 of 312 districts have rail; 30 have none (mostly Patagonia; 0 km rail is correct for TdF).
- Mean `tot_rails_1960` = 137 km, `tot_rails_1986` = 107 km → 22% average drop.
- Mean `share_studied_larkin` = 0.44 across the 282 rail-bearing districts.
- CF (32002001): ~88 km rail, 4% Larkin-studied (Larkin focused on rural lines, as expected).

## Assumption flagged for Diego

The primary interpretation assumes `status1979 == 3` ("closed before 1976") means closed *between 1960 and 1976*, so those segments existed in 1960 and contribute to `tot_rails_1960`. The manifest (`data_file_manifest_rails.log`) prints an alternate interpretation (`status == 3` closed *before 1960*, so excluded from `tot_rails_1960`). In practice the two differ by a small amount (mean 137.1 vs 124.6 km) because status 3 is only 72 of 565 segments. The change variable `chg_tot_rails_86_60` is identical under both interpretations (since status 3 cancels on both sides).

If the alt interpretation is correct, the fix is one line: redefine `tot_rails_1960` in `collapse_and_compute()`.

## Verified

- Script runs cleanly, ~10 s.
- Key (`geolev2`) is unique, non-missing, character.
- Manifest written with per-variable N, mean, SD, min, max, NA count.
- Raw-data readme updated with field dictionary and provenance.