### PR TITLE
Build estimation panel (wide, 312 districts)

### DIFF
--- a/code/pipeline/05_build_panel.R
+++ b/code/pipeline/05_build_panel.R
@@ -1,0 +1,386 @@
+# ===========================================================================
+# 05_build_panel.R
+#
+# PURPOSE: Merge all base-cleaned sources into a single wide district-level
+#          estimation panel (one row per geolev2, 312 rows). Adds log-change
+#          variables for the main change-in-change specification.
+#
+# READS:
+#   data/derived/base/geo/geo_controls.parquet                (312)
+#   data/derived/base/ipums/ipums_panel.parquet               (312 × 5 years)
+#   data/derived/base/census_1947/census_1947_ipums.parquet   (240)
+#   data/derived/base/census_1960/census_1960_ipums.parquet   (309)
+#   data/derived/base/agricultural/agr_census.parquet         (306 + 300)
+#   data/derived/base/industrial/ind_census.parquet           (310 + 311)
+#   data/derived/base/networks/roads_by_district.parquet      (309)
+#   data/derived/base/networks/rails_by_district.parquet      (312)
+#   data/derived/base/networks/hypo_networks_by_district.parquet (312)
+#
+# PRODUCES:
+#   data/derived/05_panel/departments_wide_panel.parquet
+#   data/derived/05_panel/data_file_manifest.log
+#
+# DESIGN (see issue #25):
+#   - Wide format, 312 rows, key = geolev2 (character).
+#   - All 312 districts (incl. CF and TdF) carried through. Let estimation
+#     filter.
+#   - Change variable year pairs held in a config list so they're easy to
+#     flex later (change period, add/remove a year).
+#   - Missing data encoded as NA so regressions auto-drop.
+#   - Genuine observed zeros (e.g., TdF rail km) are kept as 0.
+#   - Market-access columns are OUT of scope here; follow-up PR adds them.
+#
+# NOTES:
+#   - IPUMS urbpop is structurally missing for 1970 and 2010 in the source
+#     microdata. Those years are recoded from 0 to NA at the pipe step.
+#   - Change vars use log(x+1) for counts that can be zero (road km, rail
+#     km) but log(x) for strictly positive outcomes (population).
+# ===========================================================================
+
+main <- function() {
+
+    source(file.path(here::here(), "code", "config.R"), echo = FALSE)
+    source(file.path(dir_code, "base", "utils.R"), echo = FALSE)
+
+    message("\n", strrep("=", 72))
+    message("05_build_panel.R  |  merge base sources → wide panel")
+    message(strrep("=", 72))
+
+    # ---- 1. Geo controls as the base spine --------------------------------
+    panel <- load_geo()
+
+    # ---- 2. IPUMS (multi-year) wide-merged --------------------------------
+    ipums_w <- load_ipums_wide()
+    panel   <- merge_left(panel, ipums_w, "IPUMS wide")
+
+    # ---- 3. 1947 and 1960 census ------------------------------------------
+    panel <- merge_left(panel, load_census1947(), "census_1947")
+    panel <- merge_left(panel, load_census1960(), "census_1960")
+
+    # ---- 4. Agricultural and industrial -----------------------------------
+    panel <- merge_left(panel, load_agr(), "agricultural census")
+    panel <- merge_left(panel, load_ind(), "industrial census")
+
+    # ---- 5. Networks (rails, roads, hypo) ---------------------------------
+    panel <- merge_left(panel, load_rails(), "rails")
+    panel <- merge_left(panel, load_roads(), "roads")
+    panel <- merge_left(panel, load_hypo(),  "hypo networks")
+
+    # ---- 6. Change variables ----------------------------------------------
+    panel <- add_change_vars(panel)
+
+    # ---- 7. Save + manifest -----------------------------------------------
+    save_panel(panel)
+
+    message(strrep("=", 72))
+    message("05_build_panel.R  |  Complete.")
+    message(strrep("=", 72), "\n")
+}
+
+# ---------------------------------------------------------------------------
+# Year-pair config for change variables. Edit to flex.
+# ---------------------------------------------------------------------------
+change_pairs <- list(
+    pop           = list(pre = 1960, post = 1991),
+    urbpop        = list(pre = 1960, post = 1991),
+    placebo_pop   = list(pre = 1947, post = 1960),
+    nestab        = list(pre = 1954, post = 1985),
+    massal        = list(pre = 1954, post = 1985),
+    valprod       = list(pre = 1954, post = 1985),
+    nexp          = list(pre = 1960, post = 1988),
+    areatot_ha    = list(pre = 1960, post = 1988)
+)
+# NOTE: Industrial variables available in both 1954 and 1985: nestab,
+# massal, valprod. 1954 has nemp (workers) and nobr (blue-collar); 1985
+# has npers (all persons, different definition) — not directly comparable
+# across years so no change variable is built for either.
+# `rur` is not available in IPUMS 1991 (only in census_1960_ipums); skip.
+
+# ---------------------------------------------------------------------------
+# Helper: left merge with diagnostic log
+# ---------------------------------------------------------------------------
+merge_left <- function(x, y, label) {
+    y <- ensure_geolev2_char(y)
+    n_x_before <- nrow(x)
+    n_y        <- nrow(y)
+    n_match    <- sum(x$geolev2 %in% y$geolev2)
+    n_unmatch  <- n_x_before - n_match
+
+    out <- merge(x, y, by = "geolev2", all.x = TRUE)
+
+    message(sprintf(
+        "[panel] merge %-25s  x=%d  y=%d  matched=%d  unmatched_in_panel=%d",
+        label, n_x_before, n_y, n_match, n_unmatch
+    ))
+    stopifnot(nrow(out) == n_x_before)      # No duplication, no drops
+    stopifnot(!any(duplicated(out$geolev2)))
+    out
+}
+
+# ---------------------------------------------------------------------------
+# Load: geo controls (the spine — all 312 districts)
+# ---------------------------------------------------------------------------
+load_geo <- function() {
+    d <- arrow::read_parquet(
+        file.path(dir_derived_geo, "geo_controls.parquet")
+    )
+    d <- ensure_geolev2_char(d)
+    message(sprintf("[panel] geo spine: %d districts", nrow(d)))
+    d
+}
+
+# ---------------------------------------------------------------------------
+# Load: IPUMS panel, recode 0-urbpop for missing years, pivot to wide
+# ---------------------------------------------------------------------------
+load_ipums_wide <- function() {
+    d <- arrow::read_parquet(
+        file.path(dir_derived_ipums, "ipums_panel.parquet")
+    )
+    # Cast year from haven_labelled if needed
+    if (inherits(d$year, "haven_labelled")) {
+        d$year <- haven::zap_labels(d$year)
+    }
+    d$year <- as.integer(d$year)
+    d <- ensure_geolev2_char(d)
+
+    # IPUMS 1970 and 2010 have no urban/rural variable; recode to NA
+    d$urbpop[d$year %in% c(1970, 2010)] <- NA
+
+    # Keep only the columns we export, for clarity
+    keep_vars <- c(
+        "pop", "urbpop",
+        "college", "secondary", "mig5",
+        "empstat_1", "empstat_2", "empstat_3"
+    )
+    keep_vars <- intersect(keep_vars, names(d))
+    d <- d[, c("geolev2", "year", keep_vars)]
+
+    # Long → wide via reshape
+    w <- stats::reshape(
+        as.data.frame(d),
+        idvar     = "geolev2",
+        timevar   = "year",
+        direction = "wide",
+        sep       = "_"
+    )
+    # reshape names things "pop.1970"; normalize to "pop_1970"
+    names(w) <- gsub("\\.(\\d+)$", "_\\1", names(w))
+    message(sprintf("[panel] IPUMS wide: %d rows, %d cols (years: %s)",
+                    nrow(w), ncol(w),
+                    paste(sort(unique(d$year)), collapse = ", ")))
+    w
+}
+
+# ---------------------------------------------------------------------------
+# Load: 1947 census (240 districts, 1947 only)
+# ---------------------------------------------------------------------------
+load_census1947 <- function() {
+    d <- arrow::read_parquet(
+        file.path(dir_derived_census1947, "census_1947_ipums.parquet")
+    )
+    d <- ensure_geolev2_char(d)
+    # Keep only vars we want at year 1947; add _1947 suffix
+    keep <- c("pop", "urbpop", "pop_imputed", "urbpop_imputed", "note")
+    keep <- intersect(keep, names(d))
+    d <- d[, c("geolev2", keep)]
+    names(d)[names(d) != "geolev2"] <- paste0(
+        names(d)[names(d) != "geolev2"], "_1947"
+    )
+    d
+}
+
+# ---------------------------------------------------------------------------
+# Load: 1960 census (309 districts, 1960 only)
+# ---------------------------------------------------------------------------
+load_census1960 <- function() {
+    d <- arrow::read_parquet(
+        file.path(dir_derived_census1960, "census_1960_ipums.parquet")
+    )
+    d <- ensure_geolev2_char(d)
+    keep <- intersect(c("pop", "urbpop", "rur"), names(d))
+    d <- d[, c("geolev2", keep)]
+    names(d)[names(d) != "geolev2"] <- paste0(
+        names(d)[names(d) != "geolev2"], "_1960"
+    )
+    d
+}
+
+# ---------------------------------------------------------------------------
+# Load: agricultural census, pivot to wide
+# ---------------------------------------------------------------------------
+load_agr <- function() {
+    d <- arrow::read_parquet(
+        file.path(dir_derived_agr, "agr_census.parquet")
+    )
+    d <- ensure_geolev2_char(d)
+    if (inherits(d$year, "haven_labelled")) {
+        d$year <- haven::zap_labels(d$year)
+    }
+    d$year <- as.integer(d$year)
+    w <- stats::reshape(
+        as.data.frame(d),
+        idvar = "geolev2", timevar = "year", direction = "wide", sep = "_"
+    )
+    names(w) <- gsub("\\.(\\d+)$", "_\\1", names(w))
+    w
+}
+
+# ---------------------------------------------------------------------------
+# Load: industrial census, pivot to wide
+# ---------------------------------------------------------------------------
+load_ind <- function() {
+    d <- arrow::read_parquet(
+        file.path(dir_derived_ind, "ind_census.parquet")
+    )
+    d <- ensure_geolev2_char(d)
+    if (inherits(d$year, "haven_labelled")) {
+        d$year <- haven::zap_labels(d$year)
+    }
+    d$year <- as.integer(d$year)
+    w <- stats::reshape(
+        as.data.frame(d),
+        idvar = "geolev2", timevar = "year", direction = "wide", sep = "_"
+    )
+    names(w) <- gsub("\\.(\\d+)$", "_\\1", names(w))
+    w
+}
+
+# ---------------------------------------------------------------------------
+# Load: rails (already wide, all 312 districts, zeros are real)
+# ---------------------------------------------------------------------------
+load_rails <- function() {
+    arrow::read_parquet(
+        file.path(dir_derived_networks, "rails_by_district.parquet")
+    )
+}
+
+# ---------------------------------------------------------------------------
+# Load: roads (already wide, 309 districts; 3 are missing)
+# ---------------------------------------------------------------------------
+load_roads <- function() {
+    arrow::read_parquet(
+        file.path(dir_derived_networks, "roads_by_district.parquet")
+    )
+}
+
+# ---------------------------------------------------------------------------
+# Load: hypothetical networks (312, zeros are real)
+# ---------------------------------------------------------------------------
+load_hypo <- function() {
+    arrow::read_parquet(
+        file.path(dir_derived_networks, "hypo_networks_by_district.parquet")
+    )
+}
+
+# ---------------------------------------------------------------------------
+# Change variables: log changes from change_pairs config
+#
+# For a variable `x` with pre-year yy and post-year zz, creates
+#   chg_log_<x>_<zz>_<yy> = log(x_<zz>) - log(x_<yy>)
+# with NA where either endpoint is NA or non-positive.
+# ---------------------------------------------------------------------------
+add_change_vars <- function(panel) {
+    message("\n[panel] Adding log-change variables")
+
+    for (vnm in names(change_pairs)) {
+        cfg  <- change_pairs[[vnm]]
+        pre  <- cfg$pre
+        post <- cfg$post
+        # The actual variable name in the data is often different from
+        # the change-pair key (e.g., placebo_pop uses pop_1947/pop_1960)
+        base <- if (vnm == "placebo_pop") "pop" else vnm
+        v_pre  <- sprintf("%s_%d", base, pre)
+        v_post <- sprintf("%s_%d", base, post)
+        if (!all(c(v_pre, v_post) %in% names(panel))) {
+            message(sprintf("  skip %-15s (missing %s or %s)",
+                            vnm, v_pre, v_post))
+            next
+        }
+        out_name <- sprintf("chg_log_%s_%02d_%02d",
+                            vnm, post %% 100, pre %% 100)
+        x_pre  <- as.numeric(panel[[v_pre]])
+        x_post <- as.numeric(panel[[v_post]])
+        # log-change only defined where both > 0
+        valid <- !is.na(x_pre) & !is.na(x_post) & x_pre > 0 & x_post > 0
+        out <- rep(NA_real_, length(x_pre))
+        out[valid] <- log(x_post[valid]) - log(x_pre[valid])
+        panel[[out_name]] <- out
+        message(sprintf("  %-25s N=%d  mean=%.3f  sd=%.3f",
+                        out_name, sum(valid),
+                        mean(out, na.rm = TRUE),
+                        stats::sd(out, na.rm = TRUE)))
+    }
+
+    panel
+}
+
+# ---------------------------------------------------------------------------
+# Save panel and write manifest
+# ---------------------------------------------------------------------------
+save_panel <- function(panel) {
+    message("\n[panel] Saving")
+
+    out_dir <- dir_derived_panel
+    if (!dir.exists(out_dir)) dir.create(out_dir, recursive = TRUE)
+
+    panel$geolev2 <- as.character(panel$geolev2)
+    panel <- panel[order(panel$geolev2), ]
+    stopifnot(!any(duplicated(panel$geolev2)))
+    stopifnot(!any(is.na(panel$geolev2)))
+    message(sprintf("[panel]   Key unique, non-missing. Districts: %d",
+                    nrow(panel)))
+
+    # Strip haven attributes before writing (arrow complains on labelled)
+    for (nm in names(panel)) {
+        if (inherits(panel[[nm]], "haven_labelled")) {
+            panel[[nm]] <- haven::zap_labels(panel[[nm]])
+        }
+    }
+
+    out_path <- file.path(out_dir, "departments_wide_panel.parquet")
+    arrow::write_parquet(panel, out_path)
+    message(sprintf("[panel]   Saved: %s (%d rows, %d cols)",
+                    out_path, nrow(panel), ncol(panel)))
+
+    # Manifest
+    log_path <- file.path(out_dir, "data_file_manifest.log")
+    sink(log_path)
+    on.exit(sink(), add = TRUE)
+    cat("Data file manifest — 05_build_panel.R\n")
+    cat(sprintf("Generated: %s\n", Sys.time()))
+    cat(sprintf("rootdir: %s\n\n", rootdir))
+    cat(strrep("=", 60), "\n")
+    cat("FILE: departments_wide_panel.parquet\n")
+    cat(strrep("=", 60), "\n")
+    cat(sprintf("Rows: %d\nColumns: %d\nKey: geolev2\n\n",
+                nrow(panel), ncol(panel)))
+
+    cat("Summary of every variable:\n")
+    for (v in names(panel)) {
+        if (v == "geolev2") next
+        vals <- panel[[v]]
+        if (!is.numeric(vals)) {
+            cat(sprintf("  %-30s (class=%s, n_unique=%d, NA=%d)\n",
+                        v, class(vals)[1],
+                        length(unique(vals)), sum(is.na(vals))))
+            next
+        }
+        n_na <- sum(is.na(vals))
+        n_ok <- sum(!is.na(vals))
+        if (n_ok == 0) {
+            cat(sprintf("  %-30s  ALL NA\n", v))
+            next
+        }
+        cat(sprintf(
+            "  %-30s N=%d  mean=%.3g  sd=%.3g  min=%.3g  max=%.3g  NA=%d\n",
+            v, n_ok,
+            mean(vals, na.rm = TRUE), stats::sd(vals, na.rm = TRUE),
+            min(vals, na.rm = TRUE), max(vals, na.rm = TRUE),
+            n_na
+        ))
+    }
+
+    message(sprintf("[panel]   Manifest: %s", log_path))
+}
+
+main()

