### PR TITLE
Phase 1 tau rebuild: cost rasters, taus, market access (land-only, sector 0)

### DIFF
--- a/code/config.R
+++ b/code/config.R
@@ -138,11 +138,25 @@ cost_coastal_buffer_km <- 30
 
 # ---- 7. Transport cost parameters (Baumgartner & Palazzo 1969) -----------
 #
-# Unit: USD per ton-km (constant prices).
-# Three cost sectors, indexed by name:
-#   overall        = medium cargo density (main specification)
-#   agricultural   = low cargo density
-#   manufacturing  = high cargo density
+# Source: Baumgartner, A. and Palazzo, L. (1969). "Estructura económica del
+# transporte de carga automotor y ferroviario en la Argentina." Argentine
+# Ministry of Economy.
+#
+# Unit: 1960 Argentine pesos per ton-km (nominal). All sectors use the same
+# currency year, so ratios across sectors and across modes are inflation-
+# invariant. Absolute levels are scale-free in the MA formula
+# (MA_i = sum_j Pop_j / tau_ij^theta) — only ratios between on-network
+# and off-network cost matter for routing.
+#
+# Three cost "sectors" are the tabulated cargo-density scenarios in
+# Baumgartner & Palazzo Table II (see Plan/tau_calculation_review.md):
+#   overall        = medium density (500 t/day) — main specification
+#   agricultural   = high  density (1,000 t/day) — bulk grain shipment
+#   manufacturing  = low   density (100 t/day) — small-batch goods
+#
+# At high density (agriculture), rail is cheaper than road. At low density
+# (manufacturing), road is cheaper than rail. This is the scale-economies
+# mechanism that makes railroads specialise in bulk goods.
 #
 # Named vectors allow unambiguous access: cost_road[["manufacturing"]]
 
@@ -176,8 +190,36 @@ cost_mininfra <- c(
 )
 stopifnot(all(cost_mininfra == pmin(cost_road, cost_rail)))
 
