### PR TITLE
Strip dead Old data/Train references from base cleaning headers

### DIFF
--- a/code/base/agricultural/clean_agricultural.R
+++ b/code/base/agricultural/clean_agricultural.R
@@ -14,12 +14,6 @@
 #       Key: geolev2 + year. Variables: nexp, areatot_ha.
 #   data/derived/base/agricultural/data_file_manifest.log
 #
-# REFERENCE:
-#   Old data/Train/base/agr_census_1960/code/clean_agro1960.do
-#   Old data/Train/base/agr_census_1988/code/clean_agro1988.do
-#   Old data/Train/derived/agr_census_1960/code/merge_ag1960_to_IPUMS.do
-#   Old data/Train/derived/agr_census_1988/code/merge_ag1988_to_IPUMS.do
-#
 # NOTES:
 #   - 1960 data is wide format: provincia, distrito, nexp, areatot_ha
 #   - 1988 data is long format: provincia, distrito, unidad, valor
@@ -306,7 +300,6 @@ harmonize_and_merge <- function(ag, xwalk, year) {
 
 # ---------------------------------------------------------------------------
 # Helper: district name fixes for 1960
-# Ported from: Old data/Train/derived/agr_census_1960/code/merge_ag1960_to_IPUMS.do
 # ---------------------------------------------------------------------------
 apply_name_fixes_1960 <- function(ag) {
     fix <- function(prov, old, new) {
@@ -387,7 +380,6 @@ apply_name_fixes_1960 <- function(ag) {
 
 # ---------------------------------------------------------------------------
 # Helper: district name fixes for 1988
-# Ported from: Old data/Train/derived/agr_census_1988/code/merge_ag1988_to_IPUMS.do
 # The 1988 census has many more abbreviations and typos than 1960.
 # ---------------------------------------------------------------------------
 apply_name_fixes_1988 <- function(ag) {

--- a/code/base/census_1947/clean_census_1947.R
+++ b/code/base/census_1947/clean_census_1947.R
@@ -21,10 +21,6 @@
 #
 #   data/derived/05a_census/census_1947_manifest.log
 #
-# REFERENCE:
-#   Old data/Train/base/census_1946/code/clean_censo1946.do
-#   Old data/Train/derived/census_1946/code/merge_popurb1946_to_IPUMS.do
-#
 # NOTES:
 #   - The 1947 census predates the current provincial boundaries. Several
 #     districts were renamed, split, or reassigned to different provinces

--- a/code/base/census_1960/clean_census_1960.R
+++ b/code/base/census_1960/clean_census_1960.R
@@ -17,10 +17,6 @@
 #
 #   data/derived/05a_census/census_1960_manifest.log
 #
-# REFERENCE:
-#   Old data/Train/base/census_1960/code/import_c1960.do
-#   Old data/Train/derived/census_1960/code/merge_c1960_to_IPUMS.do
-#
 # NOTES:
 #   - The 1960 census is organized by geographic region, each with
 #     multiple Excel pages (one per sub-region or province within the

--- a/code/base/geo_controls/clean_geo_controls.R
+++ b/code/base/geo_controls/clean_geo_controls.R
@@ -19,8 +19,6 @@
 #   data/derived/base/geo_controls/data_file_manifest.log
 #
 # REFERENCE:
-#   Old data/Train/base/geo_controls/code/geoControls_create_districts.py
-#   Old data/Train/derived/geo_controls/code/run.do
 #   Plan/geo_controls_pipeline.md
 #
 # NOTES:

--- a/code/base/industrial/clean_industrial.R
+++ b/code/base/industrial/clean_industrial.R
@@ -16,12 +16,6 @@
 #       Variables: nestab, nemp (1954) / npers (1985), massal, valprod.
 #   data/derived/base/industrial/data_file_manifest.log
 #
-# REFERENCE:
-#   Old data/Train/base/ind_census_1954/code/clean_Industrial1954.do
-#   Old data/Train/base/ind_census_1985/code/clean_Economico1985.do
-#   Old data/Train/derived/ind_census_1954/code/merge_in1954_to_IPUMS.do
-#   Old data/Train/derived/ind_census_1985/code/merge_ec1985_to_IPUMS.do
-#
 # NOTES:
 #   - 1954 files are numbered by province code (20, 22, ..., 66), wide format.
 #     Variables: Nestab, Nemp, Nobr, Massal, Valprod.

--- a/code/base/ipums/clean_ipums.R
+++ b/code/base/ipums/clean_ipums.R
@@ -23,8 +23,6 @@
 #
 #   data/derived/base/ipums/data_file_manifest.log
 #
-# REFERENCE: Old data/Train/base/ipums/code/clean_ipums.do
-#
 # NOTES:
 #   - The raw .dta file is ~2GB. haven::read_dta() loads it into memory.
 #     Ensure at least 8GB RAM available.

--- a/code/base/networks/clean_roads.R
+++ b/code/base/networks/clean_roads.R
@@ -15,9 +15,6 @@
 #   data/derived/base/networks/data_file_manifest.log
 #
 # REFERENCE:
-#   Old data/Train/derived/networks_to_districts/code/networks_to_districts.py
-#   Old data/Train/derived/networks_to_districts/code/infra_to_Stata.do
-#   Old data/Train/derived/preclean/code/preclean_departments_wide.do
 #   Plan/roads_pipeline.md
 #
 # NOTES:


### PR DESCRIPTION
## What

Deletes the `REFERENCE:` blocks (and two inline `Ported from:` comments) in seven base cleaning scripts that pointed to `Old data/Train/...` paths. These were legacy breadcrumbs from the Stata + QGIS port; they don't exist in a replicator's working copy and are misleading noise.

## Why

Per AEA self-containment: the new repo must be readable and runnable without referencing any outside artifact. Pointing to files a replicator doesn't have hurts more than it helps. Git history of the original port PRs preserves any forensic value of the cross-references.

## Scope

Pure deletions across 7 files, 29 lines total. No code logic touched.

| File | Lines removed |
|---|---|
| code/base/agricultural/clean_agricultural.R | 8 |
| code/base/census_1947/clean_census_1947.R | 4 |
| code/base/census_1960/clean_census_1960.R | 4 |
| code/base/geo_controls/clean_geo_controls.R | 2 |
| code/base/industrial/clean_industrial.R | 6 |
| code/base/ipums/clean_ipums.R | 2 |
| code/base/networks/clean_roads.R | 3 |

## Verified

- All 7 files `parse()` cleanly in R.
- Re-ran `clean_roads.R` end-to-end; still produces 309 districts with a clean manifest.
- `grep` confirms no remaining `Old data` / `Train/base` / `Train/derived` / `old_repo` / `old-repo` strings anywhere in `code/`.