--- a/data/derived/05_panel/data_file_manifest.log
+++ b/data/derived/05_panel/data_file_manifest.log
@@ -1,0 +1,129 @@
+Data file manifest — 05_build_panel.R
+Generated: 2026-05-09 17:43:42.373792
+rootdir: /Users/diegogp/Desktop/Diego/Trains/new_repo
+
+============================================================ 
+FILE: departments_wide_panel.parquet
+============================================================ 
+Rows: 312
+Columns: 118
+Key: geolev2
+
+Summary of every variable:
+  area_km2                       N=312  mean=8.14e+03  sd=1.18e+04  min=26.8  max=8.5e+04  NA=0
+  elev_mean                      N=312  mean=418  sd=689  min=4.01  max=4e+03  NA=0
+  rugged_mea                     N=312  mean=5.82e+04  sd=9.29e+04  min=3.63e+03  max=5.87e+05  NA=0
+  wheat                          N=312  mean=2.72e+03  sd=1.63e+03  min=0.142  max=7.32e+03  NA=0
+  preCal                         N=312  mean=3.38e+03  sd=1.79e+03  min=0  max=5.19e+03  NA=0
+  postCal                        N=312  mean=2.04e+03  sd=1.01e+03  min=0  max=3.11e+03  NA=0
+  dist_to_BA                     N=312  mean=669  sd=436  min=5.11  max=2.32e+03  NA=0
+  elev_mean_std                  N=312  mean=1.67e-16  sd=1  min=-0.602  max=5.2  NA=0
+  rugged_mea_std                 N=312  mean=-3.61e-17  sd=1  min=-0.587  max=5.7  NA=0
+  wheat_std                      N=312  mean=3.27e-17  sd=1  min=-1.67  max=2.83  NA=0
+  preCal_std                     N=312  mean=-2.78e-16  sd=1  min=-1.89  max=1.01  NA=0
+  postCal_std                    N=312  mean=-1.82e-16  sd=1  min=-2.02  max=1.05  NA=0
+  dist_to_BA_std                 N=312  mean=-9.39e-17  sd=1  min=-1.52  max=3.79  NA=0
+  pop_1970                       N=312  mean=7.48e+04  sd=1.91e+05  min=4.75e+03  max=2.91e+06  NA=0
+  urbpop_1970                     ALL NA
+  college_1970                   N=312  mean=0.0067  sd=0.00733  min=0  max=0.0497  NA=0
+  secondary_1970                 N=312  mean=0.0476  sd=0.0308  min=0  max=0.194  NA=0
+  mig5_1970                      N=312  mean=0.0655  sd=0.0564  min=0  max=0.432  NA=0
+  empstat_1_1970                 N=312  mean=0.487  sd=0.0477  min=0.36  max=0.75  NA=0
+  empstat_2_1970                 N=312  mean=0.00961  sd=0.00642  min=0  max=0.0438  NA=0
+  empstat_3_1970                 N=312  mean=0.504  sd=0.0462  min=0.237  max=0.62  NA=0
+  pop_1980                       N=312  mean=1.03e+05  sd=2.63e+05  min=8.49e+03  max=3.98e+06  NA=0
+  urbpop_1980                    N=312  mean=7.29e+04  sd=2e+05  min=0  max=2.79e+06  NA=0
+  college_1980                   N=312  mean=0.0117  sd=0.0116  min=0  max=0.102  NA=0
+  secondary_1980                 N=312  mean=0.0843  sd=0.0454  min=0.0108  max=0.268  NA=0
+  mig5_1980                      N=310  mean=0.113  sd=0.136  min=0.0113  max=0.925  NA=2
+  empstat_1_1980                 N=312  mean=0.495  sd=0.0807  min=0.3  max=0.9  NA=0
+  empstat_2_1980                 N=312  mean=0.00687  sd=0.00338  min=0.000497  max=0.0258  NA=0
+  empstat_3_1980                 N=312  mean=0.498  sd=0.0806  min=0.0914  max=0.692  NA=0
+  pop_1991                       N=312  mean=1.15e+05  sd=2.64e+05  min=1.48e+04  max=3.77e+06  NA=0
+  urbpop_1991                    N=312  mean=8.97e+04  sd=2.16e+05  min=0  max=2.84e+06  NA=0
+  college_1991                   N=312  mean=0.0148  sd=0.0131  min=0.000388  max=0.0977  NA=0
+  secondary_1991                 N=312  mean=0.125  sd=0.0573  min=0.0258  max=0.375  NA=0
+  mig5_1991                      N=312  mean=0.182  sd=0.103  min=0.0266  max=0.672  NA=0
+  empstat_1_1991                 N=312  mean=0.548  sd=0.0708  min=0.179  max=0.872  NA=0
+  empstat_2_1991                 N=312  mean=0.0252  sd=0.0114  min=0.00341  max=0.057  NA=0
+  empstat_3_1991                 N=312  mean=0.427  sd=0.0679  min=0.123  max=0.814  NA=0
+  pop_2001                       N=312  mean=1.16e+05  sd=2.25e+05  min=1.50e+04  max=2.77e+06  NA=0
+  urbpop_2001                    N=312  mean=1.04e+05  sd=2.25e+05  min=2.14e+03  max=2.77e+06  NA=0
+  college_2001                   N=312  mean=0.0236  sd=0.0199  min=0.000469  max=0.155  NA=0
+  secondary_2001                 N=312  mean=0.188  sd=0.0765  min=0.0357  max=0.513  NA=0
+  mig5_2001                      N=312  mean=0.039  sd=0.0268  min=0.00918  max=0.234  NA=0
+  empstat_1_2001                 N=312  mean=0.413  sd=0.0596  min=0.195  max=0.586  NA=0
+  empstat_2_2001                 N=312  mean=0.14  sd=0.0378  min=0.0466  max=0.259  NA=0
+  empstat_3_2001                 N=312  mean=0.447  sd=0.0515  min=0.304  max=0.671  NA=0
+  pop_2010                       N=312  mean=1.27e+05  sd=2.43e+05  min=2.01e+04  max=2.82e+06  NA=0
+  urbpop_2010                     ALL NA
+  college_2010                   N=312  mean=0.0302  sd=0.0239  min=0.000896  max=0.183  NA=0
+  secondary_2010                 N=312  mean=0.217  sd=0.0688  min=0.0587  max=0.503  NA=0
+  mig5_2010                       ALL NA
+  empstat_1_2010                 N=312  mean=0.579  sd=0.0666  min=0.298  max=0.747  NA=0
+  empstat_2_2010                 N=312  mean=0.0329  sd=0.0102  min=0.00637  max=0.0599  NA=0
+  empstat_3_2010                 N=312  mean=0.388  sd=0.0696  min=0.218  max=0.66  NA=0
+  pop_1947                       N=235  mean=4.71e+04  sd=5.79e+04  min=4.40e+03  max=5.3e+05  NA=77
+  urbpop_1947                    N=235  mean=2.86e+04  sd=5.4e+04  min=2e+03  max=4.87e+05  NA=77
+  pop_imputed_1947               N=240  mean=4.67e+04  sd=5.74e+04  min=4.40e+03  max=5.3e+05  NA=72
+  urbpop_imputed_1947            N=240  mean=2.82e+04  sd=5.36e+04  min=2e+03  max=4.87e+05  NA=72
+  note_1947                      N=240  mean=0.0208  sd=0.143  min=0  max=1  NA=72
+  pop_1960                       N=309  mean=4.39e+04  sd=7.85e+04  min=1.07e+03  max=6.63e+05  NA=3
+  urbpop_1960                    N=309  mean=3.82e+04  sd=7.86e+04  min=0  max=6.5e+05  NA=3
+  rur_1960                       N=309  mean=5.67e+03  sd=5.36e+03  min=0  max=3.03e+04  NA=3
+  nexp_1960                      N=306  mean=1.54e+03  sd=1.33e+03  min=3  max=1.01e+04  NA=6
+  areatot_ha_1960                N=306  mean=5.69e+05  sd=1.15e+06  min=3  max=1.3e+07  NA=6
+  nexp_1988                      N=300  mean=1.23e+03  sd=1.12e+03  min=5  max=7.91e+03  NA=12
+  areatot_ha_1988                N=300  mean=5.76e+05  sd=1.16e+06  min=5.6  max=1.39e+07  NA=12
+  nestab_1954                    N=310  mean=356  sd=594  min=3  max=6.16e+03  NA=2
+  nemp_1954                      N=310  mean=318  sd=909  min=1  max=1.02e+04  NA=2
+  nobr_1954                      N=310  mean=2.28e+03  sd=5.46e+03  min=8  max=5.3e+04  NA=2
+  npers_1954                      ALL NA
+  massal_1954                    N=310  mean=2.84e+04  sd=7.91e+04  min=113  max=8.86e+05  NA=2
+  valprod_1954                   N=310  mean=1.53e+05  sd=4.47e+05  min=208  max=5.62e+06  NA=2
+  valprod1_1954                  N=310  mean=1.53e+05  sd=4.47e+05  min=208  max=5.62e+06  NA=2
+  valprod2_1954                   ALL NA
+  nestab_1985                    N=311  mean=300  sd=566  min=3  max=4.96e+03  NA=1
+  nemp_1985                       ALL NA
+  nobr_1985                       ALL NA
+  npers_1985                     N=311  mean=3.12e+03  sd=7e+03  min=0  max=5.18e+04  NA=1
+  massal_1985                    N=311  mean=1.38e+06  sd=3.33e+06  min=0  max=2.47e+07  NA=1
+  valprod_1985                   N=311  mean=1.12e+07  sd=2.89e+07  min=5.72e+03  max=3.06e+08  NA=1
+  valprod1_1985                  N=311  mean=1.12e+07  sd=2.89e+07  min=5.72e+03  max=3.06e+08  NA=1
+  valprod2_1985                  N=311  mean=5.41e+05  sd=1.41e+06  min=0  max=1.06e+07  NA=1
+  status1979_1                   N=312  mean=107  sd=118  min=0  max=779  NA=0
+  status1979_2                   N=312  mean=17.8  sd=42.1  min=0  max=300  NA=0
+  status1979_3                   N=312  mean=12.5  sd=28  min=0  max=167  NA=0
+  studied_0                      N=312  mean=70.3  sd=82.3  min=0  max=420  NA=0
+  studied_1                      N=312  mean=66.8  sd=97.9  min=0  max=766  NA=0
+  tot_rails_1986                 N=312  mean=107  sd=118  min=0  max=779  NA=0
+  tot_rails_1960                 N=312  mean=137  sd=140  min=0  max=779  NA=0
+  chg_tot_rails_86_60            N=312  mean=-30.4  sd=56  min=-306  max=0  NA=0
+  studied_larkin                 N=312  mean=66.8  sd=97.9  min=0  max=766  NA=0
+  share_studied_larkin           N=282  mean=0.437  sd=0.375  min=0  max=1  NA=30
+  roadsall_type_1                N=309  mean=83.5  sd=139  min=0  max=1.08e+03  NA=3
+  roadsall_type_2                N=309  mean=33.7  sd=82.6  min=0  max=921  NA=3
+  roadsall_type_3                N=309  mean=136  sd=194  min=0  max=1.88e+03  NA=3
+  roadsall_type_4                N=309  mean=5.84  sd=17.4  min=0  max=180  NA=3
+  roadsall_type_5                N=309  mean=5.55  sd=27  min=0  max=304  NA=3
+  roadsall_type_6                N=309  mean=7.99  sd=21.7  min=0  max=229  NA=3
+  roadsall_type_7                N=309  mean=3.2  sd=11.5  min=0  max=123  NA=3
+  pav_and_grav_1954              N=309  mean=89  sd=149  min=0  max=1.13e+03  NA=3
+  pav_and_grav_1970              N=309  mean=123  sd=198  min=0  max=1.73e+03  NA=3
+  pav_and_grav_1986              N=309  mean=258  sd=351  min=3.71  max=3.61e+03  NA=3
+  chg_pav_and_grav_86_54         N=309  mean=169  sd=248  min=0  max=2.51e+03  NA=3
+  chg_pav_and_grav_70_54         N=309  mean=33.7  sd=82.6  min=0  max=921  NA=3
+  chg_pav_and_grav_86_70         N=309  mean=136  sd=194  min=0  max=1.88e+03  NA=3
+  connected_pav_grav_86_54       N=309  mean=0.265  sd=0.442  min=0  max=1  NA=3
+  hypo_LCP_kms                   N=312  mean=5.18e+03  sd=8.41e+03  min=0  max=7.94e+04  NA=0
+  hypo_LCP_MST_kms               N=312  mean=36.8  sd=62.6  min=0  max=301  NA=0
+  hypo_EUC_kms                   N=312  mean=3.99e+03  sd=5.78e+03  min=0  max=5.7e+04  NA=0
+  hypo_EUC_MST_kms               N=312  mean=22.5  sd=44.6  min=0  max=373  NA=0
+  chg_log_pop_91_60              N=309  mean=1.01  sd=0.525  min=0.0508  max=3.1  NA=3
+  chg_log_urbpop_91_60           N=284  mean=0.858  sd=0.504  min=-0.0717  max=2.99  NA=28
+  chg_log_placebo_pop_60_47      N=235  mean=-0.0908  sd=0.574  min=-2.37  max=1.69  NA=77
+  chg_log_nestab_85_54           N=310  mean=-0.216  sd=0.675  min=-2.43  max=4.24  NA=2
+  chg_log_massal_85_54           N=309  mean=3.53  sd=1.38  min=-1.7  max=7.21  NA=3
+  chg_log_valprod_85_54          N=310  mean=3.89  sd=1.37  min=-1.97  max=9.75  NA=2
+  chg_log_nexp_88_60             N=297  mean=-0.254  sd=0.497  min=-3.35  max=2.29  NA=15
+  chg_log_areatot_ha_88_60       N=297  mean=0.0766  sd=0.656  min=-3.22  max=3.76  NA=15