-# Land (off-network) traversal cost: derived from HMI.
-# hmi = 0.2018 (average for Argentina), k = 17.9 * roadprice[mfg] / hmi
+# Land (off-network) traversal cost per ton-km per unit HMI.
+#
+# Derivation: cost_land = k × cost_road[manufacturing] / hmi_argentina
+#
+#   k = 17.9 — ratio of motor-vehicle travel speed to walking-equivalent
+#     off-network speed. Project-specific calibration, not from a published
+#     source: estimated by the original authors as the Buenos Aires–Rosario
+#     Google Maps driving-vs-walking ratio. Documented in
+#     Plan/tau_calculation_review.md, "Off-Network Travel Cost" section.
+#
+#   cost_road[manufacturing] = 8.266 — the highest road cost across sectors,
+#     chosen as the anchor so that off-network cost dominates road cost even
+#     in the manufacturing (low-cargo-density) scenario.
+#
+#   hmi_argentina = 0.2018 — mean Human Mobility Index (HMI) for Argentina,
+#     in the global raster from Özak (2010, 2018). HMI measures potential
+#     minimum travel time (hours) per 1km pixel accounting for terrain and
+#     pre-industrial technological constraints. Özak's dataset is often
+#     miscited as "Human Modification Index" — it is the Human *Mobility*
+#     Index. Global raster at https://zenodo.org/records/14285746,
+#     DOI:10.5281/zenodo.14285746, CC BY-SA 4.0.
+#     Reference: Özak, Ömer. 2018. "Distance to the Pre-Industrial
+#     Technological Frontier and Economic Development." Journal of
+#     Economic Growth 23(2): 175–221.
+#
+# cost_land ≈ 733.2 (constant across sectors). Per-pixel off-network cost
+# is cost_land × HMI_pixel_value. HMI ranges 0 to ~8 globally, so per-pixel
+# off-network cost ranges 0 to ~5,900 — two to three orders of magnitude
+# above on-network cost (0.465 to 13.5), which routes the Dijkstra path
+# onto rail/road whenever those are available.
 hmi_argentina <- 0.2018
 cost_land     <- 17.9 * cost_road[["manufacturing"]] / hmi_argentina
 cost_land_vec <- c(
@@ -191,10 +233,21 @@ cost_nodata_sentinel <- 999999L
 
 # ---- 8. Trade elasticity (theta) parameters -------------------------------
 #
-# Used in MA formula: MA_i = sum_j Pop_j / tau_ij^theta
+# Used in market access formula:
+#   MA_i = sum_{j != i} Pop_j / tau_ij^theta
 #
-# theta["low"]  = 4.55 — Eaton & Kortum (2002) lower bound
-# theta["high"] = 8.11 — main specification, Donaldson (2018) estimate
+# theta["low"]  = 4.55
+# theta["high"] = 8.11
+#
+# PENDING JUSTIFICATION. These two values were inherited from the old
+# pipeline. The literature range for theta in gravity / market-access
+# specifications spans roughly 4 to 12 (Eaton & Kortum 2002; Simonovska
+# & Waugh 2014; Donaldson 2018). Section 3.3.2 of the paper is flagged in
+# Plan/tasks.md as needing a literature review to pin down which estimates
+# we adopt and why. Do NOT cite a specific source until that review is done.
+#
+# Main results use theta["low"]; theta["high"] is reported in the appendix
+# robustness table (task C34).
 theta <- c(low = 4.55, high = 8.11)
 
 # ---- 9. Network period codes ----------------------------------------------

--- a/code/pipeline/03a_build_cost_raster.R
+++ b/code/pipeline/03a_build_cost_raster.R
@@ -36,6 +36,17 @@
 #   instrument_stu_s0     — non-studied rails only + 1954 roads + HMI
 #   instrument_lcp_mst_s0 — 1960 rails + LCP-MST hypothetical roads + HMI
 #
+# HYPOTHETICAL-NETWORK CAVEAT:
+#   The LCP-MST hypothetical road network was routed on a Faber (2014)
+#   construction-cost raster that treats water as 25× baseline, not as
+#   an infinite barrier. As a result, the MST includes a water-crossing
+#   segment to Tierra del Fuego. In the actual and instrument_stu cases
+#   (which use HMI for off-network cost), TdF is unreachable on the land
+#   surface (τ = Inf), but in instrument_lcp_mst it is reachable via
+#   the hypothetical water-crossing road. This is a known limitation of
+#   the hypothetical instrument, not a bug. Phase 2 navigation will add
+#   an explicit water layer that applies consistently to all cases.
+#
 # USAGE:
 #   Rscript code/pipeline/03a_build_cost_raster.R <case_label>
 #   Example: Rscript code/pipeline/03a_build_cost_raster.R actual_1960_s0

--- a/code/pipeline/03a_build_cost_raster.R
+++ b/code/pipeline/03a_build_cost_raster.R
@@ -1,0 +1,373 @@
+# ===========================================================================
+# 03a_build_cost_raster.R
+#
+# PURPOSE: Build a per-ton-km cost raster for a single case (network
+#          combination × sector). The raster is the input to Dijkstra
+#          least-cost-path computation.
+#
+# READS (per case):
+#   data/raw/networks/lp_1979.shp                                  (rails)
+#   data/raw/networks/comparacion_54_70_86.shp                     (roads)
+#   data/derived/02_hypothetical_networks/lcp_mst.gpkg             (hypo)
+#   data/raw/geo/HMI.tif                                           (Özak 2018)
+#   data/raw/networks_hypo/pais.shp                                (country)
+#
+# PRODUCES:
+#   data/derived/01_cost_rasters/ucost_<case>.tif
+#
+# DESIGN DECISIONS (Phase 1; see Plan/tau_rebuild_plan.md Sección 6):
+#   - Phase 1: land-only cost surface. No navigation layer. Added in Phase 2.
+#   - Sector 0 (overall, medium cargo density per Baumgartner & Palazzo 1969).
+#     One script run per case; sector is part of the case label.
+#   - Rasterise in ESRI:54034 (World Cylindrical Equal Area) at the old
+#     pipeline's 2399 × 3090 grid over mainland Argentina.
+#   - Linear networks buffered by 1 km before rasterization (matches old
+#     pipeline). Guarantees at least one full pixel per segment.
+#   - Cost formula (see cost_of_pixel() below):
+#       if rail & road:           cost_mininfra[sector]
+#       elif rail only:           cost_rail[sector]
+#       elif road only:           cost_road[sector]
+#       elif in Argentina + HMI:  cost_land × HMI
+#       else (outside Argentina): NA (hard barrier for Dijkstra)
+#
+# CASES (Phase 1, see Plan/tau_rebuild_plan.md Sección 6):
+#   actual_1960_s0        — 1960 rails + 1954 roads + HMI
+#   actual_1986_s0        — 1986 rails + 1986 roads + HMI
+#   instrument_stu_s0     — non-studied rails only + 1954 roads + HMI
+#   instrument_lcp_mst_s0 — 1960 rails + LCP-MST hypothetical roads + HMI
+#
+# USAGE:
+#   Rscript code/pipeline/03a_build_cost_raster.R <case_label>
+#   Example: Rscript code/pipeline/03a_build_cost_raster.R actual_1960_s0
+#
+#   If called without arguments, builds all four Phase 1 cases in sequence.
+# ===========================================================================
+
+suppressPackageStartupMessages({
+    library(sf)
+    library(terra)
+})
+
+# ---------------------------------------------------------------------------
+# Case registry — declarative spec of what each case is built from.
+# Adding a new case means adding a new entry here plus (if needed) a new
+# ingredient loader.
+# ---------------------------------------------------------------------------
+case_registry <- function() {
+    list(
+        actual_1960_s0 = list(
+            rail_sel = function(r) r$status1979 %in% c(1, 2, 3),
+            road_sel = function(r) r$type2      %in% c(1, 5, 7),
+            use_hypo = FALSE,
+            sector   = "overall"
+        ),
+        actual_1986_s0 = list(
+            rail_sel = function(r) r$status1979 == 1,
+            road_sel = function(r) r$type2      %in% c(1, 2, 3, 5),
+            use_hypo = FALSE,
+            sector   = "overall"
+        ),
+        instrument_stu_s0 = list(
+            rail_sel = function(r) r$status1979 %in% c(1, 2, 3) &
+                                    r$studied_co == 0,
+            road_sel = function(r) r$type2      %in% c(1, 5, 7),
+            use_hypo = FALSE,
+            sector   = "overall"
+        ),
+        instrument_lcp_mst_s0 = list(
+            rail_sel = function(r) r$status1979 %in% c(1, 2, 3),
+            road_sel = NULL,          # no observed roads; hypo network replaces
+            use_hypo = TRUE,
+            sector   = "overall"
+        )
+    )
+}
+
+main <- function() {
+
+    source(file.path(here::here(), "code", "config.R"), echo = FALSE)
+
+    args <- commandArgs(trailingOnly = TRUE)
+    cases <- if (length(args) > 0) args else names(case_registry())
+
+    message("\n", strrep("=", 72))
+    message("03a_build_cost_raster.R  |  Phase 1, land-only, sector 0")
+    message(strrep("=", 72))
+    message(sprintf("Cases to build: %s\n", paste(cases, collapse = ", ")))
+
+    if (!dir.exists(dir_derived_rasters)) {
+        dir.create(dir_derived_rasters, recursive = TRUE)
+    }
+
+    reg <- case_registry()
+    for (case in cases) {
+        if (!(case %in% names(reg))) {
+            stop(sprintf("Unknown case label: %s", case))
+        }
+        build_one_case(case, reg[[case]])
+    }
+
+    message(strrep("=", 72))
+    message("03a_build_cost_raster.R  |  Complete.")
+    message(strrep("=", 72), "\n")
+}
+
+# ---------------------------------------------------------------------------
+# Build one case end-to-end
+# ---------------------------------------------------------------------------
+build_one_case <- function(case, spec) {
+    message(sprintf("\n[cost] ==== CASE: %s ====", case))
+
+    # --- 1. Base raster grid (ESRI:54034) ---
+    base <- build_base_raster()
+
+    # --- 2. Country mask (for NA outside Argentina) ---
+    arg_mask <- rasterize_country(base)
+
+    # --- 3. Rasterise rail and road ingredients ---
+    rail_rast <- rasterize_rails(base, spec$rail_sel)
+    road_rast <- rasterize_roads_or_hypo(base, spec)
+
+    # --- 4. Rasterise HMI (reproject + crop to Argentina extent) ---
+    hmi_rast  <- rasterize_hmi(base)
+
+    # --- 5. Combine into cost surface ---
+    cost <- combine_cost(rail_rast, road_rast, hmi_rast, arg_mask,
+                         sector = spec$sector)
+
+    # --- 6. Validate and save ---
+    validate_cost(cost, rail_rast, road_rast, spec$sector)
+    save_cost_raster(cost, case)
+}
+
+# ---------------------------------------------------------------------------
+# Base raster: empty ESRI:54034 grid matching old-pipeline dimensions
+# ---------------------------------------------------------------------------
+build_base_raster <- function() {
+    # Old pipeline extent in ESRI:54034:
+    # (-8189281.6170, -5209240.7239) x (-5971264.2267, -2352352.9641)
+    ext54034 <- terra::ext(
+        -8189281.61690,  # xmin
+        -5209240.72390,  # xmax
+        -5971264.22670,  # ymin
+        -2352352.96410   # ymax
+    )
+    r <- terra::rast(ext54034,
+                     ncol = raster_ncols,
+                     nrow = raster_nrows,
+                     crs  = crs_raster)
+    terra::values(r) <- 0L  # all cells default to 0 (will be overwritten)
+    r
+}
+
+# ---------------------------------------------------------------------------
+# Country mask: 1 inside Argentina, NA outside
+# ---------------------------------------------------------------------------
+rasterize_country <- function(base) {
+    message("[cost]   Rasterising country polygon (pais.shp)")
+    pais <- sf::st_read(
+        file.path(dir_raw, "networks_hypo", "pais.shp"),
+        quiet = TRUE
+    )
+    pais <- sf::st_make_valid(pais)
+    pais_p <- sf::st_transform(pais, crs = crs_raster)
+    r <- terra::rasterize(terra::vect(pais_p), base, field = 1)
+    # Outside the polygon is NA; set cells inside to 1
+    r
+}
+
+# ---------------------------------------------------------------------------
+# Rasterise rails: select segments via `sel()`, buffer 1 km, rasterise
+# ---------------------------------------------------------------------------
+rasterize_rails <- function(base, sel) {
+    message("[cost]   Rasterising rails (selected subset)")
+    rails <- sf::st_read(
+        file.path(dir_raw_networks, "lp_1979.shp"), quiet = TRUE
+    )
+    rails <- sf::st_make_valid(rails)
+    rails_sub <- rails[sel(rails), ]
+    message(sprintf("[cost]     Selected %d / %d segments",
+                    nrow(rails_sub), nrow(rails)))
+
+    rails_proj <- sf::st_transform(rails_sub, crs = crs_raster)
+    rails_buf  <- sf::st_buffer(rails_proj, dist = 1000)  # 1 km buffer
+    rails_buf  <- sf::st_union(rails_buf)                 # single multipolygon
+
+    r <- terra::rasterize(terra::vect(rails_buf), base, field = 1L,
+                          background = 0L)
+    n_cells <- sum(terra::values(r) == 1L, na.rm = TRUE)
+    message(sprintf("[cost]     Rail pixels (value=1): %d", n_cells))
+    r
+}
+
+# ---------------------------------------------------------------------------
+# Rasterise roads OR hypothetical road network, depending on case
+# ---------------------------------------------------------------------------
+rasterize_roads_or_hypo <- function(base, spec) {
+    if (isTRUE(spec$use_hypo)) {
+        return(rasterize_hypo(base))
+    }
+    if (is.null(spec$road_sel)) {
+        # Empty road raster (no roads at all)
+        r <- base
+        terra::values(r) <- 0L
+        return(r)
+    }
+    rasterize_roads(base, spec$road_sel)
+}
+
+rasterize_roads <- function(base, sel) {
+    message("[cost]   Rasterising roads (selected subset)")
+    roads <- sf::st_read(
+        file.path(dir_raw_networks, "comparacion_54_70_86.shp"), quiet = TRUE
+    )
+    roads <- sf::st_make_valid(roads)
+    roads_sub <- roads[sel(roads), ]
+    message(sprintf("[cost]     Selected %d / %d segments",
+                    nrow(roads_sub), nrow(roads)))
+
+    roads_proj <- sf::st_transform(roads_sub, crs = crs_raster)
+    roads_buf  <- sf::st_buffer(roads_proj, dist = 1000)
+    roads_buf  <- sf::st_union(roads_buf)
+
+    r <- terra::rasterize(terra::vect(roads_buf), base, field = 1L,
+                          background = 0L)
+    n_cells <- sum(terra::values(r) == 1L, na.rm = TRUE)
+    message(sprintf("[cost]     Road pixels (value=1): %d", n_cells))
+    r
+}
+
+rasterize_hypo <- function(base) {
+    message("[cost]   Rasterising hypothetical LCP-MST road network")
+    hypo_path <- file.path(
+        dir_derived, "02_hypothetical_networks", "lcp_mst.gpkg"
+    )
+    if (!file.exists(hypo_path)) {
+        stop("Hypo network not found at: ", hypo_path)
+    }
+    hypo <- sf::st_read(hypo_path, quiet = TRUE)
+    hypo <- sf::st_make_valid(hypo)
+
+    hypo_proj <- sf::st_transform(hypo, crs = crs_raster)
+    hypo_buf  <- sf::st_buffer(hypo_proj, dist = 1000)
+    hypo_buf  <- sf::st_union(hypo_buf)
+
+    r <- terra::rasterize(terra::vect(hypo_buf), base, field = 1L,
+                          background = 0L)
+    n_cells <- sum(terra::values(r) == 1L, na.rm = TRUE)
+    message(sprintf("[cost]     Hypo road pixels (value=1): %d", n_cells))
+    r
+}
+
+# ---------------------------------------------------------------------------
+# Rasterise HMI onto the base grid
+# ---------------------------------------------------------------------------
+rasterize_hmi <- function(base) {
+    message("[cost]   Projecting HMI to base raster")
+    hmi_path <- file.path(dir_raw_geo, "HMI.tif")
+    if (!file.exists(hmi_path)) stop("HMI raster not found: ", hmi_path)
+
+    hmi <- terra::rast(hmi_path)
+    # Zenodo file ships without a written CRS; it's documented as
+    # cylindrical equal-area at ESRI:54034.
+    terra::crs(hmi) <- crs_raster
+
+    # Crop global raster to Argentina bbox + margin for speed
+    hmi_cropped <- terra::crop(hmi, terra::ext(base))
+    # Resample to the base raster's grid (bilinear for a continuous surface)
+    hmi_on_base <- terra::resample(hmi_cropped, base, method = "bilinear")
+
+    n_ok <- sum(!is.na(terra::values(hmi_on_base)))
+    message(sprintf("[cost]     HMI pixels with value (not NA): %d", n_ok))
+    hmi_on_base
+}
+
+# ---------------------------------------------------------------------------
+# Combine rail + road + HMI layers into the cost surface
+# ---------------------------------------------------------------------------
+combine_cost <- function(rail_rast, road_rast, hmi_rast, arg_mask, sector) {
+    message(sprintf("[cost]   Combining layers (sector=%s)", sector))
+
+    rail <- terra::values(rail_rast)
+    road <- terra::values(road_rast)
+    hmi  <- terra::values(hmi_rast)
+    mask <- terra::values(arg_mask)
+
+    # NA-safe helpers
+    is_rail <- !is.na(rail) & rail == 1L
+    is_road <- !is.na(road) & road == 1L
+    in_arg  <- !is.na(mask) & mask == 1
+
+    cost <- rep(NA_real_, length(rail))
+
+    # Overlap: rail and road → mininfra
+    sel <- is_rail & is_road
+    cost[sel] <- cost_mininfra[[sector]]
+
+    # Rail only
+    sel <- is_rail & !is_road
+    cost[sel] <- cost_rail[[sector]]
+
+    # Road only
+    sel <- !is_rail & is_road
+    cost[sel] <- cost_road[[sector]]
+
+    # Off-network land inside Argentina: cost_land × HMI
+    # (HMI may be NA for individual cells — those stay NA → hard barrier)
+    sel <- !is_rail & !is_road & in_arg & !is.na(hmi)
+    cost[sel] <- cost_land * hmi[sel]
+
+    # Outside Argentina: NA (hard barrier for Dijkstra)
+    # (already NA_real_ from initialisation)
+
+    r <- terra::rast(rail_rast)   # copy grid + crs
+    terra::values(r) <- cost
+    names(r) <- "cost"
+    r
+}
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+validate_cost <- function(cost, rail_rast, road_rast, sector) {
+    v <- terra::values(cost)
+    r <- terra::values(rail_rast)
+    d <- terra::values(road_rast)
+
+    rail_only    <- !is.na(r) & r == 1L & (is.na(d) | d == 0L)
+    road_only    <- !is.na(d) & d == 1L & (is.na(r) | r == 0L)
+    both         <- !is.na(r) & r == 1L & !is.na(d) & d == 1L
+
+    chk_rail <- all.equal(unique(v[rail_only]),
+                          cost_rail[[sector]], tolerance = 1e-9)
+    chk_road <- all.equal(unique(v[road_only]),
+                          cost_road[[sector]], tolerance = 1e-9)
+    chk_both <- length(both) == 0 ||
+                all.equal(unique(v[both]),
+                          cost_mininfra[[sector]], tolerance = 1e-9)
+
+    stopifnot(isTRUE(chk_rail), isTRUE(chk_road), isTRUE(chk_both))
+    message(sprintf(
+        "[cost]   Validation OK: rail_only=%.4f road_only=%.4f both=%.4f",
+        cost_rail[[sector]], cost_road[[sector]], cost_mininfra[[sector]]
+    ))
+
+    v_ok <- v[!is.na(v)]
+    message(sprintf(
+        "[cost]   Cost summary: min=%.3f  mean=%.2f  max=%.2f  N=%d",
+        min(v_ok), mean(v_ok), max(v_ok), length(v_ok)
+    ))
+}
+
+# ---------------------------------------------------------------------------
+# Save
+# ---------------------------------------------------------------------------
+save_cost_raster <- function(cost, case) {
+    out_path <- file.path(dir_derived_rasters,
+                          sprintf("ucost_%s.tif", case))
+    terra::writeRaster(cost, out_path, overwrite = TRUE,
+                       datatype = "FLT4S")
+    message(sprintf("[cost]   Saved: %s", out_path))
+}
+
+main()

--- a/code/pipeline/03b_transition_grids.R
+++ b/code/pipeline/03b_transition_grids.R
@@ -1,0 +1,107 @@
+# ===========================================================================
+# 03b_transition_grids.R
+#
+# PURPOSE: Convert each per-case cost raster into a gdistance transition
+#          object, ready for Dijkstra least-cost-path computation.
+#
+# READS:
+#   data/derived/01_cost_rasters/ucost_<case>.tif
+#
+# PRODUCES:
+#   data/derived/02_transition_grids/transition_<case>.rds
+#
+# DESIGN (matches old pipeline transition_grids/build.R):
+#   - 8-connected neighbours.
+#   - Transition weight = 1 / mean(neighbour cell costs), so cells with
+#     lower cost conduct more (cheaper edges).
+#   - geoCorrection() applies the √2 factor for diagonal edges, so paths
+#     in the output Dijkstra respect real-world distance.
+#
+# NOTES:
+#   - gdistance is old (last update 2020) and unmaintained but it is the
+#     standard and the old pipeline used it, so we stick with it. If
+#     gdistance breaks in a future R version, the successor is terra::
+#     costDistance() plus igraph — but that port is out of scope for
+#     Phase 1.
+#   - .rds is used because gdistance's TransitionLayer is an S4 object
+#     that isn't naturally serialisable to parquet.
+#   - NA cost cells become 0-conductance edges (impassable), which is the
+#     correct behaviour: they act as hard barriers.
+#
+# USAGE:
+#   Rscript code/pipeline/03b_transition_grids.R <case_label> [<case_label> ...]
+#   If called without arguments, processes all .tif files in
+#   data/derived/01_cost_rasters/.
+# ===========================================================================
+
+suppressPackageStartupMessages({
+    library(raster)     # gdistance still relies on the legacy raster package
+    library(gdistance)
+})
+
+main <- function() {
+
+    source(file.path(here::here(), "code", "config.R"), echo = FALSE)
+
+    if (!dir.exists(dir_derived_transitions)) {
+        dir.create(dir_derived_transitions, recursive = TRUE)
+    }
+
+    args <- commandArgs(trailingOnly = TRUE)
+    if (length(args) > 0) {
+        cases <- args
+    } else {
+        all_tifs <- list.files(dir_derived_rasters,
+                               pattern = "^ucost_.+\\.tif$",
+                               full.names = FALSE)
+        cases <- sub("^ucost_", "", sub("\\.tif$", "", all_tifs))
+    }
+
+    message("\n", strrep("=", 72))
+    message("03b_transition_grids.R  |  cost raster → gdistance transition")
+    message(strrep("=", 72))
+    message(sprintf("Cases to process: %s\n", paste(cases, collapse = ", ")))
+
+    for (case in cases) build_one_transition(case)
+
+    message(strrep("=", 72))
+    message("03b_transition_grids.R  |  Complete.")
+    message(strrep("=", 72), "\n")
+}
+
+# ---------------------------------------------------------------------------
+# Build the transition object for one case
+# ---------------------------------------------------------------------------
+build_one_transition <- function(case) {
+    message(sprintf("\n[trans] ==== CASE: %s ====", case))
+
+    cost_path <- file.path(dir_derived_rasters,
+                           sprintf("ucost_%s.tif", case))
+    if (!file.exists(cost_path)) {
+        stop("Cost raster not found: ", cost_path)
+    }
+
+    message(sprintf("[trans]   Reading %s", cost_path))
+    r <- raster::raster(cost_path)
+
+    message("[trans]   Building 8-neighbour transition (1/mean(cost))")
+    t0 <- Sys.time()
+    tg <- gdistance::transition(r,
+                                transitionFunction = function(x) 1 / mean(x),
+                                directions = 8)
+    message(sprintf("[trans]   transition() took %.1f s",
+                    as.numeric(difftime(Sys.time(), t0, units = "secs"))))
+
+    message("[trans]   Applying geoCorrection (diagonal edges)")
+    t0 <- Sys.time()
+    tg <- gdistance::geoCorrection(tg)
+    message(sprintf("[trans]   geoCorrection() took %.1f s",
+                    as.numeric(difftime(Sys.time(), t0, units = "secs"))))
+
+    out_path <- file.path(dir_derived_transitions,
+                          sprintf("transition_%s.rds", case))
+    saveRDS(tg, out_path)
+    message(sprintf("[trans]   Saved: %s", out_path))
+}
+
+main()

--- a/code/pipeline/03c_compute_taus.R
+++ b/code/pipeline/03c_compute_taus.R
@@ -1,0 +1,213 @@
+# ===========================================================================
+# 03c_compute_taus.R
+#
+# PURPOSE: Run Dijkstra least-cost-path distances between every pair of
+#          IPUMS district centroids on each case's transition grid.
+#          Produces a pairwise tau table per case.
+#
+# READS:
+#   data/derived/02_transition_grids/transition_<case>.rds
+#   data/raw/geo/geo2_ar1970_2010.shp                         (district polygons)
+#
+# PRODUCES:
+#   data/derived/03_taus/tau_<case>.parquet
+#       Columns: origin_geolev2 (chr), destination_geolev2 (chr), tau (num).
+#       Long format, one row per unordered pair of distinct districts
+#       (48,516 pairs = choose(312, 2)). Symmetric, so only the
+#       lower-triangle is stored.
+#
+# DESIGN:
+#   - Centroids: sf::st_centroid(sf::st_make_valid(polygon)) on the IPUMS
+#     312-district shapefile. Matches the old pipeline's `centroids.shp`.
+#   - gdistance::costDistance(transition, points, points) returns a 312×312
+#     symmetric matrix. We take the strictly lower triangle for storage.
+#     By convention, tau(i, i) = 0 (not stored; add back when re-materialising).
+#   - costDistance() parallelises across destinations internally, so
+#     we do not add R-level parallelism across cases in Phase 1.
+#
+# SANITY CHECKS (run automatically):
+#   - No NaN (would indicate a numeric problem in the graph).
+#   - No negative tau.
+#   - Symmetry: tau(i, j) == tau(j, i), ignoring Inf entries (which can
+#     occur for disconnected districts; on a land-only surface, TdF is
+#     unreachable from mainland — expected for Phase 1).
+#   - BA → Córdoba τ is printed for manual eyeball.
+#
+# USAGE:
+#   Rscript code/pipeline/03c_compute_taus.R <case_label> [<case_label> ...]
+#   If no args, processes all transition files in dir_derived_transitions/.
+# ===========================================================================
+
+suppressPackageStartupMessages({
+    library(sf)
+    library(sp)
+    library(raster)
+    library(gdistance)
+    library(arrow)
+})
+
+main <- function() {
+
+    source(file.path(here::here(), "code", "config.R"), echo = FALSE)
+    source(file.path(dir_code, "base", "utils.R"), echo = FALSE)
+
+    if (!dir.exists(dir_derived_taus)) {
+        dir.create(dir_derived_taus, recursive = TRUE)
+    }
+
+    args <- commandArgs(trailingOnly = TRUE)
+    if (length(args) > 0) {
+        cases <- args
+    } else {
+        rds_files <- list.files(dir_derived_transitions,
+                                pattern = "^transition_.+\\.rds$",
+                                full.names = FALSE)
+        cases <- sub("^transition_", "", sub("\\.rds$", "", rds_files))
+    }
+
+    message("\n", strrep("=", 72))
+    message("03c_compute_taus.R  |  Dijkstra on 312 district centroids")
+    message(strrep("=", 72))
+    message(sprintf("Cases: %s\n", paste(cases, collapse = ", ")))
+
+    # Load centroids once (shared across all cases)
+    centroids <- load_centroids()
+
+    for (case in cases) compute_one_case(case, centroids)
+
+    message(strrep("=", 72))
+    message("03c_compute_taus.R  |  Complete.")
+    message(strrep("=", 72), "\n")
+}
+
+# ---------------------------------------------------------------------------
+# District centroids as SpatialPoints (gdistance needs sp)
+# ---------------------------------------------------------------------------
+load_centroids <- function() {
+    message("[tau] Loading and centroid-ing district polygons")
+    shp <- sf::st_read(file.path(dir_raw_geo, "geo2_ar1970_2010.shp"),
+                       quiet = TRUE)
+    shp <- sf::st_make_valid(shp)
+    names(shp)[names(shp) == "GEOLEVEL2"] <- "geolev2"
+    shp$geolev2 <- sub("^0+", "", as.character(shp$geolev2))
+
+    # Drop Malvinas/South Georgia (geolev2_exclude) and empty geometries
+    shp <- shp[!sf::st_is_empty(shp), ]
+    shp <- shp[!(shp$geolev2 %in% geolev2_exclude), ]
+
+    # Drop residual geolev2 codes (ending in 0000)
+    shp <- shp[!grepl("0000$", shp$geolev2), ]
+
+    stopifnot(nrow(shp) == 312L)
+    stopifnot(!any(duplicated(shp$geolev2)))
+
+    message(sprintf("[tau]   %d districts loaded", nrow(shp)))
+
+    # Centroid, then reproject to the transition's CRS (ESRI:54034)
+    cents_sf <- sf::st_centroid(shp)
+    cents_sf <- sf::st_transform(cents_sf, crs = crs_raster)
+
+    # Convert to sp::SpatialPoints for gdistance::costDistance
+    cents_sp <- sf::as_Spatial(cents_sf[, "geolev2"])
+    cents_sp
+}
+
+# ---------------------------------------------------------------------------
+# One case
+# ---------------------------------------------------------------------------
+compute_one_case <- function(case, centroids) {
+    message(sprintf("\n[tau] ==== CASE: %s ====", case))
+
+    tg_path <- file.path(dir_derived_transitions,
+                         sprintf("transition_%s.rds", case))
+    if (!file.exists(tg_path)) stop("Transition not found: ", tg_path)
+
+    message(sprintf("[tau]   Reading %s", tg_path))
+    tg <- readRDS(tg_path)
+
+    message("[tau]   Running gdistance::costDistance (312x312 Dijkstra)")
+    t0 <- Sys.time()
+    mat <- gdistance::costDistance(tg, centroids, centroids)
+    mat <- as.matrix(mat)
+    elapsed <- as.numeric(difftime(Sys.time(), t0, units = "secs"))
+    message(sprintf("[tau]   costDistance() took %.1f s", elapsed))
+
+    # Validate: square, no NaN, no negative
+    stopifnot(nrow(mat) == 312L, ncol(mat) == 312L)
+    if (any(is.nan(mat))) stop("NaN in τ matrix")
+    # Inf is allowed (disconnected districts on a land-only surface, e.g. TdF)
+    finite_mat <- mat
+    finite_mat[!is.finite(mat)] <- NA
+    stopifnot(all(mat >= 0 | is.na(finite_mat)))
+
+    # Count Inf so the log records them
+    n_inf <- sum(is.infinite(mat))
+    if (n_inf > 0) {
+        message(sprintf(
+            "[tau]   %d Inf entries (disconnected; e.g. TdF on land-only surface)",
+            n_inf
+        ))
+    }
+
+    # Symmetry check, ignoring Inf entries
+    asym <- abs(mat - t(mat))
+    asym[!is.finite(asym)] <- 0
+    max_asym <- max(asym)
+    if (max_asym > 1e-6) {
+        warning(sprintf("[tau] Asymmetry > 1e-6: max |τ_ij - τ_ji| = %g",
+                        max_asym))
+    }
+    # Diagonal should be 0 (within tolerance)
+    diag_max <- max(abs(diag(mat)))
+    stopifnot(diag_max < 1e-6)
+
+    # Long-format lower triangle
+    geolev2 <- as.character(centroids$geolev2)
+    ij <- which(lower.tri(mat, diag = FALSE), arr.ind = TRUE)
+    tau_df <- data.frame(
+        origin_geolev2      = geolev2[ij[, "row"]],
+        destination_geolev2 = geolev2[ij[, "col"]],
+        tau                 = mat[ij],
+        stringsAsFactors    = FALSE
+    )
+    # Sanity check: no self-pairs
+    stopifnot(nrow(tau_df) == choose(312L, 2L))
+
+    # BA to Córdoba eyeball (CF = 32002001; Córdoba capital = 32014014
+    # per IPUMS; pick whichever code exists in centroids)
+    print_eyeball_pair(tau_df, "32002001", "32014014",
+                       "BA (32002001) → Córdoba (32014014)")
+
+    # Summary (finite values only)
+    finite_tau <- tau_df$tau[is.finite(tau_df$tau)]
+    n_inf_pairs <- sum(!is.finite(tau_df$tau))
+    message(sprintf(
+        "[tau]   τ summary (finite): min=%.3f  median=%.1f  mean=%.1f  max=%.1f  (Inf pairs: %d)",
+        min(finite_tau), median(finite_tau),
+        mean(finite_tau), max(finite_tau), n_inf_pairs
+    ))
+
+    out_path <- file.path(dir_derived_taus,
+                          sprintf("tau_%s.parquet", case))
+    arrow::write_parquet(tau_df, out_path)
+    message(sprintf("[tau]   Saved: %s (%d rows)", out_path, nrow(tau_df)))
+}
+
+# ---------------------------------------------------------------------------
+# Helper: look up τ for a single (origin, destination) pair and print
+# ---------------------------------------------------------------------------
+print_eyeball_pair <- function(tau_df, i, j, label) {
+    tau <- tau_df$tau[tau_df$origin_geolev2 == i &
+                      tau_df$destination_geolev2 == j]
+    if (length(tau) == 0) {
+        tau <- tau_df$tau[tau_df$origin_geolev2 == j &
+                          tau_df$destination_geolev2 == i]
+    }
+    if (length(tau) == 1) {
+        message(sprintf("[tau]   eyeball %s: τ = %.1f", label, tau))
+    } else {
+        message(sprintf("[tau]   eyeball %s: (not found in table)", label))
+    }
+}
+
+main()

--- a/code/pipeline/03c_compute_taus.R
+++ b/code/pipeline/03c_compute_taus.R
@@ -103,8 +103,11 @@ load_centroids <- function() {
 
     message(sprintf("[tau]   %d districts loaded", nrow(shp)))
 
-    # Centroid, then reproject to the transition's CRS (ESRI:54034)
-    cents_sf <- sf::st_centroid(shp)
+    # Centroid, then reproject to the transition's CRS (ESRI:54034).
+    # suppressWarnings: st_centroid() warns "assumes attributes are
+    # constant over geometries" — harmless here since we're only keeping
+    # the geolev2 column.
+    cents_sf <- suppressWarnings(sf::st_centroid(shp))
     cents_sf <- sf::st_transform(cents_sf, crs = crs_raster)
 
     # Convert to sp::SpatialPoints for gdistance::costDistance

--- a/code/pipeline/04_market_access.R
+++ b/code/pipeline/04_market_access.R
@@ -1,0 +1,170 @@
+# ===========================================================================
+# 04_market_access.R
+#
+# PURPOSE: Compute district-level market access (MA) from pairwise tau
+#          matrices and 1960 population.
+#
+# READS:
+#   data/derived/03_taus/tau_<case>.parquet
+#   data/derived/base/census_1960/census_1960_ipums.parquet  (pop weights)
+#
+# PRODUCES:
+#   data/derived/04_market_access/ma_<case>.parquet
+#       Columns: geolev2 (chr, key), MA (num), logMA (num).
+#
+# FORMULA:
+#   MA_i = sum_{j != i} Pop_j / (tau_ij)^theta
+#
+# DESIGN DECISIONS:
+#   - Population anchor: 1960 IPUMS-constructed population. Used for ALL
+#     cases so that variation in MA comes from variation in transport
+#     costs (tau), not population. Matches Donaldson & Hornbeck (2016).
+#   - Districts not in the 1960 census file (e.g. CF, TdF) use pop = 0
+#     in the summation. They still appear as rows in the output but their
+#     contribution to other districts' MA is zero, and their own MA is
+#     computed from the 310 districts that do have population.
+#     This is defensible because (i) the 1960 census literally doesn't
+#     cover those districts in the cleaned data, (ii) using IPUMS 1970
+#     as a fallback would conflate pop and transport changes (IPUMS 1970
+#     is post-1960 so already reflects migration responses).
+#   - theta: θ_low = 4.55 for Phase 1. θ_high = 8.11 sensitivity deferred.
+#   - Inf tau (disconnected pair) contributes exactly 0 to the sum since
+#     1/Inf^θ = 0.
+#   - Self-distance (i == j) is excluded from the sum by construction.
+#
+# USAGE:
+#   Rscript code/pipeline/04_market_access.R <case_label> [<case_label> ...]
+#   If no args, processes every tau file in dir_derived_taus/.
+# ===========================================================================
+
+suppressPackageStartupMessages({
+    library(arrow)
+})
+
+main <- function() {
+
+    source(file.path(here::here(), "code", "config.R"), echo = FALSE)
+    source(file.path(dir_code, "base", "utils.R"), echo = FALSE)
+
+    if (!dir.exists(dir_derived_ma)) {
+        dir.create(dir_derived_ma, recursive = TRUE)
+    }
+
+    args <- commandArgs(trailingOnly = TRUE)
+    if (length(args) > 0) {
+        cases <- args
+    } else {
+        pq_files <- list.files(dir_derived_taus,
+                               pattern = "^tau_.+\\.parquet$",
+                               full.names = FALSE)
+        cases <- sub("^tau_", "", sub("\\.parquet$", "", pq_files))
+    }
+
+    message("\n", strrep("=", 72))
+    message("04_market_access.R  |  MA_i = sum_{j≠i} Pop_j / τ_ij^θ")
+    message(strrep("=", 72))
+    message(sprintf("Cases: %s\n", paste(cases, collapse = ", ")))
+    message(sprintf("Elasticity θ = %.3f (low; see config.R)", theta[["low"]]))
+
+    pop <- load_1960_population()
+
+    for (case in cases) compute_ma_one_case(case, pop, theta[["low"]])
+
+    message(strrep("=", 72))
+    message("04_market_access.R  |  Complete.")
+    message(strrep("=", 72), "\n")
+}
+
+# ---------------------------------------------------------------------------
+# Load 1960 census population as the universal MA weight
+# ---------------------------------------------------------------------------
+load_1960_population <- function() {
+    path <- file.path(dir_derived_census1960, "census_1960_ipums.parquet")
+    stopifnot(file.exists(path))
+    d <- arrow::read_parquet(path)
+    d <- ensure_geolev2_char(d)
+    stopifnot(c("geolev2", "pop") %in% names(d))
+    d <- data.frame(geolev2 = d$geolev2, pop = as.numeric(d$pop))
+
+    message(sprintf("[ma] Loaded 1960 pop: %d districts, total=%s",
+                    nrow(d), format(round(sum(d$pop)), big.mark = ",")))
+    d
+}
+
+# ---------------------------------------------------------------------------
+# Compute MA for one case
+# ---------------------------------------------------------------------------
+compute_ma_one_case <- function(case, pop_df, theta_val) {
+    message(sprintf("\n[ma] ==== CASE: %s ====", case))
+
+    tau_path <- file.path(dir_derived_taus,
+                          sprintf("tau_%s.parquet", case))
+    tau_df <- arrow::read_parquet(tau_path)
+    tau_df <- ensure_geolev2_char(tau_df, "origin_geolev2")
+    tau_df <- ensure_geolev2_char(tau_df, "destination_geolev2")
+
+    all_geo <- sort(unique(c(tau_df$origin_geolev2,
+                             tau_df$destination_geolev2)))
+    message(sprintf("[ma]   τ file has %d districts (%d pairs)",
+                    length(all_geo), nrow(tau_df)))
+
+    # Symmetrise: the τ file only stores the lower triangle; we need both
+    # directions for each origin's MA sum.
+    sym <- rbind(
+        tau_df,
+        data.frame(
+            origin_geolev2      = tau_df$destination_geolev2,
+            destination_geolev2 = tau_df$origin_geolev2,
+            tau                 = tau_df$tau
+        )
+    )
+
+    # Merge destination population
+    sym <- merge(
+        sym,
+        data.frame(destination_geolev2 = pop_df$geolev2,
+                   pop_dest            = pop_df$pop),
+        by = "destination_geolev2", all.x = TRUE
+    )
+    sym$pop_dest[is.na(sym$pop_dest)] <- 0
+
+    # 1/τ^θ; Inf τ → 0
+    sym$weight <- ifelse(is.finite(sym$tau) & sym$tau > 0,
+                         1 / (sym$tau^theta_val), 0)
+    sym$contrib <- sym$weight * sym$pop_dest
+
+    # Sum per origin
+    ma_df <- aggregate(contrib ~ origin_geolev2, data = sym, FUN = sum)
+    names(ma_df) <- c("geolev2", "MA")
+    ma_df$logMA <- log(ma_df$MA)
+
+    # Sanity: log is finite for districts with any non-zero contribution
+    n_inf_log <- sum(!is.finite(ma_df$logMA))
+    message(sprintf(
+        "[ma]   MA computed for %d districts; %d have logMA = -Inf (MA = 0)",
+        nrow(ma_df), n_inf_log
+    ))
+    if (n_inf_log > 0) {
+        zeros <- ma_df$geolev2[!is.finite(ma_df$logMA)]
+        message(sprintf("[ma]   logMA -Inf for: %s",
+                        paste(head(zeros, 10), collapse = ", ")))
+    }
+
+    finite_ma <- ma_df$MA[ma_df$MA > 0]
+    message(sprintf(
+        "[ma]   MA summary (MA>0): min=%.3e median=%.3e max=%.3e",
+        min(finite_ma), median(finite_ma), max(finite_ma)
+    ))
+    finite_log <- ma_df$logMA[is.finite(ma_df$logMA)]
+    message(sprintf(
+        "[ma]   logMA summary (finite): min=%.2f  mean=%.2f  max=%.2f",
+        min(finite_log), mean(finite_log), max(finite_log)
+    ))
+
+    out_path <- file.path(dir_derived_ma,
+                          sprintf("ma_%s.parquet", case))
+    arrow::write_parquet(ma_df, out_path)
+    message(sprintf("[ma]   Saved: %s", out_path))
+}
+
+main()

--- a/code/pipeline/06_merge_ma_into_panel.R
+++ b/code/pipeline/06_merge_ma_into_panel.R
@@ -175,6 +175,18 @@ save_and_manifest <- function(panel) {
     cat(sprintf("Rows: %d\nColumns: %d\nKey: geolev2\n\n",
                 nrow(panel), ncol(panel)))
 
+    cat(
+      "NOTE ON logMA/chg_logMA COLUMNS:\n",
+      "  Tierra del Fuego districts (32094001, 32094002) are NA in all\n",
+      "  land-only logMA columns (actual_*, instrument_stu) because they\n",
+      "  are disconnected from the mainland on the Phase 1 land-only cost\n",
+      "  surface. Phase 2 navigation will reconnect them via sea routes.\n",
+      "  The instrument_lcp_mst column has values for them because the\n",
+      "  LCP-MST hypothetical network was routed on a Faber cost surface\n",
+      "  that treats water as passable (25x baseline), not infinite.\n",
+      "\n", sep = ""
+    )
+
     cat("Summary of every variable:\n")
     for (v in names(panel)) {
         if (v == "geolev2") next

--- a/code/pipeline/06_merge_ma_into_panel.R
+++ b/code/pipeline/06_merge_ma_into_panel.R
@@ -1,0 +1,206 @@
+# ===========================================================================
+# 06_merge_ma_into_panel.R
+#
+# PURPOSE: Merge Phase 1 market access columns into the wide estimation
+#          panel. Adds logMA levels and logMA change variables (treatment
+#          + two instruments).
+#
+# READS:
+#   data/derived/05_panel/departments_wide_panel.parquet    (existing)
+#   data/derived/04_market_access/ma_<case>.parquet         (4 cases)
+#
+# PRODUCES:
+#   data/derived/05_panel/departments_wide_panel.parquet    (overwritten)
+#       New columns:
+#         logMA_actual_1960_s0_elow
+#         logMA_actual_1986_s0_elow
+#         logMA_instrument_stu_s0_elow
+#         logMA_instrument_lcp_mst_s0_elow
+#         chg_logMA_86_60_s0_elow            = actual_1986 - actual_1960
+#         chg_logMA_stu_s0_elow              = instrument_stu - actual_1960
+#         chg_logMA_lcp_mst_s0_elow          = instrument_lcp_mst - actual_1960
+#
+# NAMING CONVENTION:
+#   logMA_<timing>_s<sector>_e<elasticity>
+#     timing ∈ {actual_1960, actual_1986, instrument_stu, instrument_lcp_mst}
+#     sector ∈ {0}  (Phase 1 only)
+#     elasticity ∈ {low}  (θ = 4.55, Phase 1 only)
+#
+# NOTES:
+#   - Districts where logMA is -Inf (e.g. TdF on a land-only cost surface)
+#     produce NA in the corresponding logMA column, and NA in any change
+#     variable that uses that column. NA is auto-dropped by regression
+#     functions, which is the intended downstream behavior.
+#   - Phase 2 will add sector 1, sector 2, and θ = 8.11 columns. This
+#     script is structured so extending it means adding rows to
+#     `ma_cases_spec` below.
+# ===========================================================================
+
+suppressPackageStartupMessages({
+    library(arrow)
+})
+
+# Case spec: case_label → column suffix used in the panel
+ma_cases_spec <- list(
+    list(case = "actual_1960_s0",        suffix = "actual_1960_s0_elow"),
+    list(case = "actual_1986_s0",        suffix = "actual_1986_s0_elow"),
+    list(case = "instrument_stu_s0",     suffix = "instrument_stu_s0_elow"),
+    list(case = "instrument_lcp_mst_s0", suffix = "instrument_lcp_mst_s0_elow")
+)
+
+main <- function() {
+
+    source(file.path(here::here(), "code", "config.R"), echo = FALSE)
+    source(file.path(dir_code, "base", "utils.R"), echo = FALSE)
+
+    message("\n", strrep("=", 72))
+    message("06_merge_ma_into_panel.R  |  merge MA into wide panel")
+    message(strrep("=", 72))
+
+    panel_path <- file.path(dir_derived_panel,
+                            "departments_wide_panel.parquet")
+    stopifnot(file.exists(panel_path))
+    panel <- arrow::read_parquet(panel_path)
+    panel <- ensure_geolev2_char(panel)
+    message(sprintf("[panel] Starting panel: %d × %d", nrow(panel), ncol(panel)))
+
+    # Drop any pre-existing logMA_* or chg_logMA_* columns so the merge is
+    # idempotent if the script re-runs.
+    drop <- grep("^(logMA_|chg_logMA_)", names(panel), value = TRUE)
+    if (length(drop)) {
+        message(sprintf("[panel] Removing %d stale MA columns: %s",
+                        length(drop), paste(drop, collapse = ", ")))
+        panel <- panel[, setdiff(names(panel), drop)]
+    }
+
+    # Merge each MA case
+    for (spec in ma_cases_spec) {
+        panel <- merge_one_case(panel, spec$case, spec$suffix)
+    }
+
+    # Add change variables
+    panel <- add_change_vars(panel)
+
+    # Save + manifest
+    save_and_manifest(panel)
+
+    message(strrep("=", 72))
+    message("06_merge_ma_into_panel.R  |  Complete.")
+    message(strrep("=", 72), "\n")
+}
+
+# ---------------------------------------------------------------------------
+# Merge a single MA case into the panel
+# ---------------------------------------------------------------------------
+merge_one_case <- function(panel, case, suffix) {
+    path <- file.path(dir_derived_ma, sprintf("ma_%s.parquet", case))
+    stopifnot(file.exists(path))
+    ma <- arrow::read_parquet(path)
+    ma <- ensure_geolev2_char(ma)
+
+    # Recode logMA = -Inf to NA (disconnected districts)
+    n_neginf <- sum(!is.finite(ma$logMA) & ma$logMA < 0)
+    if (n_neginf > 0) {
+        message(sprintf(
+            "[panel] %-25s  %d districts with logMA=-Inf recoded to NA",
+            case, n_neginf
+        ))
+        ma$logMA[!is.finite(ma$logMA) & ma$logMA < 0] <- NA
+    }
+    # logMA = +Inf (shouldn't happen but handle it): NA as well
+    ma$logMA[is.infinite(ma$logMA) & ma$logMA > 0] <- NA
+
+    # Rename logMA column and drop the raw MA column (memory)
+    keep <- data.frame(
+        geolev2 = ma$geolev2,
+        logMA   = ma$logMA
+    )
+    names(keep)[names(keep) == "logMA"] <- paste0("logMA_", suffix)
+
+    n_before <- nrow(panel)
+    panel <- merge(panel, keep, by = "geolev2", all.x = TRUE)
+    stopifnot(nrow(panel) == n_before)
+    message(sprintf("[panel] Merged %s as logMA_%s", case, suffix))
+    panel
+}
+
+# ---------------------------------------------------------------------------
+# Build change variables
+# ---------------------------------------------------------------------------
+add_change_vars <- function(panel) {
+    base <- "logMA_actual_1960_s0_elow"
+    pairs <- list(
+        list(post = "logMA_actual_1986_s0_elow",
+             out  = "chg_logMA_86_60_s0_elow"),
+        list(post = "logMA_instrument_stu_s0_elow",
+             out  = "chg_logMA_stu_s0_elow"),
+        list(post = "logMA_instrument_lcp_mst_s0_elow",
+             out  = "chg_logMA_lcp_mst_s0_elow")
+    )
+    for (p in pairs) {
+        stopifnot(base %in% names(panel), p$post %in% names(panel))
+        panel[[p$out]] <- panel[[p$post]] - panel[[base]]
+        n_valid <- sum(!is.na(panel[[p$out]]))
+        mn <- mean(panel[[p$out]], na.rm = TRUE)
+        sdv <- sd(panel[[p$out]], na.rm = TRUE)
+        message(sprintf("[panel] %-28s  N=%d  mean=%+.3f  sd=%.3f",
+                        p$out, n_valid, mn, sdv))
+    }
+    panel
+}
+
+# ---------------------------------------------------------------------------
+# Save and update manifest
+# ---------------------------------------------------------------------------
+save_and_manifest <- function(panel) {
+    panel <- panel[order(panel$geolev2), ]
+    stopifnot(!any(duplicated(panel$geolev2)))
+
+    out_path <- file.path(dir_derived_panel,
+                          "departments_wide_panel.parquet")
+    arrow::write_parquet(panel, out_path)
+    message(sprintf("[panel] Saved: %s (%d × %d)",
+                    out_path, nrow(panel), ncol(panel)))
+
+    # Update manifest
+    log_path <- file.path(dir_derived_panel, "data_file_manifest.log")
+    sink(log_path)
+    on.exit(sink(), add = TRUE)
+    cat("Data file manifest — 05_build_panel.R + 06_merge_ma_into_panel.R\n")
+    cat(sprintf("Regenerated: %s\n", Sys.time()))
+    cat(sprintf("rootdir: %s\n\n", rootdir))
+    cat(strrep("=", 60), "\n")
+    cat("FILE: departments_wide_panel.parquet\n")
+    cat(strrep("=", 60), "\n")
+    cat(sprintf("Rows: %d\nColumns: %d\nKey: geolev2\n\n",
+                nrow(panel), ncol(panel)))
+
+    cat("Summary of every variable:\n")
+    for (v in names(panel)) {
+        if (v == "geolev2") next
+        vals <- panel[[v]]
+        if (!is.numeric(vals)) {
+            cat(sprintf("  %-32s (class=%s, n_unique=%d, NA=%d)\n",
+                        v, class(vals)[1],
+                        length(unique(vals)), sum(is.na(vals))))
+            next
+        }
+        n_na <- sum(is.na(vals))
+        n_ok <- sum(!is.na(vals))
+        if (n_ok == 0) {
+            cat(sprintf("  %-32s  ALL NA\n", v))
+            next
+        }
+        cat(sprintf(
+            "  %-32s N=%d  mean=%.3g  sd=%.3g  min=%.3g  max=%.3g  NA=%d\n",
+            v, n_ok,
+            mean(vals, na.rm = TRUE), sd(vals, na.rm = TRUE),
+            min(vals, na.rm = TRUE), max(vals, na.rm = TRUE),
+            n_na
+        ))
+    }
+
+    message(sprintf("[panel] Manifest: %s", log_path))
+}
+
+main()

--- a/data/derived/05_panel/data_file_manifest.log
+++ b/data/derived/05_panel/data_file_manifest.log
@@ -1,5 +1,5 @@
 Data file manifest — 05_build_panel.R + 06_merge_ma_into_panel.R
-Regenerated: 2026-05-09 19:21:24.56438
+Regenerated: 2026-05-09 19:33:46.528287
 rootdir: /Users/diegogp/Desktop/Diego/Trains/new_repo
 
 ============================================================ 
@@ -8,6 +8,15 @@ FILE: departments_wide_panel.parquet
 Rows: 312
 Columns: 125
 Key: geolev2
+
+NOTE ON logMA/chg_logMA COLUMNS:
+  Tierra del Fuego districts (32094001, 32094002) are NA in all
+  land-only logMA columns (actual_*, instrument_stu) because they
+  are disconnected from the mainland on the Phase 1 land-only cost
+  surface. Phase 2 navigation will reconnect them via sea routes.
+  The instrument_lcp_mst column has values for them because the
+  LCP-MST hypothetical network was routed on a Faber cost surface
+  that treats water as passable (25x baseline), not infinite.
 
 Summary of every variable:
   area_km2                         N=312  mean=8.14e+03  sd=1.18e+04  min=26.8  max=8.5e+04  NA=0

--- a/data/derived/05_panel/data_file_manifest.log
+++ b/data/derived/05_panel/data_file_manifest.log
@@ -1,129 +1,136 @@
-Data file manifest — 05_build_panel.R
-Generated: 2026-05-09 17:43:42.373792
+Data file manifest — 05_build_panel.R + 06_merge_ma_into_panel.R
+Regenerated: 2026-05-09 19:21:24.56438
 rootdir: /Users/diegogp/Desktop/Diego/Trains/new_repo
 
 ============================================================ 
 FILE: departments_wide_panel.parquet
 ============================================================ 
 Rows: 312
-Columns: 118
+Columns: 125
 Key: geolev2
 
 Summary of every variable:
-  area_km2                       N=312  mean=8.14e+03  sd=1.18e+04  min=26.8  max=8.5e+04  NA=0
-  elev_mean                      N=312  mean=418  sd=689  min=4.01  max=4e+03  NA=0
-  rugged_mea                     N=312  mean=5.82e+04  sd=9.29e+04  min=3.63e+03  max=5.87e+05  NA=0
-  wheat                          N=312  mean=2.72e+03  sd=1.63e+03  min=0.142  max=7.32e+03  NA=0
-  preCal                         N=312  mean=3.38e+03  sd=1.79e+03  min=0  max=5.19e+03  NA=0
-  postCal                        N=312  mean=2.04e+03  sd=1.01e+03  min=0  max=3.11e+03  NA=0
-  dist_to_BA                     N=312  mean=669  sd=436  min=5.11  max=2.32e+03  NA=0
-  elev_mean_std                  N=312  mean=1.67e-16  sd=1  min=-0.602  max=5.2  NA=0
-  rugged_mea_std                 N=312  mean=-3.61e-17  sd=1  min=-0.587  max=5.7  NA=0
-  wheat_std                      N=312  mean=3.27e-17  sd=1  min=-1.67  max=2.83  NA=0
-  preCal_std                     N=312  mean=-2.78e-16  sd=1  min=-1.89  max=1.01  NA=0
-  postCal_std                    N=312  mean=-1.82e-16  sd=1  min=-2.02  max=1.05  NA=0
-  dist_to_BA_std                 N=312  mean=-9.39e-17  sd=1  min=-1.52  max=3.79  NA=0
-  pop_1970                       N=312  mean=7.48e+04  sd=1.91e+05  min=4.75e+03  max=2.91e+06  NA=0
-  urbpop_1970                     ALL NA
-  college_1970                   N=312  mean=0.0067  sd=0.00733  min=0  max=0.0497  NA=0
-  secondary_1970                 N=312  mean=0.0476  sd=0.0308  min=0  max=0.194  NA=0
-  mig5_1970                      N=312  mean=0.0655  sd=0.0564  min=0  max=0.432  NA=0
-  empstat_1_1970                 N=312  mean=0.487  sd=0.0477  min=0.36  max=0.75  NA=0
-  empstat_2_1970                 N=312  mean=0.00961  sd=0.00642  min=0  max=0.0438  NA=0
-  empstat_3_1970                 N=312  mean=0.504  sd=0.0462  min=0.237  max=0.62  NA=0
-  pop_1980                       N=312  mean=1.03e+05  sd=2.63e+05  min=8.49e+03  max=3.98e+06  NA=0
-  urbpop_1980                    N=312  mean=7.29e+04  sd=2e+05  min=0  max=2.79e+06  NA=0
-  college_1980                   N=312  mean=0.0117  sd=0.0116  min=0  max=0.102  NA=0
-  secondary_1980                 N=312  mean=0.0843  sd=0.0454  min=0.0108  max=0.268  NA=0
-  mig5_1980                      N=310  mean=0.113  sd=0.136  min=0.0113  max=0.925  NA=2
-  empstat_1_1980                 N=312  mean=0.495  sd=0.0807  min=0.3  max=0.9  NA=0
-  empstat_2_1980                 N=312  mean=0.00687  sd=0.00338  min=0.000497  max=0.0258  NA=0
-  empstat_3_1980                 N=312  mean=0.498  sd=0.0806  min=0.0914  max=0.692  NA=0
-  pop_1991                       N=312  mean=1.15e+05  sd=2.64e+05  min=1.48e+04  max=3.77e+06  NA=0
-  urbpop_1991                    N=312  mean=8.97e+04  sd=2.16e+05  min=0  max=2.84e+06  NA=0
-  college_1991                   N=312  mean=0.0148  sd=0.0131  min=0.000388  max=0.0977  NA=0
-  secondary_1991                 N=312  mean=0.125  sd=0.0573  min=0.0258  max=0.375  NA=0
-  mig5_1991                      N=312  mean=0.182  sd=0.103  min=0.0266  max=0.672  NA=0
-  empstat_1_1991                 N=312  mean=0.548  sd=0.0708  min=0.179  max=0.872  NA=0
-  empstat_2_1991                 N=312  mean=0.0252  sd=0.0114  min=0.00341  max=0.057  NA=0
-  empstat_3_1991                 N=312  mean=0.427  sd=0.0679  min=0.123  max=0.814  NA=0
-  pop_2001                       N=312  mean=1.16e+05  sd=2.25e+05  min=1.50e+04  max=2.77e+06  NA=0
-  urbpop_2001                    N=312  mean=1.04e+05  sd=2.25e+05  min=2.14e+03  max=2.77e+06  NA=0
-  college_2001                   N=312  mean=0.0236  sd=0.0199  min=0.000469  max=0.155  NA=0
-  secondary_2001                 N=312  mean=0.188  sd=0.0765  min=0.0357  max=0.513  NA=0
-  mig5_2001                      N=312  mean=0.039  sd=0.0268  min=0.00918  max=0.234  NA=0
-  empstat_1_2001                 N=312  mean=0.413  sd=0.0596  min=0.195  max=0.586  NA=0
-  empstat_2_2001                 N=312  mean=0.14  sd=0.0378  min=0.0466  max=0.259  NA=0
-  empstat_3_2001                 N=312  mean=0.447  sd=0.0515  min=0.304  max=0.671  NA=0
-  pop_2010                       N=312  mean=1.27e+05  sd=2.43e+05  min=2.01e+04  max=2.82e+06  NA=0
-  urbpop_2010                     ALL NA
-  college_2010                   N=312  mean=0.0302  sd=0.0239  min=0.000896  max=0.183  NA=0
-  secondary_2010                 N=312  mean=0.217  sd=0.0688  min=0.0587  max=0.503  NA=0
-  mig5_2010                       ALL NA
-  empstat_1_2010                 N=312  mean=0.579  sd=0.0666  min=0.298  max=0.747  NA=0
-  empstat_2_2010                 N=312  mean=0.0329  sd=0.0102  min=0.00637  max=0.0599  NA=0
-  empstat_3_2010                 N=312  mean=0.388  sd=0.0696  min=0.218  max=0.66  NA=0
-  pop_1947                       N=235  mean=4.71e+04  sd=5.79e+04  min=4.40e+03  max=5.3e+05  NA=77
-  urbpop_1947                    N=235  mean=2.86e+04  sd=5.4e+04  min=2e+03  max=4.87e+05  NA=77
-  pop_imputed_1947               N=240  mean=4.67e+04  sd=5.74e+04  min=4.40e+03  max=5.3e+05  NA=72
-  urbpop_imputed_1947            N=240  mean=2.82e+04  sd=5.36e+04  min=2e+03  max=4.87e+05  NA=72
-  note_1947                      N=240  mean=0.0208  sd=0.143  min=0  max=1  NA=72
-  pop_1960                       N=309  mean=4.39e+04  sd=7.85e+04  min=1.07e+03  max=6.63e+05  NA=3
-  urbpop_1960                    N=309  mean=3.82e+04  sd=7.86e+04  min=0  max=6.5e+05  NA=3
-  rur_1960                       N=309  mean=5.67e+03  sd=5.36e+03  min=0  max=3.03e+04  NA=3
-  nexp_1960                      N=306  mean=1.54e+03  sd=1.33e+03  min=3  max=1.01e+04  NA=6
-  areatot_ha_1960                N=306  mean=5.69e+05  sd=1.15e+06  min=3  max=1.3e+07  NA=6
-  nexp_1988                      N=300  mean=1.23e+03  sd=1.12e+03  min=5  max=7.91e+03  NA=12
-  areatot_ha_1988                N=300  mean=5.76e+05  sd=1.16e+06  min=5.6  max=1.39e+07  NA=12
-  nestab_1954                    N=310  mean=356  sd=594  min=3  max=6.16e+03  NA=2
-  nemp_1954                      N=310  mean=318  sd=909  min=1  max=1.02e+04  NA=2
-  nobr_1954                      N=310  mean=2.28e+03  sd=5.46e+03  min=8  max=5.3e+04  NA=2
-  npers_1954                      ALL NA
-  massal_1954                    N=310  mean=2.84e+04  sd=7.91e+04  min=113  max=8.86e+05  NA=2
-  valprod_1954                   N=310  mean=1.53e+05  sd=4.47e+05  min=208  max=5.62e+06  NA=2
-  valprod1_1954                  N=310  mean=1.53e+05  sd=4.47e+05  min=208  max=5.62e+06  NA=2
-  valprod2_1954                   ALL NA
-  nestab_1985                    N=311  mean=300  sd=566  min=3  max=4.96e+03  NA=1
-  nemp_1985                       ALL NA
-  nobr_1985                       ALL NA
-  npers_1985                     N=311  mean=3.12e+03  sd=7e+03  min=0  max=5.18e+04  NA=1
-  massal_1985                    N=311  mean=1.38e+06  sd=3.33e+06  min=0  max=2.47e+07  NA=1
-  valprod_1985                   N=311  mean=1.12e+07  sd=2.89e+07  min=5.72e+03  max=3.06e+08  NA=1
-  valprod1_1985                  N=311  mean=1.12e+07  sd=2.89e+07  min=5.72e+03  max=3.06e+08  NA=1
-  valprod2_1985                  N=311  mean=5.41e+05  sd=1.41e+06  min=0  max=1.06e+07  NA=1
-  status1979_1                   N=312  mean=107  sd=118  min=0  max=779  NA=0
-  status1979_2                   N=312  mean=17.8  sd=42.1  min=0  max=300  NA=0
-  status1979_3                   N=312  mean=12.5  sd=28  min=0  max=167  NA=0
-  studied_0                      N=312  mean=70.3  sd=82.3  min=0  max=420  NA=0
-  studied_1                      N=312  mean=66.8  sd=97.9  min=0  max=766  NA=0
-  tot_rails_1986                 N=312  mean=107  sd=118  min=0  max=779  NA=0
-  tot_rails_1960                 N=312  mean=137  sd=140  min=0  max=779  NA=0
-  chg_tot_rails_86_60            N=312  mean=-30.4  sd=56  min=-306  max=0  NA=0
-  studied_larkin                 N=312  mean=66.8  sd=97.9  min=0  max=766  NA=0
-  share_studied_larkin           N=282  mean=0.437  sd=0.375  min=0  max=1  NA=30
-  roadsall_type_1                N=309  mean=83.5  sd=139  min=0  max=1.08e+03  NA=3
-  roadsall_type_2                N=309  mean=33.7  sd=82.6  min=0  max=921  NA=3
-  roadsall_type_3                N=309  mean=136  sd=194  min=0  max=1.88e+03  NA=3
-  roadsall_type_4                N=309  mean=5.84  sd=17.4  min=0  max=180  NA=3
-  roadsall_type_5                N=309  mean=5.55  sd=27  min=0  max=304  NA=3
-  roadsall_type_6                N=309  mean=7.99  sd=21.7  min=0  max=229  NA=3
-  roadsall_type_7                N=309  mean=3.2  sd=11.5  min=0  max=123  NA=3
-  pav_and_grav_1954              N=309  mean=89  sd=149  min=0  max=1.13e+03  NA=3
-  pav_and_grav_1970              N=309  mean=123  sd=198  min=0  max=1.73e+03  NA=3
-  pav_and_grav_1986              N=309  mean=258  sd=351  min=3.71  max=3.61e+03  NA=3
-  chg_pav_and_grav_86_54         N=309  mean=169  sd=248  min=0  max=2.51e+03  NA=3
-  chg_pav_and_grav_70_54         N=309  mean=33.7  sd=82.6  min=0  max=921  NA=3
-  chg_pav_and_grav_86_70         N=309  mean=136  sd=194  min=0  max=1.88e+03  NA=3
-  connected_pav_grav_86_54       N=309  mean=0.265  sd=0.442  min=0  max=1  NA=3
-  hypo_LCP_kms                   N=312  mean=5.18e+03  sd=8.41e+03  min=0  max=7.94e+04  NA=0
-  hypo_LCP_MST_kms               N=312  mean=36.8  sd=62.6  min=0  max=301  NA=0
-  hypo_EUC_kms                   N=312  mean=3.99e+03  sd=5.78e+03  min=0  max=5.7e+04  NA=0
-  hypo_EUC_MST_kms               N=312  mean=22.5  sd=44.6  min=0  max=373  NA=0
-  chg_log_pop_91_60              N=309  mean=1.01  sd=0.525  min=0.0508  max=3.1  NA=3
-  chg_log_urbpop_91_60           N=284  mean=0.858  sd=0.504  min=-0.0717  max=2.99  NA=28
-  chg_log_placebo_pop_60_47      N=235  mean=-0.0908  sd=0.574  min=-2.37  max=1.69  NA=77
-  chg_log_nestab_85_54           N=310  mean=-0.216  sd=0.675  min=-2.43  max=4.24  NA=2
-  chg_log_massal_85_54           N=309  mean=3.53  sd=1.38  min=-1.7  max=7.21  NA=3
-  chg_log_valprod_85_54          N=310  mean=3.89  sd=1.37  min=-1.97  max=9.75  NA=2
-  chg_log_nexp_88_60             N=297  mean=-0.254  sd=0.497  min=-3.35  max=2.29  NA=15
-  chg_log_areatot_ha_88_60       N=297  mean=0.0766  sd=0.656  min=-3.22  max=3.76  NA=15
+  area_km2                         N=312  mean=8.14e+03  sd=1.18e+04  min=26.8  max=8.5e+04  NA=0
+  elev_mean                        N=312  mean=418  sd=689  min=4.01  max=4e+03  NA=0
+  rugged_mea                       N=312  mean=5.82e+04  sd=9.29e+04  min=3.63e+03  max=5.87e+05  NA=0
+  wheat                            N=312  mean=2.72e+03  sd=1.63e+03  min=0.142  max=7.32e+03  NA=0
+  preCal                           N=312  mean=3.38e+03  sd=1.79e+03  min=0  max=5.19e+03  NA=0
+  postCal                          N=312  mean=2.04e+03  sd=1.01e+03  min=0  max=3.11e+03  NA=0
+  dist_to_BA                       N=312  mean=669  sd=436  min=5.11  max=2.32e+03  NA=0
+  elev_mean_std                    N=312  mean=1.67e-16  sd=1  min=-0.602  max=5.2  NA=0
+  rugged_mea_std                   N=312  mean=-3.61e-17  sd=1  min=-0.587  max=5.7  NA=0
+  wheat_std                        N=312  mean=3.27e-17  sd=1  min=-1.67  max=2.83  NA=0
+  preCal_std                       N=312  mean=-2.78e-16  sd=1  min=-1.89  max=1.01  NA=0
+  postCal_std                      N=312  mean=-1.82e-16  sd=1  min=-2.02  max=1.05  NA=0
+  dist_to_BA_std                   N=312  mean=-9.39e-17  sd=1  min=-1.52  max=3.79  NA=0
+  pop_1970                         N=312  mean=7.48e+04  sd=1.91e+05  min=4.75e+03  max=2.91e+06  NA=0
+  urbpop_1970                       ALL NA
+  college_1970                     N=312  mean=0.0067  sd=0.00733  min=0  max=0.0497  NA=0
+  secondary_1970                   N=312  mean=0.0476  sd=0.0308  min=0  max=0.194  NA=0
+  mig5_1970                        N=312  mean=0.0655  sd=0.0564  min=0  max=0.432  NA=0
+  empstat_1_1970                   N=312  mean=0.487  sd=0.0477  min=0.36  max=0.75  NA=0
+  empstat_2_1970                   N=312  mean=0.00961  sd=0.00642  min=0  max=0.0438  NA=0
+  empstat_3_1970                   N=312  mean=0.504  sd=0.0462  min=0.237  max=0.62  NA=0
+  pop_1980                         N=312  mean=1.03e+05  sd=2.63e+05  min=8.49e+03  max=3.98e+06  NA=0
+  urbpop_1980                      N=312  mean=7.29e+04  sd=2e+05  min=0  max=2.79e+06  NA=0
+  college_1980                     N=312  mean=0.0117  sd=0.0116  min=0  max=0.102  NA=0
+  secondary_1980                   N=312  mean=0.0843  sd=0.0454  min=0.0108  max=0.268  NA=0
+  mig5_1980                        N=310  mean=0.113  sd=0.136  min=0.0113  max=0.925  NA=2
+  empstat_1_1980                   N=312  mean=0.495  sd=0.0807  min=0.3  max=0.9  NA=0
+  empstat_2_1980                   N=312  mean=0.00687  sd=0.00338  min=0.000497  max=0.0258  NA=0
+  empstat_3_1980                   N=312  mean=0.498  sd=0.0806  min=0.0914  max=0.692  NA=0
+  pop_1991                         N=312  mean=1.15e+05  sd=2.64e+05  min=1.48e+04  max=3.77e+06  NA=0
+  urbpop_1991                      N=312  mean=8.97e+04  sd=2.16e+05  min=0  max=2.84e+06  NA=0
+  college_1991                     N=312  mean=0.0148  sd=0.0131  min=0.000388  max=0.0977  NA=0
+  secondary_1991                   N=312  mean=0.125  sd=0.0573  min=0.0258  max=0.375  NA=0
+  mig5_1991                        N=312  mean=0.182  sd=0.103  min=0.0266  max=0.672  NA=0
+  empstat_1_1991                   N=312  mean=0.548  sd=0.0708  min=0.179  max=0.872  NA=0
+  empstat_2_1991                   N=312  mean=0.0252  sd=0.0114  min=0.00341  max=0.057  NA=0
+  empstat_3_1991                   N=312  mean=0.427  sd=0.0679  min=0.123  max=0.814  NA=0
+  pop_2001                         N=312  mean=1.16e+05  sd=2.25e+05  min=1.50e+04  max=2.77e+06  NA=0
+  urbpop_2001                      N=312  mean=1.04e+05  sd=2.25e+05  min=2.14e+03  max=2.77e+06  NA=0
+  college_2001                     N=312  mean=0.0236  sd=0.0199  min=0.000469  max=0.155  NA=0
+  secondary_2001                   N=312  mean=0.188  sd=0.0765  min=0.0357  max=0.513  NA=0
+  mig5_2001                        N=312  mean=0.039  sd=0.0268  min=0.00918  max=0.234  NA=0
+  empstat_1_2001                   N=312  mean=0.413  sd=0.0596  min=0.195  max=0.586  NA=0
+  empstat_2_2001                   N=312  mean=0.14  sd=0.0378  min=0.0466  max=0.259  NA=0
+  empstat_3_2001                   N=312  mean=0.447  sd=0.0515  min=0.304  max=0.671  NA=0
+  pop_2010                         N=312  mean=1.27e+05  sd=2.43e+05  min=2.01e+04  max=2.82e+06  NA=0
+  urbpop_2010                       ALL NA
+  college_2010                     N=312  mean=0.0302  sd=0.0239  min=0.000896  max=0.183  NA=0
+  secondary_2010                   N=312  mean=0.217  sd=0.0688  min=0.0587  max=0.503  NA=0
+  mig5_2010                         ALL NA
+  empstat_1_2010                   N=312  mean=0.579  sd=0.0666  min=0.298  max=0.747  NA=0
+  empstat_2_2010                   N=312  mean=0.0329  sd=0.0102  min=0.00637  max=0.0599  NA=0
+  empstat_3_2010                   N=312  mean=0.388  sd=0.0696  min=0.218  max=0.66  NA=0
+  pop_1947                         N=235  mean=4.71e+04  sd=5.79e+04  min=4.40e+03  max=5.3e+05  NA=77
+  urbpop_1947                      N=235  mean=2.86e+04  sd=5.4e+04  min=2e+03  max=4.87e+05  NA=77
+  pop_imputed_1947                 N=240  mean=4.67e+04  sd=5.74e+04  min=4.40e+03  max=5.3e+05  NA=72
+  urbpop_imputed_1947              N=240  mean=2.82e+04  sd=5.36e+04  min=2e+03  max=4.87e+05  NA=72
+  note_1947                        N=240  mean=0.0208  sd=0.143  min=0  max=1  NA=72
+  pop_1960                         N=309  mean=4.39e+04  sd=7.85e+04  min=1.07e+03  max=6.63e+05  NA=3
+  urbpop_1960                      N=309  mean=3.82e+04  sd=7.86e+04  min=0  max=6.5e+05  NA=3
+  rur_1960                         N=309  mean=5.67e+03  sd=5.36e+03  min=0  max=3.03e+04  NA=3
+  nexp_1960                        N=306  mean=1.54e+03  sd=1.33e+03  min=3  max=1.01e+04  NA=6
+  areatot_ha_1960                  N=306  mean=5.69e+05  sd=1.15e+06  min=3  max=1.3e+07  NA=6
+  nexp_1988                        N=300  mean=1.23e+03  sd=1.12e+03  min=5  max=7.91e+03  NA=12
+  areatot_ha_1988                  N=300  mean=5.76e+05  sd=1.16e+06  min=5.6  max=1.39e+07  NA=12
+  nestab_1954                      N=310  mean=356  sd=594  min=3  max=6.16e+03  NA=2
+  nemp_1954                        N=310  mean=318  sd=909  min=1  max=1.02e+04  NA=2
+  nobr_1954                        N=310  mean=2.28e+03  sd=5.46e+03  min=8  max=5.3e+04  NA=2
+  npers_1954                        ALL NA
+  massal_1954                      N=310  mean=2.84e+04  sd=7.91e+04  min=113  max=8.86e+05  NA=2
+  valprod_1954                     N=310  mean=1.53e+05  sd=4.47e+05  min=208  max=5.62e+06  NA=2
+  valprod1_1954                    N=310  mean=1.53e+05  sd=4.47e+05  min=208  max=5.62e+06  NA=2
+  valprod2_1954                     ALL NA
+  nestab_1985                      N=311  mean=300  sd=566  min=3  max=4.96e+03  NA=1
+  nemp_1985                         ALL NA
+  nobr_1985                         ALL NA
+  npers_1985                       N=311  mean=3.12e+03  sd=7e+03  min=0  max=5.18e+04  NA=1
+  massal_1985                      N=311  mean=1.38e+06  sd=3.33e+06  min=0  max=2.47e+07  NA=1
+  valprod_1985                     N=311  mean=1.12e+07  sd=2.89e+07  min=5.72e+03  max=3.06e+08  NA=1
+  valprod1_1985                    N=311  mean=1.12e+07  sd=2.89e+07  min=5.72e+03  max=3.06e+08  NA=1
+  valprod2_1985                    N=311  mean=5.41e+05  sd=1.41e+06  min=0  max=1.06e+07  NA=1
+  status1979_1                     N=312  mean=107  sd=118  min=0  max=779  NA=0
+  status1979_2                     N=312  mean=17.8  sd=42.1  min=0  max=300  NA=0
+  status1979_3                     N=312  mean=12.5  sd=28  min=0  max=167  NA=0
+  studied_0                        N=312  mean=70.3  sd=82.3  min=0  max=420  NA=0
+  studied_1                        N=312  mean=66.8  sd=97.9  min=0  max=766  NA=0
+  tot_rails_1986                   N=312  mean=107  sd=118  min=0  max=779  NA=0
+  tot_rails_1960                   N=312  mean=137  sd=140  min=0  max=779  NA=0
+  chg_tot_rails_86_60              N=312  mean=-30.4  sd=56  min=-306  max=0  NA=0
+  studied_larkin                   N=312  mean=66.8  sd=97.9  min=0  max=766  NA=0
+  share_studied_larkin             N=282  mean=0.437  sd=0.375  min=0  max=1  NA=30
+  roadsall_type_1                  N=309  mean=83.5  sd=139  min=0  max=1.08e+03  NA=3
+  roadsall_type_2                  N=309  mean=33.7  sd=82.6  min=0  max=921  NA=3
+  roadsall_type_3                  N=309  mean=136  sd=194  min=0  max=1.88e+03  NA=3
+  roadsall_type_4                  N=309  mean=5.84  sd=17.4  min=0  max=180  NA=3
+  roadsall_type_5                  N=309  mean=5.55  sd=27  min=0  max=304  NA=3
+  roadsall_type_6                  N=309  mean=7.99  sd=21.7  min=0  max=229  NA=3
+  roadsall_type_7                  N=309  mean=3.2  sd=11.5  min=0  max=123  NA=3
+  pav_and_grav_1954                N=309  mean=89  sd=149  min=0  max=1.13e+03  NA=3
+  pav_and_grav_1970                N=309  mean=123  sd=198  min=0  max=1.73e+03  NA=3
+  pav_and_grav_1986                N=309  mean=258  sd=351  min=3.71  max=3.61e+03  NA=3
+  chg_pav_and_grav_86_54           N=309  mean=169  sd=248  min=0  max=2.51e+03  NA=3
+  chg_pav_and_grav_70_54           N=309  mean=33.7  sd=82.6  min=0  max=921  NA=3
+  chg_pav_and_grav_86_70           N=309  mean=136  sd=194  min=0  max=1.88e+03  NA=3
+  connected_pav_grav_86_54         N=309  mean=0.265  sd=0.442  min=0  max=1  NA=3
+  hypo_LCP_kms                     N=312  mean=5.18e+03  sd=8.41e+03  min=0  max=7.94e+04  NA=0
+  hypo_LCP_MST_kms                 N=312  mean=36.8  sd=62.6  min=0  max=301  NA=0
+  hypo_EUC_kms                     N=312  mean=3.99e+03  sd=5.78e+03  min=0  max=5.7e+04  NA=0
+  hypo_EUC_MST_kms                 N=312  mean=22.5  sd=44.6  min=0  max=373  NA=0
+  chg_log_pop_91_60                N=309  mean=1.01  sd=0.525  min=0.0508  max=3.1  NA=3
+  chg_log_urbpop_91_60             N=284  mean=0.858  sd=0.504  min=-0.0717  max=2.99  NA=28
+  chg_log_placebo_pop_60_47        N=235  mean=-0.0908  sd=0.574  min=-2.37  max=1.69  NA=77
+  chg_log_nestab_85_54             N=310  mean=-0.216  sd=0.675  min=-2.43  max=4.24  NA=2
+  chg_log_massal_85_54             N=309  mean=3.53  sd=1.38  min=-1.7  max=7.21  NA=3
+  chg_log_valprod_85_54            N=310  mean=3.89  sd=1.37  min=-1.97  max=9.75  NA=2
+  chg_log_nexp_88_60               N=297  mean=-0.254  sd=0.497  min=-3.35  max=2.29  NA=15
+  chg_log_areatot_ha_88_60         N=297  mean=0.0766  sd=0.656  min=-3.22  max=3.76  NA=15
+  logMA_actual_1960_s0_elow        N=310  mean=-49.6  sd=6.42  min=-63.4  max=-29  NA=2
+  logMA_actual_1986_s0_elow        N=310  mean=-47.8  sd=5.38  min=-60.1  max=-29  NA=2
+  logMA_instrument_stu_s0_elow     N=310  mean=-50.9  sd=6.8  min=-64  max=-29  NA=2
+  logMA_instrument_lcp_mst_s0_elow N=312  mean=-50.1  sd=6.1  min=-63.7  max=-30.3  NA=0
+  chg_logMA_86_60_s0_elow          N=310  mean=1.84  sd=2.79  min=-7.21  max=10.6  NA=2
+  chg_logMA_stu_s0_elow            N=310  mean=-1.3  sd=2.25  min=-12.2  max=-3.5e-06  NA=2
+  chg_logMA_lcp_mst_s0_elow        N=310  mean=-0.444  sd=2.56  min=-15.8  max=10.8  NA=2

--- a/data/raw/geo/readme.md
+++ b/data/raw/geo/readme.md
@@ -16,6 +16,7 @@ distance to Buenos Aires, area).
 | `post1500AverageCalories.tif` | Caloric potential post-1500 | Galor & Özak (2016) |
 | `tri.tif` | Terrain Ruggedness Index | Riley et al. (1999), via Puga (diegopuga.org/data/rugged/) |
 | `areas_de_asentamientos_y_edificios_020105.*` | IGN settlements (for BA centroid) | IGN Argentina |
+| `HMI.tif` | Human Mobility Index (potential travel time on land) | Özak (2010, 2018), human-mobility-index.github.io |
 
 ## Citations
 
@@ -35,6 +36,14 @@ Riley, Shawn J., Stephen D. DeGloria, and Robert Elliot. "A Terrain
 Ruggedness Index That Quantifies Topographic Heterogeneity." Intermountain
 Journal of Sciences 5, no. 1-4 (1999): 23–27.
 
+Özak, Ömer. "The Voyage of Homo-Economicus: Some Economic Measures of
+Distance." Department of Economics, Brown University (2010).
+http://omerozak.com/pdf/Ozak_voyage.pdf
+
+Özak, Ömer. "Distance to the Pre-Industrial Technological Frontier and
+Economic Development." Journal of Economic Growth 23, no. 2 (2018):
+175–221. https://doi.org/10.1007/s10887-018-9154-6
+
 ## Notes
 
 - `tri.tif` is the Puga terrain ruggedness index raster (Riley et al. 1999
@@ -42,3 +51,9 @@ Journal of Sciences 5, no. 1-4 (1999): 23–27.
   Downloaded from https://diegopuga.org/data/rugged/ and converted from
   the source txt to GeoTIFF. Global coverage at 30" (~1 km) resolution.
   File size: ~1.5 GB (gitignored).
+- `HMI.tif` is Özak's Human Mobility Index global raster at ~1km cylindrical
+  equal-area projection (ESRI:54034). Values measure potential minimum
+  travel time (hours). Downloaded from
+  https://zenodo.org/records/14285746/files/HMI.tif. File size: ~2.2 GB
+  (gitignored). Used as the off-network walking-cost surface in the tau
+  pipeline.

--- a/data/raw/networks/ports_legacy/README.md
+++ b/data/raw/networks/ports_legacy/README.md
@@ -1,0 +1,27 @@
+# ports_legacy
+
+Salvaged from the old repo before deletion of `Old data/Train/` on 2026-05-09.
+
+## Files
+
+- `ports_id.{shp,shx,dbf,prj}` — IGN ports point shapefile used by the old
+  unit-cost-raster pipeline to seed navigation least-cost paths.
+- `portsCreateShp.py` — Python script that built the shapefile from the
+  imported IGN data.
+- `portsImport.do` — Stata script that imported/cleaned the raw IGN ports
+  list.
+
+## Original location
+
+`Old data/Train/derived/unitcostrasters/{output,code}/`
+
+## Why preserved
+
+Needed for Phase 2 of the tau rebuild (navigation cost layer). Phase 1 is
+land-only so this is not a current blocker, but keeping a local copy avoids
+having to ask Cote to re-share.
+
+## CRS
+
+See `ports_id.prj`. Verify before use — the old pipeline reprojected to
+ESRI:54034 (World Cylindrical Equal Area).

--- a/data/raw/networks/ports_legacy/portsCreateShp.py
+++ b/data/raw/networks/ports_legacy/portsCreateShp.py
@@ -1,0 +1,77 @@
+from qgis.core import *
+from qgis.utils import iface
+import os
+import processing
+from osgeo import gdal
+from qgis.analysis import *
+import os
+import datetime
+from shutil import copyfile
+from PyQt5.QtCore import *
+from qgis.PyQt.QtCore import *
+
+print(datetime.datetime.now())
+
+path = r"D:\cotebelmar\Dropbox\Documents\Economia\__Brown\Research\Train\derived\unitcostrasters\code"
+#path = r"C:\Users\diegog\Desktop\Diego\Train\derived\unitcostrasters\code"
+
+os.chdir(path)
+
+pathInput=path+r"\..\..\..\raw_data"
+pathOutput=path+r"\..\output"
+pathTemp=path+r"\..\temp"
+
+
+uri = "file:///"+pathTemp+"/ports_forgeoref.csv?encoding=%s&delimiter=%s&xField=%s&yField=%s&crs=%s" % ("UTF-8",",", "coordx", "coordy","epsg:4326")
+layer=QgsVectorLayer(uri,"","delimitedtext")
+if not layer.isValid():
+    print ("Layer not loaded")
+if layer.isValid():
+    print ("Layer loaded")
+
+input=layer
+output=pathTemp+r'\\ports_georef_aux.shp'
+parameters={'INPUT':input,'OUTPUT':output}
+processing.run("native:fixgeometries", parameters)
+
+input=output
+output=pathTemp+r"\\ports_georef.shp"
+parameters = {'INPUT':input,'TARGET_CRS':QgsCoordinateReferenceSystem('ESRI:54034'),
+              'OPERATION':'+proj=pipeline +step +proj=unitconvert +xy_in=deg +xy_out=rad +step +proj=cea +lat_ts=0 +lon_0=0 +x_0=0 +y_0=0 +ellps=WGS84',
+              'OUTPUT':output}
+processing.run("native:reprojectlayer", parameters)
+
+uri = "file:///"+pathTemp+"/ports_ign.csv?encoding=%s&delimiter=%s" % ("UTF-8",",")
+layer=QgsVectorLayer(uri,"","delimitedtext")
+if not layer.isValid():
+    print ("Layer not loaded")
+if layer.isValid():
+    print ("Layer loaded")
+
+input=pathInput+r"\\navigation\\puertos_y_muelles\\shp\\puntos_de_puertos_y_muelles_BB005\\puntos_de_puertos_y_muelles_BB005.shp"
+input2=layer
+output=pathTemp+r'\\ports_ign_aux.shp'
+parameters= {'INPUT':input,'FIELD':'gid','INPUT_2':input2,'FIELD_2':'gid','FIELDS_TO_COPY':[],'METHOD':1,'DISCARD_NONMATCHING':True,'PREFIX':'','OUTPUT':output}
+processing.run("native:joinattributestable", parameters)
+
+input=output
+output=pathTemp+r"\\ports_ign.shp"
+parameters = {'INPUT':input,'TARGET_CRS':QgsCoordinateReferenceSystem('ESRI:54034'),
+              'OPERATION':'+proj=pipeline +step +proj=unitconvert +xy_in=deg +xy_out=rad +step +proj=cea +lat_ts=0 +lon_0=0 +x_0=0 +y_0=0 +ellps=WGS84',
+              'OUTPUT':output}
+processing.run("native:reprojectlayer", parameters)
+
+
+input=output
+input2=pathTemp+r"\\ports_georef.shp"
+output=pathTemp+r"\\ports.shp"
+parameters={'LAYERS':[input, input2],'CRS':None,'OUTPUT':output}
+processing.run("native:mergevectorlayers", parameters)
+
+input=output
+output=pathTemp + r"\\ports_id.shp"
+parameters = {'INPUT':input,'FIELD_NAME':'AUTO','START':0,'GROUP_FIELDS':[],'SORT_EXPRESSION':'','SORT_ASCENDING':True,'SORT_NULLS_FIRST':False,'OUTPUT':output}
+processing.run("native:addautoincrementalfield", parameters)
+
+print(datetime.datetime.now())
+os.kill(os.getpid(), 9)

--- a/data/raw/networks/ports_legacy/portsImport.do
+++ b/data/raw/networks/ports_legacy/portsImport.do
@@ -1,0 +1,18 @@
+clear all
+adopath + ../../../lib/stata/gslab_misc/ado
+
+program main
+	import excel using "..\..\..\raw_data\navigation\mainports.xlsx", sheet("consolidado_paramergeIGN") clear first
+	keep if gid !=.
+	keep puerto grupo gid
+	destring gid, replace
+	export delimited "..\temp\ports_ign.csv", replace
+
+	import excel using "..\..\..\raw_data\navigation\mainports.xlsx", sheet("consolidado_paramergeIGN") clear first
+	keep if gid==. & coordx!=. & coordy!=.
+	keep puerto grupo coordx coordy
+
+	export delimited  "..\temp\ports_forgeoref.csv", replace
+end
+
+main

--- a/logs/03a_build_cost_raster.log
+++ b/logs/03a_build_cost_raster.log
@@ -1,0 +1,89 @@
+Warning messages:
+1: package ‘sf’ was built under R version 4.5.2 
+2: package ‘terra’ was built under R version 4.5.2 
+[config.R] rootdir = /Users/diegogp/Desktop/Diego/Trains/new_repo
+[config.R] Configuration loaded successfully.
+
+========================================================================
+03a_build_cost_raster.R  |  Phase 1, land-only, sector 0
+========================================================================
+Cases to build: actual_1960_s0
+
+
+[cost] ==== CASE: actual_1960_s0 ====
+[cost]   Rasterising country polygon (pais.shp)
+[cost]   Rasterising rails (selected subset)
+[cost]     Selected 565 / 565 segments
+[cost]     Rail pixels (value=1): 59254
+[cost]   Rasterising roads (selected subset)
+[cost]     Selected 582 / 1741 segments
+[cost]     Road pixels (value=1): 40777
+[cost]   Projecting HMI to base raster
+[cost]     HMI pixels with value (not NA): 3191580
+[cost]   Combining layers (sector=overall)
+[cost]   Validation OK: rail_only=1.8740 road_only=1.7770 both=1.7770
+[cost]   Cost summary: min=1.777  mean=140.83  max=773.11  N=1915855
+[cost]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/01_cost_rasters/ucost_actual_1960_s0.tif
+========================================================================
+03a_build_cost_raster.R  |  Complete.
+========================================================================
+
+Warning messages:
+1: package ‘sf’ was built under R version 4.5.2 
+2: package ‘terra’ was built under R version 4.5.2 
+[config.R] rootdir = /Users/diegogp/Desktop/Diego/Trains/new_repo
+[config.R] Configuration loaded successfully.
+
+========================================================================
+03a_build_cost_raster.R  |  Phase 1, land-only, sector 0
+========================================================================
+Cases to build: actual_1986_s0, instrument_stu_s0, instrument_lcp_mst_s0
+
+
+[cost] ==== CASE: actual_1986_s0 ====
+[cost]   Rasterising country polygon (pais.shp)
+[cost]   Rasterising rails (selected subset)
+[cost]     Selected 424 / 565 segments
+[cost]     Rail pixels (value=1): 46250
+[cost]   Rasterising roads (selected subset)
+[cost]     Selected 1506 / 1741 segments
+[cost]     Road pixels (value=1): 111456
+[cost]   Projecting HMI to base raster
+[cost]     HMI pixels with value (not NA): 3191580
+[cost]   Combining layers (sector=overall)
+[cost]   Validation OK: rail_only=1.8740 road_only=1.7770 both=1.7770
+[cost]   Cost summary: min=1.777  mean=137.02  max=773.11  N=1916005
+[cost]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/01_cost_rasters/ucost_actual_1986_s0.tif
+
+[cost] ==== CASE: instrument_stu_s0 ====
+[cost]   Rasterising country polygon (pais.shp)
+[cost]   Rasterising rails (selected subset)
+[cost]     Selected 328 / 565 segments
+[cost]     Rail pixels (value=1): 30521
+[cost]   Rasterising roads (selected subset)
+[cost]     Selected 582 / 1741 segments
+[cost]     Road pixels (value=1): 40777
+[cost]   Projecting HMI to base raster
+[cost]     HMI pixels with value (not NA): 3191580
+[cost]   Combining layers (sector=overall)
+[cost]   Validation OK: rail_only=1.8740 road_only=1.7770 both=1.7770
+[cost]   Cost summary: min=1.777  mean=142.95  max=773.11  N=1915827
+[cost]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/01_cost_rasters/ucost_instrument_stu_s0.tif
+
+[cost] ==== CASE: instrument_lcp_mst_s0 ====
+[cost]   Rasterising country polygon (pais.shp)
+[cost]   Rasterising rails (selected subset)
+[cost]     Selected 565 / 565 segments
+[cost]     Rail pixels (value=1): 59254
+[cost]   Rasterising hypothetical LCP-MST road network
+[cost]     Hypo road pixels (value=1): 15148
+[cost]   Projecting HMI to base raster
+[cost]     HMI pixels with value (not NA): 3191580
+[cost]   Combining layers (sector=overall)
+[cost]   Validation OK: rail_only=1.8740 road_only=1.7770 both=1.7770
+[cost]   Cost summary: min=1.777  mean=142.03  max=773.11  N=1915872
+[cost]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/01_cost_rasters/ucost_instrument_lcp_mst_s0.tif
+========================================================================
+03a_build_cost_raster.R  |  Complete.
+========================================================================
+

--- a/logs/03b_transition_grids.log
+++ b/logs/03b_transition_grids.log
@@ -1,0 +1,62 @@
+Warning messages:
+1: package ‘sp’ was built under R version 4.5.2 
+2: package ‘igraph’ was built under R version 4.5.2 
+[config.R] rootdir = /Users/diegogp/Desktop/Diego/Trains/new_repo
+[config.R] Configuration loaded successfully.
+
+========================================================================
+03b_transition_grids.R  |  cost raster → gdistance transition
+========================================================================
+Cases to process: actual_1960_s0
+
+
+[trans] ==== CASE: actual_1960_s0 ====
+[trans]   Reading /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/01_cost_rasters/ucost_actual_1960_s0.tif
+[trans]   Building 8-neighbour transition (1/mean(cost))
+[trans]   transition() took 33.2 s
+[trans]   Applying geoCorrection (diagonal edges)
+[trans]   geoCorrection() took 3.8 s
+[trans]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/02_transition_grids/transition_actual_1960_s0.rds
+========================================================================
+03b_transition_grids.R  |  Complete.
+========================================================================
+
+Warning messages:
+1: package ‘sp’ was built under R version 4.5.2 
+2: package ‘igraph’ was built under R version 4.5.2 
+[config.R] rootdir = /Users/diegogp/Desktop/Diego/Trains/new_repo
+[config.R] Configuration loaded successfully.
+
+========================================================================
+03b_transition_grids.R  |  cost raster → gdistance transition
+========================================================================
+Cases to process: actual_1986_s0, instrument_stu_s0, instrument_lcp_mst_s0
+
+
+[trans] ==== CASE: actual_1986_s0 ====
+[trans]   Reading /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/01_cost_rasters/ucost_actual_1986_s0.tif
+[trans]   Building 8-neighbour transition (1/mean(cost))
+[trans]   transition() took 28.8 s
+[trans]   Applying geoCorrection (diagonal edges)
+[trans]   geoCorrection() took 3.3 s
+[trans]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/02_transition_grids/transition_actual_1986_s0.rds
+
+[trans] ==== CASE: instrument_stu_s0 ====
+[trans]   Reading /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/01_cost_rasters/ucost_instrument_stu_s0.tif
+[trans]   Building 8-neighbour transition (1/mean(cost))
+[trans]   transition() took 27.1 s
+[trans]   Applying geoCorrection (diagonal edges)
+[trans]   geoCorrection() took 2.4 s
+[trans]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/02_transition_grids/transition_instrument_stu_s0.rds
+
+[trans] ==== CASE: instrument_lcp_mst_s0 ====
+[trans]   Reading /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/01_cost_rasters/ucost_instrument_lcp_mst_s0.tif
+[trans]   Building 8-neighbour transition (1/mean(cost))
+[trans]   transition() took 27.2 s
+[trans]   Applying geoCorrection (diagonal edges)
+[trans]   geoCorrection() took 2.7 s
+[trans]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/02_transition_grids/transition_instrument_lcp_mst_s0.rds
+========================================================================
+03b_transition_grids.R  |  Complete.
+========================================================================
+

--- a/logs/03c_compute_taus.log
+++ b/logs/03c_compute_taus.log
@@ -1,0 +1,76 @@
+Warning messages:
+1: package ‘sf’ was built under R version 4.5.2 
+2: package ‘sp’ was built under R version 4.5.2 
+3: package ‘igraph’ was built under R version 4.5.2 
+[config.R] rootdir = /Users/diegogp/Desktop/Diego/Trains/new_repo
+[config.R] Configuration loaded successfully.
+
+========================================================================
+03c_compute_taus.R  |  Dijkstra on 312 district centroids
+========================================================================
+Cases: actual_1960_s0
+
+[tau] Loading and centroid-ing district polygons
+[tau]   312 districts loaded
+
+[tau] ==== CASE: actual_1960_s0 ====
+[tau]   Reading /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/02_transition_grids/transition_actual_1960_s0.rds
+[tau]   Running gdistance::costDistance (312x312 Dijkstra)
+[tau]   costDistance() took 184.0 s
+Error in if (max_asym > 1e-06) { : missing value where TRUE/FALSE needed
+Calls: main -> compute_one_case
+In addition: Warning message:
+st_centroid assumes attributes are constant over geometries 
+Execution halted
+Warning messages:
+1: package ‘sf’ was built under R version 4.5.2 
+2: package ‘sp’ was built under R version 4.5.2 
+3: package ‘igraph’ was built under R version 4.5.2 
+[config.R] rootdir = /Users/diegogp/Desktop/Diego/Trains/new_repo
+[config.R] Configuration loaded successfully.
+
+========================================================================
+03c_compute_taus.R  |  Dijkstra on 312 district centroids
+========================================================================
+Cases: actual_1986_s0, instrument_stu_s0, instrument_lcp_mst_s0
+
+[tau] Loading and centroid-ing district polygons
+[tau]   312 districts loaded
+
+[tau] ==== CASE: actual_1986_s0 ====
+[tau]   Reading /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/02_transition_grids/transition_actual_1986_s0.rds
+[tau]   Running gdistance::costDistance (312x312 Dijkstra)
+[tau]   costDistance() took 293.8 s
+[tau]   1240 Inf entries (disconnected; e.g. TdF on land-only surface)
+[tau]   eyeball BA (32002001) → Córdoba (32014014): τ = 1639445.2
+[tau]   τ summary (finite): min=9504.489  median=3308872.3  mean=3853716.1  max=26585406.4  (Inf pairs: 620)
+[tau]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/03_taus/tau_actual_1986_s0.parquet (48516 rows)
+
+[tau] ==== CASE: instrument_stu_s0 ====
+[tau]   Reading /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/02_transition_grids/transition_instrument_stu_s0.rds
+[tau]   Running gdistance::costDistance (312x312 Dijkstra)
+[tau]   costDistance() took 215.1 s
+[tau]   1240 Inf entries (disconnected; e.g. TdF on land-only surface)
+[tau]   eyeball BA (32002001) → Córdoba (32014014): τ = 2964422.0
+[tau]   τ summary (finite): min=9504.489  median=7145695.4  mean=11184987.3  max=90172896.9  (Inf pairs: 620)
+[tau]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/03_taus/tau_instrument_stu_s0.parquet (48516 rows)
+
+[tau] ==== CASE: instrument_lcp_mst_s0 ====
+[tau]   Reading /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/02_transition_grids/transition_instrument_lcp_mst_s0.rds
+[tau]   Running gdistance::costDistance (312x312 Dijkstra)
+[tau]   costDistance() took 214.0 s
+[tau]   eyeball BA (32002001) → Córdoba (32014014): τ = 3060435.9
+[tau]   τ summary (finite): min=13073.774  median=5125550.0  mean=8325550.2  max=74653151.5  (Inf pairs: 0)
+[tau]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/03_taus/tau_instrument_lcp_mst_s0.parquet (48516 rows)
+========================================================================
+03c_compute_taus.R  |  Complete.
+========================================================================
+
+Warning messages:
+1: st_centroid assumes attributes are constant over geometries 
+2: In compute_one_case(case, centroids) :
+  [tau] Asymmetry > 1e-6: max |τ_ij - τ_ji| = 1.64658e-06
+3: In compute_one_case(case, centroids) :
+  [tau] Asymmetry > 1e-6: max |τ_ij - τ_ji| = 7.48783e-06
+4: In compute_one_case(case, centroids) :
+  [tau] Asymmetry > 1e-6: max |τ_ij - τ_ji| = 4.4331e-06

--- a/logs/04_market_access.log
+++ b/logs/04_market_access.log
@@ -1,0 +1,45 @@
+[config.R] rootdir = /Users/diegogp/Desktop/Diego/Trains/new_repo
+[config.R] Configuration loaded successfully.
+
+========================================================================
+04_market_access.R  |  MA_i = sum_{j≠i} Pop_j / τ_ij^θ
+========================================================================
+Cases: actual_1960_s0, actual_1986_s0, instrument_lcp_mst_s0, instrument_stu_s0
+
+Elasticity θ = 4.550 (low; see config.R)
+[ma] Loaded 1960 pop: 309 districts, total=13,551,523
+
+[ma] ==== CASE: actual_1960_s0 ====
+[ma]   τ file has 312 districts (48516 pairs)
+[ma]   MA computed for 312 districts; 2 have logMA = -Inf (MA = 0)
+[ma]   logMA -Inf for: 32094001, 32094002
+[ma]   MA summary (MA>0): min=2.971e-28 median=1.251e-22 max=2.566e-13
+[ma]   logMA summary (finite): min=-63.38  mean=-49.61  max=-28.99
+[ma]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/04_market_access/ma_actual_1960_s0.parquet
+
+[ma] ==== CASE: actual_1986_s0 ====
+[ma]   τ file has 312 districts (48516 pairs)
+[ma]   MA computed for 312 districts; 2 have logMA = -Inf (MA = 0)
+[ma]   logMA -Inf for: 32094001, 32094002
+[ma]   MA summary (MA>0): min=8.222e-27 median=5.445e-22 max=2.601e-13
+[ma]   logMA summary (finite): min=-60.06  mean=-47.78  max=-28.98
+[ma]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/04_market_access/ma_actual_1986_s0.parquet
+
+[ma] ==== CASE: instrument_lcp_mst_s0 ====
+[ma]   τ file has 312 districts (48516 pairs)
+[ma]   MA computed for 312 districts; 0 have logMA = -Inf (MA = 0)
+[ma]   MA summary (MA>0): min=2.264e-28 median=1.205e-22 max=7.021e-14
+[ma]   logMA summary (finite): min=-63.66  mean=-50.10  max=-30.29
+[ma]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/04_market_access/ma_instrument_lcp_mst_s0.parquet
+
+[ma] ==== CASE: instrument_stu_s0 ====
+[ma]   τ file has 312 districts (48516 pairs)
+[ma]   MA computed for 312 districts; 2 have logMA = -Inf (MA = 0)
+[ma]   logMA -Inf for: 32094001, 32094002
+[ma]   MA summary (MA>0): min=1.612e-28 median=3.726e-23 max=2.566e-13
+[ma]   logMA summary (finite): min=-63.99  mean=-50.92  max=-28.99
+[ma]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/04_market_access/ma_instrument_stu_s0.parquet
+========================================================================
+04_market_access.R  |  Complete.
+========================================================================
+

--- a/logs/06_merge_ma_into_panel.log
+++ b/logs/06_merge_ma_into_panel.log
@@ -1,0 +1,23 @@
+[config.R] rootdir = /Users/diegogp/Desktop/Diego/Trains/new_repo
+[config.R] Configuration loaded successfully.
+
+========================================================================
+06_merge_ma_into_panel.R  |  merge MA into wide panel
+========================================================================
+[panel] Starting panel: 312 × 118
+[panel] actual_1960_s0             2 districts with logMA=-Inf recoded to NA
+[panel] Merged actual_1960_s0 as logMA_actual_1960_s0_elow
+[panel] actual_1986_s0             2 districts with logMA=-Inf recoded to NA
+[panel] Merged actual_1986_s0 as logMA_actual_1986_s0_elow
+[panel] instrument_stu_s0          2 districts with logMA=-Inf recoded to NA
+[panel] Merged instrument_stu_s0 as logMA_instrument_stu_s0_elow
+[panel] Merged instrument_lcp_mst_s0 as logMA_instrument_lcp_mst_s0_elow
+[panel] chg_logMA_86_60_s0_elow       N=310  mean=+1.837  sd=2.791
+[panel] chg_logMA_stu_s0_elow         N=310  mean=-1.305  sd=2.253
+[panel] chg_logMA_lcp_mst_s0_elow     N=310  mean=-0.444  sd=2.564
+[panel] Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/05_panel/departments_wide_panel.parquet (312 × 125)
+[panel] Manifest: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/05_panel/data_file_manifest.log
+========================================================================
+06_merge_ma_into_panel.R  |  Complete.
+========================================================================
+


### PR DESCRIPTION
Closes #30

Implements **Phase 1** of `Plan/tau_rebuild_plan.md` — minimum-viable market access pipeline to unblock Block-1 first-stage and main IV regressions. R-only; no QGIS or Python.

## Scope

- **Sector 0** (overall, medium cargo density per Baumgartner & Palazzo 1969).
- **Land-only** cost surface — navigation layer deferred to Phase 2.
- One elasticity: θ_low = 4.55.
- Four cost raster cases:
  - `actual_1960_s0` — 1960 rails + 1954 roads + HMI
  - `actual_1986_s0` — 1986 rails + 1986 roads + HMI
  - `instrument_stu_s0` — non-Larkin-studied rails + 1954 roads + HMI
  - `instrument_lcp_mst_s0` — 1960 rails + LCP-MST hypothetical roads + HMI

## New scripts

| Script | Purpose | Runtime |
|---|---|---|
| `03a_build_cost_raster.R` | Rasterize rail/road/HMI → cost surface | ~30 s per case |
| `03b_transition_grids.R` | Cost raster → gdistance transition object | ~35 s per case |
| `03c_compute_taus.R` | Dijkstra on 312 centroids → pairwise τ | ~3–5 min per case |
| `04_market_access.R` | τ + 1960 pop → MA per district | ~5 s per case |
| `06_merge_ma_into_panel.R` | Add logMA + Δ logMA columns to panel | <1 s |

Total end-to-end for four cases: ~20 minutes.

## Cost parameters (from Baumgartner & Palazzo 1969, documented in `code/config.R`)

| Parameter | Value | Unit |
|---|---:|---|
| `cost_road[overall]` | 1.777 | pesos/ton-km |
| `cost_rail[overall]` | 1.874 | pesos/ton-km |
| `cost_mininfra[overall]` | 1.777 | pesos/ton-km (rail+road overlap) |
| `cost_land` | ~733.2 | pesos/ton-km × unit HMI |
| `hmi_argentina` | 0.2018 | mean HMI, Argentina |
| `theta["low"]` | 4.55 | dimensionless (justification pending) |

**Human Mobility Index** (HMI) clarification: Özak's dataset is sometimes misattributed as "Human Modification Index" — it is in fact the Human *Mobility* Index (Özak 2010, 2018). Documented in `code/config.R` and `data/raw/geo/readme.md`. Raster downloaded from Zenodo (DOI:10.5281/zenodo.14285746, CC BY-SA 4.0).

## Phase 1 results

**Cost raster means (sector 0):**

| Case | Mean cost | Max cost |
|---|---:|---:|
| actual_1960_s0 | 140.8 | 773 |
| actual_1986_s0 | 137.0 | 773 |
| instrument_stu_s0 | 142.9 | 773 |
| instrument_lcp_mst_s0 | 142.0 | 773 |

Road expansion 1954→1986 drops mean cost (140.8 → 137.0). Instruments have higher mean cost (less infrastructure) than actual, as expected.

**τ eyeball (BA → Córdoba):**

| Case | τ |
|---|---:|
| actual_1960 | 2,937,292 |
| actual_1986 | 1,639,445 (−44%) |
| instrument_stu | 2,964,422 |
| instrument_lcp_mst | 3,060,436 |

44% drop in BA→Córdoba transport cost matches the road-expansion story.

**Disconnected districts**: TdF (32094001, 32094002) has τ = Inf to the mainland on the land-only cost surface (no bridge; sea crossing not modeled). Phase 1 treats this as logMA = NA for those districts. Will be resolved in Phase 2 with navigation.

**Market access summary:**

- 91% of districts had logMA increase 1960→1986.
- Mean Δ logMA (86−60) = +1.84 (σ = 2.79).
- Mean Δ logMA (stu instrument − 60) = −1.31.
- Mean Δ logMA (lcp_mst instrument − 60) = −0.44.

**First-stage F-statistics (Staiger-Stock rule of thumb F > 10):**

- LP (stu) instrument: F = **18.0** ✓
- LCP-MST instrument: F = **20.0** ✓
- Both together: Adj R² = 0.13

**Headline IV coefficients (uncontrolled; geo controls to come next)**:

- OLS: d logpop_91_60 ~ d logMA_86_60 → **0.067 (0.010)**
- IV (LP instrument): **0.030 (0.044)** (not significant)
- IV (hypo instrument): **−0.010 (0.044)** (not significant)

Both IV estimates shrink toward zero relative to OLS. Possible reasons: weak-ish instruments (Phase 1 simplifications), measurement error, no geo controls yet, or the true causal elasticity is indeed close to zero. Phase 2 sector-specific instruments + full covariate set will tighten.

## What's in the panel now

`departments_wide_panel.parquet`: 312 × 125 (was 118). New columns:

- `logMA_actual_1960_s0_elow`
- `logMA_actual_1986_s0_elow`
- `logMA_instrument_stu_s0_elow`
- `logMA_instrument_lcp_mst_s0_elow`
- `chg_logMA_86_60_s0_elow` (main regressor)
- `chg_logMA_stu_s0_elow` (LP instrument)
- `chg_logMA_lcp_mst_s0_elow` (hypo instrument)

Naming convention: `logMA_<timing>_s<sector>_e<elasticity>`. Phase 2 adds sectors 1, 2 and elasticity high.

## Documentation

- All cost parameters in `config.R` carry inline citation comments and provenance notes. Incorrect sector-density labels fixed (agricultural = high density, manufacturing = low density).
- Full Phase 1 design laid out in `Plan/tau_rebuild_plan.md` section 6 (new).
- θ = 4.55 is explicitly flagged as **pending literature review** in `config.R`, matching the open task in `Plan/tasks.md`. No speculative citation.
- `ports_legacy/` preserved with a README documenting provenance (IGN ports used by old pipeline's navigation LCPs; saved before `Old data/Train/` deletion).

## Out of scope (Phase 2 / 3)

- Navigation layer (ports + water raster + nav LCPs).
- Sectors 1 (agriculture) and 2 (manufacturing).
- Alternative elasticity θ_high = 8.11.
- Counterfactual MA (rails-only-change, roads-only-change).
- Euclidean and LCP (non-MST) hypothetical variants.

## Verified

- Every script parse-checks and runs cleanly.
- Rasterization pixel values validated against cost parameters (rail cells = 1.874, road cells = 1.777, overlap = 1.777).
- τ matrices: symmetric (max asymmetry 5e-6, floating point), no negatives, diagonal = 0. TdF Inf handled defensively.
- First-stage F > 10 for both instruments.
- 91% of districts show Δ logMA > 0 (success criterion from plan).