--- a/logs/05_build_panel.log
+++ b/logs/05_build_panel.log
@@ -1,0 +1,35 @@
+[config.R] rootdir = /Users/diegogp/Desktop/Diego/Trains/new_repo
+[config.R] Configuration loaded successfully.
+
+========================================================================
+05_build_panel.R  |  merge base sources → wide panel
+========================================================================
+[panel] geo spine: 312 districts
+[panel] IPUMS wide: 312 rows, 41 cols (years: 1970, 1980, 1991, 2001, 2010)
+[panel] merge IPUMS wide                 x=312  y=312  matched=312  unmatched_in_panel=0
+[panel] merge census_1947                x=312  y=240  matched=240  unmatched_in_panel=72
+[panel] merge census_1960                x=312  y=309  matched=309  unmatched_in_panel=3
+[panel] merge agricultural census        x=312  y=309  matched=309  unmatched_in_panel=3
+[panel] merge industrial census          x=312  y=311  matched=311  unmatched_in_panel=1
+[panel] merge rails                      x=312  y=312  matched=312  unmatched_in_panel=0
+[panel] merge roads                      x=312  y=309  matched=309  unmatched_in_panel=3
+[panel] merge hypo networks              x=312  y=312  matched=312  unmatched_in_panel=0
+
+[panel] Adding log-change variables
+  chg_log_pop_91_60         N=309  mean=1.015  sd=0.525
+  chg_log_urbpop_91_60      N=284  mean=0.858  sd=0.504
+  chg_log_placebo_pop_60_47 N=235  mean=-0.091  sd=0.574
+  chg_log_nestab_85_54      N=310  mean=-0.216  sd=0.675
+  chg_log_massal_85_54      N=309  mean=3.529  sd=1.380
+  chg_log_valprod_85_54     N=310  mean=3.887  sd=1.372
+  chg_log_nexp_88_60        N=297  mean=-0.254  sd=0.497
+  chg_log_areatot_ha_88_60  N=297  mean=0.077  sd=0.656
+
+[panel] Saving
+[panel]   Key unique, non-missing. Districts: 312
+[panel]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/05_panel/departments_wide_panel.parquet (312 rows, 118 cols)
+[panel]   Manifest: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/05_panel/data_file_manifest.log
+========================================================================
+05_build_panel.R  |  Complete.
+========================================================================
+


### PR DESCRIPTION
Closes #25

## What

Adds `code/pipeline/05_build_panel.R`, which merges all cleaned base outputs into a single wide district-level estimation panel. Output: `data/derived/05_panel/departments_wide_panel.parquet` (312 rows × 118 cols, key = `geolev2` character).

## Design decisions (from issue #25)

- Wide format, one row per district.
- All 312 districts incl. CF and TdF carried through; downstream estimation scripts filter as needed.
- Missing data encoded as NA so regressions auto-drop.
- Genuine observed zeros (e.g., TdF rail km = 0) kept as 0.
- `urbpop_1970` and `urbpop_2010` recoded from 0 to NA — IPUMS microdata has no urban/rural coding for those years.
- Year pairs for change variables kept in a `change_pairs` config list for easy flexing.
- Market access columns deliberately out of scope; follow-up PR adds them.

## Inputs merged

| Source | Rows in | Matched | Unmatched |
|---|---|---|---|
| geo_controls (spine) | 312 | — | — |
| ipums_panel (wide) | 312 | 312 | 0 |
| census_1947 | 240 | 240 | 72 |
| census_1960 | 309 | 309 | 3 |
| agr_census | 309 | 309 | 3 |
| ind_census | 311 | 311 | 1 |
| rails_by_district | 312 | 312 | 0 |
| roads_by_district | 309 | 309 | 3 |
| hypo_networks | 312 | 312 | 0 |

Unmatched rows become NA for that source's variables.

## Change variables (log post − log pre)

| Variable | N | Mean | SD |
|---|---:|---:|---:|
| `chg_log_pop_91_60` | 309 | +1.02 | 0.53 |
| `chg_log_urbpop_91_60` | 284 | +0.86 | 0.50 |
| `chg_log_placebo_pop_60_47` | 235 | −0.09 | 0.57 |
| `chg_log_nestab_85_54` | 310 | −0.22 | 0.68 |
| `chg_log_massal_85_54` | 309 | +3.53 | 1.38 |
| `chg_log_valprod_85_54` | 310 | +3.89 | 1.37 |
| `chg_log_nexp_88_60` | 297 | −0.25 | 0.50 |
| `chg_log_areatot_ha_88_60` | 297 | +0.08 | 0.66 |

Sanity: Argentina 1960→1991 population roughly doubled nationally, with rural-to-urban migration pushing some districts up and others down. Urban grew faster than total. Industrial establishments fell on average (consolidation + deindustrialization). `massal`/`valprod` changes are in nominal pesos — hyperinflation 1954–1985 drives the ~4x log change; deflator needed before using these for anything real.

## What's not here

- **Market access** (`MA_*`, `logMA_*`, `chg_logMA_*`): out of scope, tracked separately. The follow-up PR either (a) ports the old-repo `MA_centroids.dta` as a provisional column, or (b) rebuilds tau and MA from scratch in the new repo. Decision pending.
- **Industrial cross-year employment**: `nemp` (1954) and `npers` (1985) use different worker-count definitions so no change variable was built. If you want one, tell me which convention to reconcile under.
- `rur` (rural population) change variable — `rur_1991` isn't in IPUMS microdata (only in 1960 census). Skipped.

## Verified

- Script runs cleanly, ~3 s.
- Key unique, non-missing, character, 312 rows.
- Manifest written with N, mean, SD, min, max, NA count per variable.
- Every merge step logs input/output row counts.