### PR TITLE
Phase 2b: add navigation layer to cost rasters

### DIFF
--- a/code/config.R
+++ b/code/config.R
@@ -136,6 +136,23 @@ cost_water           <- 25L       # water bodies / rivers surcharge
 # Magellan while still blocking Río de la Plata mouth and open Atlantic.
 cost_coastal_buffer_km <- 30
 
+# ---- 6c. Transport cost raster: navigation-layer parameters --------------
+#
+# Linear network buffer (rivers in cursos_de_agua.shp are linear).
+# 1 km buffer guarantees at least one full raster cell of navigable water
+# per river segment at the ~1.2 km/cell resolution of this raster grid.
+nav_linear_buffer_m <- 1000L
+
+# Strait of Magellan additional buffer (on top of the polygon outline).
+# The IGN polygon traces the water surface; in a ~1.2 km raster the
+# polygon leaves a gap between the water and both coastlines. A 5 km
+# buffer extends the polygon across both shorelines so at least one
+# raster cell per coast is navigable, allowing Dijkstra to cross.
+# Rule of thumb: ≥ 2 × ceiling(cellsize_km), giving one cell of slack
+# per shore. At 1.2 km/cell, 5 km = ~4 cells per shore.
+nav_magellan_buffer_m <- 5000L
+stopifnot(nav_magellan_buffer_m >= 2 * 1200L)  # ≥ 2 cells per shore
+
 # ---- 7. Transport cost parameters (Baumgartner & Palazzo 1969) -----------
 #
 # Source: Baumgartner, A. and Palazzo, L. (1969). "Estructura económica del

--- a/code/pipeline/03a_build_cost_raster.R
+++ b/code/pipeline/03a_build_cost_raster.R
@@ -343,27 +343,28 @@ rasterize_navigation <- function(base) {
         nrow(magellan)
     ))
 
-    # Reproject + buffer rivers to 1 km (they're linear features)
+    # Reproject + buffer rivers by nav_linear_buffer_m (config.R, default 1 km)
     rivers_proj <- sf::st_transform(navigable_rivers, crs = crs_raster)
-    rivers_buf  <- sf::st_buffer(rivers_proj, dist = 1000)
+    rivers_buf  <- sf::st_buffer(rivers_proj, dist = nav_linear_buffer_m)
     rivers_buf  <- sf::st_union(rivers_buf)
 
-    # Reproject Magellan polygons and buffer by 5 km.
+    # Reproject Magellan polygons and buffer by nav_magellan_buffer_m.
     #
     # The IGN Strait of Magellan polygons trace the water itself, which
-    # in the 1.2 km raster leaves a gap between the water and the
+    # in the ~1.2 km raster leaves a gap between the water and the
     # coastlines on both sides (TdF to the south, mainland to the north).
     # Dijkstra on 8-connected cells can't bridge that gap, so TdF stays
-    # disconnected.
+    # disconnected with zero buffer.
     #
-    # A 5 km buffer extends the polygon across the shoreline on both
-    # sides, so at least one raster cell along each coast becomes
-    # navigable. This is the minimum intervention that reconnects TdF
-    # in Phase 2b. The alternative (port-to-port LCPs) is the old
-    # pipeline's approach; noted as a Phase 2c option if the 5 km buffer
-    # produces routing artifacts elsewhere.
+    # The configured buffer extends the polygon across the shoreline on
+    # both sides, so at least one raster cell along each coast becomes
+    # navigable. config.R enforces a minimum of ≥ 2 cells per shore.
+    # The alternative (port-to-port LCPs) is the old pipeline's approach;
+    # noted as a Phase 2c option if this buffer produces routing
+    # artifacts elsewhere.
     magellan_proj <- sf::st_transform(magellan, crs = crs_raster)
-    magellan_buf  <- sf::st_buffer(magellan_proj, dist = 5000)
+    magellan_buf  <- sf::st_buffer(magellan_proj,
+                                    dist = nav_magellan_buffer_m)
     magellan_u    <- sf::st_union(magellan_buf)
 
     nav_union <- sf::st_union(rivers_buf, magellan_u)
@@ -415,6 +416,12 @@ rasterize_hmi <- function(base) {
 # or the Strait of Magellan isn't "inside Argentina" in a cadastral
 # sense, but should be traversable. Only non-navigation, non-network
 # pixels are masked to NA when outside pais.shp.
+#
+# Concrete example: the Paraná river bed between Argentina and Uruguay
+# gets cost_nav[sector] even though half of its pixels are outside
+# pais.shp. A shipment from Rosario to Concepción del Uruguay routes
+# through those pixels at nav cost. Without this exception the river
+# would be a hard barrier, forcing the shipment overland.
 # ---------------------------------------------------------------------------
 combine_cost <- function(rail_rast, road_rast, nav_rast, hmi_rast,
                          arg_mask, sector) {

--- a/code/pipeline/03a_build_cost_raster.R
+++ b/code/pipeline/03a_build_cost_raster.R
@@ -9,25 +9,29 @@
 #   data/raw/networks/lp_1979.shp                                  (rails)
 #   data/raw/networks/comparacion_54_70_86.shp                     (roads)
 #   data/derived/02_hypothetical_networks/lcp_mst.gpkg             (hypo)
+#   data/raw/networks_hypo/cursos_de_agua.shp                      (rivers)
+#   data/raw/networks_hypo/cuerpos_de_agua.shp                     (water bodies)
 #   data/raw/geo/HMI.tif                                           (Özak 2018)
 #   data/raw/networks_hypo/pais.shp                                (country)
 #
 # PRODUCES:
 #   data/derived/01_cost_rasters/ucost_<case>.tif
 #
-# DESIGN DECISIONS (Phase 1 + 2a; see Plan/tau_rebuild_plan.md Sección 6):
-#   - Land-only cost surface. No navigation layer yet — added in Phase 2b.
-#   - Three cost sectors, all with the same spatial formula but different
-#     parameter values from Baumgartner & Palazzo 1969:
+# DESIGN DECISIONS (Phase 1 + 2a + 2b; see Plan/tau_rebuild_plan.md):
+#   - Three cost sectors from Baumgartner & Palazzo 1969:
 #       s0 (overall)       — medium cargo density, main specification
 #       s1 (agricultural)  — high  cargo density, rail cheaper than road
 #       s2 (manufacturing) — low   cargo density, road cheaper than rail
+#   - NAVIGATION layer added in Phase 2b: navigable water gets
+#     cost_nav[sector] and takes precedence over rail/road. Defined as
+#     cursos_de_agua (navegabili == "SI") ∪ Strait of Magellan.
 #   - Rasterise in ESRI:54034 (World Cylindrical Equal Area) at the old
 #     pipeline's 2399 × 3090 grid over mainland Argentina.
 #   - Linear networks buffered by 1 km before rasterization (matches old
 #     pipeline). Guarantees at least one full pixel per segment.
 #   - Cost formula (see combine_cost() below):
-#       if rail & road:           cost_mininfra[sector]
+#       if navigable:             cost_nav[sector]
+#       elif rail & road:         cost_mininfra[sector]
 #       elif rail only:           cost_rail[sector]
 #       elif road only:           cost_road[sector]
 #       elif in Argentina + HMI:  cost_land × HMI    (constant across sectors)
@@ -128,7 +132,7 @@ main <- function() {
     cases <- if (length(args) > 0) args else names(case_registry())
 
     message("\n", strrep("=", 72))
-    message("03a_build_cost_raster.R  |  Phase 1+2a, land-only, sectors 0/1/2")
+    message("03a_build_cost_raster.R  |  Phase 2b, with navigation, sectors 0/1/2")
     message(strrep("=", 72))
     message(sprintf("Cases to build: %s\n", paste(cases, collapse = ", ")))
 
@@ -165,15 +169,19 @@ build_one_case <- function(case, spec) {
     rail_rast <- rasterize_rails(base, spec$rail_sel)
     road_rast <- rasterize_roads_or_hypo(base, spec)
 
-    # --- 4. Rasterise HMI (reproject + crop to Argentina extent) ---
+    # --- 4. Rasterise navigation layer (water = cheap) ---
+    nav_rast <- rasterize_navigation(base)
+
+    # --- 5. Rasterise HMI (reproject + crop to Argentina extent) ---
     hmi_rast  <- rasterize_hmi(base)
 
-    # --- 5. Combine into cost surface ---
-    cost <- combine_cost(rail_rast, road_rast, hmi_rast, arg_mask,
+    # --- 6. Combine into cost surface ---
+    cost <- combine_cost(rail_rast, road_rast, nav_rast,
+                         hmi_rast, arg_mask,
                          sector = spec$sector)
 
-    # --- 6. Validate and save ---
-    validate_cost(cost, rail_rast, road_rast, spec$sector)
+    # --- 7. Validate and save ---
+    validate_cost(cost, rail_rast, road_rast, nav_rast, spec$sector)
     save_cost_raster(cost, case)
 }
 
@@ -297,6 +305,77 @@ rasterize_hypo <- function(base) {
 }
 
 # ---------------------------------------------------------------------------
+# Rasterise navigation layer
+#
+# Source (see Plan/tau_rebuild_plan.md Sección 7):
+#   1. Navigable river segments from cursos_de_agua.shp (navegabili == "SI")
+#   2. Strait of Magellan from cuerpos_de_agua.shp (nombre == "DE MAGALLANES")
+#      The Magellan entries have navegabili = NA in the IGN data but are
+#      navigable by ferry; included manually so Tierra del Fuego connects
+#      to the mainland. This is the only hand-curated inclusion; all other
+#      water bodies rely on the IGN navigability flag.
+#
+# Output raster: 1 = navigable (gets cost_nav[sector] in combine_cost),
+#                0 = not navigable.
+# ---------------------------------------------------------------------------
+rasterize_navigation <- function(base) {
+    message("[cost]   Rasterising navigation layer")
+    rivers_path <- file.path(dir_raw, "networks_hypo",
+                             "cursos_de_agua.shp")
+    bodies_path <- file.path(dir_raw, "networks_hypo",
+                             "cuerpos_de_agua.shp")
+
+    rivers <- sf::st_read(rivers_path, quiet = TRUE)
+    rivers <- sf::st_make_valid(rivers)
+    navigable_rivers <- rivers[!is.na(rivers$navegabili) &
+                                rivers$navegabili == "SI", ]
+    message(sprintf(
+        "[cost]     Navigable river segments (cursos_de_agua): %d",
+        nrow(navigable_rivers)
+    ))
+
+    bodies <- sf::st_read(bodies_path, quiet = TRUE)
+    bodies <- sf::st_make_valid(bodies)
+    magellan <- bodies[!is.na(bodies$nombre) &
+                        bodies$nombre == "DE MAGALLANES", ]
+    message(sprintf(
+        "[cost]     Strait of Magellan polygons (cuerpos_de_agua): %d",
+        nrow(magellan)
+    ))
+
+    # Reproject + buffer rivers to 1 km (they're linear features)
+    rivers_proj <- sf::st_transform(navigable_rivers, crs = crs_raster)
+    rivers_buf  <- sf::st_buffer(rivers_proj, dist = 1000)
+    rivers_buf  <- sf::st_union(rivers_buf)
+
+    # Reproject Magellan polygons and buffer by 5 km.
+    #
+    # The IGN Strait of Magellan polygons trace the water itself, which
+    # in the 1.2 km raster leaves a gap between the water and the
+    # coastlines on both sides (TdF to the south, mainland to the north).
+    # Dijkstra on 8-connected cells can't bridge that gap, so TdF stays
+    # disconnected.
+    #
+    # A 5 km buffer extends the polygon across the shoreline on both
+    # sides, so at least one raster cell along each coast becomes
+    # navigable. This is the minimum intervention that reconnects TdF
+    # in Phase 2b. The alternative (port-to-port LCPs) is the old
+    # pipeline's approach; noted as a Phase 2c option if the 5 km buffer
+    # produces routing artifacts elsewhere.
+    magellan_proj <- sf::st_transform(magellan, crs = crs_raster)
+    magellan_buf  <- sf::st_buffer(magellan_proj, dist = 5000)
+    magellan_u    <- sf::st_union(magellan_buf)
+
+    nav_union <- sf::st_union(rivers_buf, magellan_u)
+
+    r <- terra::rasterize(terra::vect(nav_union), base, field = 1L,
+                          background = 0L)
+    n_cells <- sum(terra::values(r) == 1L, na.rm = TRUE)
+    message(sprintf("[cost]     Navigation pixels (value=1): %d", n_cells))
+    r
+}
+
+# ---------------------------------------------------------------------------
 # Rasterise HMI onto the base grid
 # ---------------------------------------------------------------------------
 rasterize_hmi <- function(base) {
@@ -320,41 +399,64 @@ rasterize_hmi <- function(base) {
 }
 
 # ---------------------------------------------------------------------------
-# Combine rail + road + HMI layers into the cost surface
+# Combine rail + road + navigation + HMI layers into the cost surface
+#
+# Order of precedence (matches old pipeline's unitcostrasters.py):
+#   navigation > rail+road overlap > rail only > road only > off-network
+#
+# Navigation goes first because water is the cheapest mode (0.621) and
+# a pixel with both a river and a rail line (e.g. Rosario port) should
+# take the water cost, not the rail cost.
+#
+# NOTE on country mask: the country polygon (pais.shp) covers Argentine
+# LAND territory and excludes oceans, rivers that form borders, and the
+# Strait of Magellan. Navigation cells are therefore allowed OUTSIDE
+# the country mask — a water crossing of the Paraná border with Uruguay
+# or the Strait of Magellan isn't "inside Argentina" in a cadastral
+# sense, but should be traversable. Only non-navigation, non-network
+# pixels are masked to NA when outside pais.shp.
 # ---------------------------------------------------------------------------
-combine_cost <- function(rail_rast, road_rast, hmi_rast, arg_mask, sector) {
+combine_cost <- function(rail_rast, road_rast, nav_rast, hmi_rast,
+                         arg_mask, sector) {
     message(sprintf("[cost]   Combining layers (sector=%s)", sector))
 
     rail <- terra::values(rail_rast)
     road <- terra::values(road_rast)
+    nav  <- terra::values(nav_rast)
     hmi  <- terra::values(hmi_rast)
     mask <- terra::values(arg_mask)
 
     # NA-safe helpers
     is_rail <- !is.na(rail) & rail == 1L
     is_road <- !is.na(road) & road == 1L
+    is_nav  <- !is.na(nav)  & nav  == 1L
     in_arg  <- !is.na(mask) & mask == 1
 
     cost <- rep(NA_real_, length(rail))
 
-    # Overlap: rail and road → mininfra
-    sel <- is_rail & is_road
+    # 1. Navigation takes precedence (cheapest mode). Allowed outside the
+    #    country mask (rivers-as-borders and the Strait of Magellan).
+    sel <- is_nav
+    cost[sel] <- cost_nav[[sector]]
+
+    # 2. Rail + road overlap (mode overlap → use min of the two)
+    sel <- !is_nav & is_rail & is_road
     cost[sel] <- cost_mininfra[[sector]]
 
-    # Rail only
-    sel <- is_rail & !is_road
+    # 3. Rail only
+    sel <- !is_nav & is_rail & !is_road
     cost[sel] <- cost_rail[[sector]]
 
-    # Road only
-    sel <- !is_rail & is_road
+    # 4. Road only
+    sel <- !is_nav & !is_rail & is_road
     cost[sel] <- cost_road[[sector]]
 
-    # Off-network land inside Argentina: cost_land × HMI
+    # 5. Off-network land inside Argentina: cost_land × HMI
     # (HMI may be NA for individual cells — those stay NA → hard barrier)
-    sel <- !is_rail & !is_road & in_arg & !is.na(hmi)
+    sel <- !is_nav & !is_rail & !is_road & in_arg & !is.na(hmi)
     cost[sel] <- cost_land * hmi[sel]
 
-    # Outside Argentina: NA (hard barrier for Dijkstra)
+    # 6. Outside Argentina and not navigable: NA (hard barrier)
     # (already NA_real_ from initialisation)
 
     r <- terra::rast(rail_rast)   # copy grid + crs
@@ -366,27 +468,41 @@ combine_cost <- function(rail_rast, road_rast, hmi_rast, arg_mask, sector) {
 # ---------------------------------------------------------------------------
 # Validation
 # ---------------------------------------------------------------------------
-validate_cost <- function(cost, rail_rast, road_rast, sector) {
+validate_cost <- function(cost, rail_rast, road_rast, nav_rast, sector) {
     v <- terra::values(cost)
     r <- terra::values(rail_rast)
     d <- terra::values(road_rast)
+    n <- terra::values(nav_rast)
 
-    rail_only    <- !is.na(r) & r == 1L & (is.na(d) | d == 0L)
-    road_only    <- !is.na(d) & d == 1L & (is.na(r) | r == 0L)
-    both         <- !is.na(r) & r == 1L & !is.na(d) & d == 1L
+    is_rail <- !is.na(r) & r == 1L
+    is_road <- !is.na(d) & d == 1L
+    is_nav  <- !is.na(n) & n == 1L
 
-    chk_rail <- all.equal(unique(v[rail_only]),
+    nav_only_no_infra <- is_nav & !is_rail & !is_road
+    rail_only         <- !is_nav & is_rail & !is_road
+    road_only         <- !is_nav & !is_rail & is_road
+    both_infra        <- !is_nav & is_rail & is_road
+
+    chk_nav  <- length(v[nav_only_no_infra]) == 0 ||
+                all.equal(unique(v[nav_only_no_infra]),
+                          cost_nav[[sector]], tolerance = 1e-9)
+    chk_rail <- length(v[rail_only]) == 0 ||
+                all.equal(unique(v[rail_only]),
                           cost_rail[[sector]], tolerance = 1e-9)
-    chk_road <- all.equal(unique(v[road_only]),
+    chk_road <- length(v[road_only]) == 0 ||
+                all.equal(unique(v[road_only]),
                           cost_road[[sector]], tolerance = 1e-9)
-    chk_both <- length(both) == 0 ||
-                all.equal(unique(v[both]),
+    chk_both <- length(v[both_infra]) == 0 ||
+                all.equal(unique(v[both_infra]),
                           cost_mininfra[[sector]], tolerance = 1e-9)
 
-    stopifnot(isTRUE(chk_rail), isTRUE(chk_road), isTRUE(chk_both))
+    stopifnot(isTRUE(chk_nav), isTRUE(chk_rail),
+              isTRUE(chk_road), isTRUE(chk_both))
     message(sprintf(
-        "[cost]   Validation OK: rail_only=%.4f road_only=%.4f both=%.4f",
-        cost_rail[[sector]], cost_road[[sector]], cost_mininfra[[sector]]
+        paste0("[cost]   Validation OK: nav=%.4f  rail_only=%.4f  ",
+               "road_only=%.4f  both=%.4f"),
+        cost_nav[[sector]], cost_rail[[sector]],
+        cost_road[[sector]], cost_mininfra[[sector]]
     ))
 
     v_ok <- v[!is.na(v)]

--- a/data/derived/05_panel/data_file_manifest.log
+++ b/data/derived/05_panel/data_file_manifest.log
@@ -1,5 +1,5 @@
 Data file manifest — 05_build_panel.R + 06_merge_ma_into_panel.R
-Regenerated: 2026-05-09 22:10:52.487714
+Regenerated: 2026-05-10 08:44:15.071006
 rootdir: /Users/diegogp/Desktop/Diego/Trains/new_repo
 
 ============================================================ 
@@ -144,45 +144,45 @@ Summary of every variable:
   chg_log_valprod_85_54            N=310  mean=3.89  sd=1.37  min=-1.97  max=9.75  NA=2
   chg_log_nexp_88_60               N=297  mean=-0.254  sd=0.497  min=-3.35  max=2.29  NA=15
   chg_log_areatot_ha_88_60         N=297  mean=0.0766  sd=0.656  min=-3.22  max=3.76  NA=15
-  logMA_actual_1960_s0_elow        N=310  mean=-49.6  sd=6.42  min=-63.4  max=-29  NA=2
-  logMA_actual_1960_s0_ehigh       N=310  mean=-99.8  sd=12.1  min=-123  max=-61.7  NA=2
-  logMA_actual_1960_s1_elow        N=310  mean=-47.3  sd=7.64  min=-63.3  max=-24  NA=2
-  logMA_actual_1960_s1_ehigh       N=310  mean=-96.1  sd=14.4  min=-122  max=-52.9  NA=2
-  logMA_actual_1960_s2_elow        N=310  mean=-53.7  sd=5.29  min=-63.8  max=-37  NA=2
-  logMA_actual_1960_s2_ehigh       N=310  mean=-106  sd=9.6  min=-124  max=-76  NA=2
-  logMA_actual_1986_s0_elow        N=310  mean=-47.8  sd=5.38  min=-60.1  max=-29  NA=2
-  logMA_actual_1986_s0_ehigh       N=310  mean=-96.3  sd=10.3  min=-120  max=-61.7  NA=2
-  logMA_actual_1986_s1_elow        N=310  mean=-45.4  sd=6.4  min=-59.7  max=-24  NA=2
-  logMA_actual_1986_s1_ehigh       N=310  mean=-92.5  sd=12.3  min=-119  max=-52.9  NA=2
-  logMA_actual_1986_s2_elow        N=310  mean=-52  sd=4.49  min=-61.7  max=-37  NA=2
-  logMA_actual_1986_s2_ehigh       N=310  mean=-103  sd=8.26  min=-123  max=-76  NA=2
-  logMA_instrument_stu_s0_elow     N=310  mean=-50.9  sd=6.8  min=-64  max=-29  NA=2
-  logMA_instrument_stu_s0_ehigh    N=310  mean=-102  sd=12.7  min=-127  max=-61.7  NA=2
-  logMA_instrument_stu_s1_elow     N=310  mean=-49  sd=7.93  min=-63.7  max=-24.1  NA=2
-  logMA_instrument_stu_s1_ehigh    N=310  mean=-99.2  sd=14.7  min=-126  max=-52.9  NA=2
-  logMA_instrument_stu_s2_elow     N=310  mean=-54.4  sd=5.57  min=-65  max=-37  NA=2
-  logMA_instrument_stu_s2_ehigh    N=310  mean=-107  sd=10.2  min=-128  max=-76  NA=2
-  logMA_instrument_lcp_mst_s0_elow N=312  mean=-50.1  sd=6.1  min=-63.7  max=-30.3  NA=0
-  logMA_instrument_lcp_mst_s0_ehigh N=312  mean=-101  sd=11.5  min=-123  max=-64  NA=0
-  logMA_instrument_lcp_mst_s1_elow N=312  mean=-47.9  sd=7.27  min=-63.6  max=-24.1  NA=0
-  logMA_instrument_lcp_mst_s1_ehigh N=312  mean=-97.3  sd=13.6  min=-123  max=-52.9  NA=0
-  logMA_instrument_lcp_mst_s2_elow N=312  mean=-54.4  sd=4.97  min=-64  max=-38.5  NA=0
-  logMA_instrument_lcp_mst_s2_ehigh N=312  mean=-107  sd=9.11  min=-125  max=-78.7  NA=0
-  chg_logMA_86_60_s0_elow          N=310  mean=1.84  sd=2.79  min=-7.21  max=10.6  NA=2
-  chg_logMA_stu_s0_elow            N=310  mean=-1.3  sd=2.25  min=-12.2  max=-3.5e-06  NA=2
-  chg_logMA_lcp_mst_s0_elow        N=310  mean=-0.444  sd=2.56  min=-15.8  max=10.8  NA=2
-  chg_logMA_86_60_s0_ehigh         N=310  mean=3.48  sd=5.56  min=-14.5  max=21.8  NA=2
-  chg_logMA_stu_s0_ehigh           N=310  mean=-2.34  sd=4.4  min=-23.4  max=-3.47e-10  NA=2
-  chg_logMA_lcp_mst_s0_ehigh       N=310  mean=-0.887  sd=5.22  min=-29  max=22.8  NA=2
-  chg_logMA_86_60_s1_elow          N=310  mean=1.95  sd=3.67  min=-12.8  max=12.1  NA=2
-  chg_logMA_stu_s1_elow            N=310  mean=-1.71  sd=3.09  min=-16.8  max=-1.16e-06  NA=2
-  chg_logMA_lcp_mst_s1_elow        N=310  mean=-0.57  sd=3.29  min=-17.1  max=12.9  NA=2
-  chg_logMA_86_60_s1_ehigh         N=310  mean=3.55  sd=6.97  min=-24.9  max=22.8  NA=2
-  chg_logMA_stu_s1_ehigh           N=310  mean=-3.05  sd=5.77  min=-31.3  max=-1.69e-10  NA=2
-  chg_logMA_lcp_mst_s1_ehigh       N=310  mean=-1.1  sd=6.36  min=-33  max=24.6  NA=2
-  chg_logMA_86_60_s2_elow          N=310  mean=1.75  sd=1.81  min=-2.01  max=8.16  NA=2
-  chg_logMA_stu_s2_elow            N=310  mean=-0.707  sd=1.22  min=-7.12  max=-6.6e-07  NA=2
-  chg_logMA_lcp_mst_s2_elow        N=310  mean=-0.596  sd=1.88  min=-9.6  max=8.32  NA=2
-  chg_logMA_86_60_s2_ehigh         N=310  mean=3.16  sd=3.62  min=-4.23  max=15.1  NA=2
-  chg_logMA_stu_s2_ehigh           N=310  mean=-1.35  sd=2.55  min=-15.8  max=-4.97e-11  NA=2
-  chg_logMA_lcp_mst_s2_ehigh       N=310  mean=-1.16  sd=3.88  min=-17.3  max=17.2  NA=2
+  logMA_actual_1960_s0_elow        N=312  mean=-49  sd=6.05  min=-63.1  max=-29  NA=0
+  logMA_actual_1960_s0_ehigh       N=312  mean=-98.9  sd=11.6  min=-125  max=-61.7  NA=0
+  logMA_actual_1960_s1_elow        N=312  mean=-46.8  sd=7.23  min=-62.6  max=-24  NA=0
+  logMA_actual_1960_s1_ehigh       N=312  mean=-95.3  sd=13.8  min=-124  max=-52.9  NA=0
+  logMA_actual_1960_s2_elow        N=312  mean=-52.9  sd=5.02  min=-65.6  max=-37  NA=0
+  logMA_actual_1960_s2_ehigh       N=312  mean=-105  sd=9.37  min=-129  max=-76  NA=0
+  logMA_actual_1986_s0_elow        N=312  mean=-47.5  sd=5.36  min=-59.9  max=-29  NA=0
+  logMA_actual_1986_s0_ehigh       N=312  mean=-95.8  sd=10.3  min=-120  max=-61.7  NA=0
+  logMA_actual_1986_s1_elow        N=312  mean=-45.3  sd=6.4  min=-59.7  max=-24  NA=0
+  logMA_actual_1986_s1_ehigh       N=312  mean=-92.3  sd=12.3  min=-119  max=-52.9  NA=0
+  logMA_actual_1986_s2_elow        N=312  mean=-51.4  sd=4.47  min=-60.9  max=-37  NA=0
+  logMA_actual_1986_s2_ehigh       N=312  mean=-102  sd=8.32  min=-121  max=-76  NA=0
+  logMA_instrument_stu_s0_elow     N=312  mean=-50.3  sd=6.4  min=-64  max=-29  NA=0
+  logMA_instrument_stu_s0_ehigh    N=312  mean=-101  sd=12.1  min=-127  max=-61.7  NA=0
+  logMA_instrument_stu_s1_elow     N=312  mean=-48.4  sd=7.49  min=-63.7  max=-24.1  NA=0
+  logMA_instrument_stu_s1_ehigh    N=312  mean=-98.2  sd=14.1  min=-126  max=-52.9  NA=0
+  logMA_instrument_stu_s2_elow     N=312  mean=-53.6  sd=5.26  min=-65.8  max=-37  NA=0
+  logMA_instrument_stu_s2_ehigh    N=312  mean=-106  sd=9.85  min=-130  max=-76  NA=0
+  logMA_instrument_lcp_mst_s0_elow N=312  mean=-49.5  sd=5.73  min=-60.6  max=-30.3  NA=0
+  logMA_instrument_lcp_mst_s0_ehigh N=312  mean=-99.9  sd=11  min=-121  max=-64  NA=0
+  logMA_instrument_lcp_mst_s1_elow N=312  mean=-47.5  sd=6.89  min=-60.2  max=-24.1  NA=0
+  logMA_instrument_lcp_mst_s1_ehigh N=312  mean=-96.6  sd=13.1  min=-120  max=-52.9  NA=0
+  logMA_instrument_lcp_mst_s2_elow N=312  mean=-53.6  sd=4.81  min=-63.3  max=-38.5  NA=0
+  logMA_instrument_lcp_mst_s2_ehigh N=312  mean=-106  sd=9.01  min=-125  max=-78.7  NA=0
+  chg_logMA_86_60_s0_elow          N=312  mean=1.56  sd=2.48  min=-7.18  max=9.58  NA=0
+  chg_logMA_stu_s0_elow            N=312  mean=-1.24  sd=2.22  min=-12.5  max=-3.5e-06  NA=0
+  chg_logMA_lcp_mst_s0_elow        N=312  mean=-0.494  sd=2.48  min=-15.8  max=8.86  NA=0
+  chg_logMA_86_60_s0_ehigh         N=312  mean=3.07  sd=5.14  min=-14.5  max=18.1  NA=0
+  chg_logMA_stu_s0_ehigh           N=312  mean=-2.22  sd=4.32  min=-23.5  max=-3.47e-10  NA=0
+  chg_logMA_lcp_mst_s0_ehigh       N=312  mean=-0.979  sd=5.02  min=-29  max=17.2  NA=0
+  chg_logMA_86_60_s1_elow          N=312  mean=1.57  sd=3.3  min=-12.8  max=11.8  NA=0
+  chg_logMA_stu_s1_elow            N=312  mean=-1.61  sd=3.02  min=-16.8  max=-3.05e-06  NA=0
+  chg_logMA_lcp_mst_s1_elow        N=312  mean=-0.663  sd=3.17  min=-17.1  max=10.7  NA=0
+  chg_logMA_86_60_s1_ehigh         N=312  mean=3  sd=6.48  min=-24.9  max=21.3  NA=0
+  chg_logMA_stu_s1_ehigh           N=312  mean=-2.88  sd=5.63  min=-31.3  max=-1.7e-10  NA=0
+  chg_logMA_lcp_mst_s1_ehigh       N=312  mean=-1.23  sd=6.19  min=-33  max=21.7  NA=0
+  chg_logMA_86_60_s2_elow          N=312  mean=1.57  sd=1.6  min=-1.99  max=6.66  NA=0
+  chg_logMA_stu_s2_elow            N=312  mean=-0.636  sd=1.23  min=-6.42  max=-6.6e-07  NA=0
+  chg_logMA_lcp_mst_s2_elow        N=312  mean=-0.682  sd=1.73  min=-9.6  max=6.66  NA=0
+  chg_logMA_86_60_s2_ehigh         N=312  mean=2.91  sd=3.38  min=-4.23  max=14  NA=0
+  chg_logMA_stu_s2_ehigh           N=312  mean=-1.24  sd=2.51  min=-14.6  max=-4.97e-11  NA=0
+  chg_logMA_lcp_mst_s2_ehigh       N=312  mean=-1.29  sd=3.61  min=-17.3  max=13.1  NA=0

--- a/logs/03a_build_cost_raster.log
+++ b/logs/03a_build_cost_raster.log
@@ -5,9 +5,9 @@ Warning messages:
 [config.R] Configuration loaded successfully.
 
 ========================================================================
-03a_build_cost_raster.R  |  Phase 1, land-only, sector 0
+03a_build_cost_raster.R  |  Phase 2b, with navigation, sectors 0/1/2
 ========================================================================
-Cases to build: actual_1960_s0
+Cases to build: actual_1960_s0, actual_1960_s1, actual_1960_s2, actual_1986_s0, actual_1986_s1, actual_1986_s2, instrument_stu_s0, instrument_stu_s1, instrument_stu_s2, instrument_lcp_mst_s0, instrument_lcp_mst_s1, instrument_lcp_mst_s2
 
 
 [cost] ==== CASE: actual_1960_s0 ====
@@ -18,130 +18,35 @@ Cases to build: actual_1960_s0
 [cost]   Rasterising roads (selected subset)
 [cost]     Selected 582 / 1741 segments
 [cost]     Road pixels (value=1): 40777
+[cost]   Rasterising navigation layer
+[cost]     Navigable river segments (cursos_de_agua): 1128
+[cost]     Strait of Magellan polygons (cuerpos_de_agua): 3
+[cost]     Navigation pixels (value=1): 13016
 [cost]   Projecting HMI to base raster
 [cost]     HMI pixels with value (not NA): 3191580
 [cost]   Combining layers (sector=overall)
-[cost]   Validation OK: rail_only=1.8740 road_only=1.7770 both=1.7770
-[cost]   Cost summary: min=1.777  mean=140.83  max=773.11  N=1915855
+[cost]   Validation OK: nav=0.6210  rail_only=1.8740  road_only=1.7770  both=1.7770
+[cost]   Cost summary: min=0.621  mean=139.77  max=773.11  N=1922809
 [cost]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/01_cost_rasters/ucost_actual_1960_s0.tif
-========================================================================
-03a_build_cost_raster.R  |  Complete.
-========================================================================
 
-Warning messages:
-1: package ‘sf’ was built under R version 4.5.2 
-2: package ‘terra’ was built under R version 4.5.2 
-[config.R] rootdir = /Users/diegogp/Desktop/Diego/Trains/new_repo
-[config.R] Configuration loaded successfully.
-
-========================================================================
-03a_build_cost_raster.R  |  Phase 1, land-only, sector 0
-========================================================================
-Cases to build: actual_1986_s0, instrument_stu_s0, instrument_lcp_mst_s0
-
-
-[cost] ==== CASE: actual_1986_s0 ====
-[cost]   Rasterising country polygon (pais.shp)
-[cost]   Rasterising rails (selected subset)
-[cost]     Selected 424 / 565 segments
-[cost]     Rail pixels (value=1): 46250
-[cost]   Rasterising roads (selected subset)
-[cost]     Selected 1506 / 1741 segments
-[cost]     Road pixels (value=1): 111456
-[cost]   Projecting HMI to base raster
-[cost]     HMI pixels with value (not NA): 3191580
-[cost]   Combining layers (sector=overall)
-[cost]   Validation OK: rail_only=1.8740 road_only=1.7770 both=1.7770
-[cost]   Cost summary: min=1.777  mean=137.02  max=773.11  N=1916005
-[cost]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/01_cost_rasters/ucost_actual_1986_s0.tif
-
-[cost] ==== CASE: instrument_stu_s0 ====
-[cost]   Rasterising country polygon (pais.shp)
-[cost]   Rasterising rails (selected subset)
-[cost]     Selected 328 / 565 segments
-[cost]     Rail pixels (value=1): 30521
-[cost]   Rasterising roads (selected subset)
-[cost]     Selected 582 / 1741 segments
-[cost]     Road pixels (value=1): 40777
-[cost]   Projecting HMI to base raster
-[cost]     HMI pixels with value (not NA): 3191580
-[cost]   Combining layers (sector=overall)
-[cost]   Validation OK: rail_only=1.8740 road_only=1.7770 both=1.7770
-[cost]   Cost summary: min=1.777  mean=142.95  max=773.11  N=1915827
-[cost]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/01_cost_rasters/ucost_instrument_stu_s0.tif
-
-[cost] ==== CASE: instrument_lcp_mst_s0 ====
+[cost] ==== CASE: actual_1960_s1 ====
 [cost]   Rasterising country polygon (pais.shp)
 [cost]   Rasterising rails (selected subset)
 [cost]     Selected 565 / 565 segments
 [cost]     Rail pixels (value=1): 59254
-[cost]   Rasterising hypothetical LCP-MST road network
-[cost]     Hypo road pixels (value=1): 15148
-[cost]   Projecting HMI to base raster
-[cost]     HMI pixels with value (not NA): 3191580
-[cost]   Combining layers (sector=overall)
-[cost]   Validation OK: rail_only=1.8740 road_only=1.7770 both=1.7770
-[cost]   Cost summary: min=1.777  mean=142.03  max=773.11  N=1915872
-[cost]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/01_cost_rasters/ucost_instrument_lcp_mst_s0.tif
-========================================================================
-03a_build_cost_raster.R  |  Complete.
-========================================================================
-
-Warning messages:
-1: package ‘sf’ was built under R version 4.5.2 
-2: package ‘terra’ was built under R version 4.5.2 
-[config.R] rootdir = /Users/diegogp/Desktop/Diego/Trains/new_repo
-[config.R] Configuration loaded successfully.
-
-========================================================================
-03a_build_cost_raster.R  |  Phase 1+2a, land-only, sectors 0/1/2
-========================================================================
-Cases to build: actual_1986_s1, instrument_stu_s1, instrument_lcp_mst_s1, actual_1960_s2, actual_1986_s2, instrument_stu_s2, instrument_lcp_mst_s2
-
-
-[cost] ==== CASE: actual_1986_s1 ====
-[cost]   Rasterising country polygon (pais.shp)
-[cost]   Rasterising rails (selected subset)
-[cost]     Selected 424 / 565 segments
-[cost]     Rail pixels (value=1): 46250
-[cost]   Rasterising roads (selected subset)
-[cost]     Selected 1506 / 1741 segments
-[cost]     Road pixels (value=1): 111456
-[cost]   Projecting HMI to base raster
-[cost]     HMI pixels with value (not NA): 3191580
-[cost]   Combining layers (sector=agricultural)
-[cost]   Validation OK: rail_only=0.4650 road_only=1.0000 both=0.4650
-[cost]   Cost summary: min=0.465  mean=136.95  max=773.11  N=1916005
-[cost]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/01_cost_rasters/ucost_actual_1986_s1.tif
-
-[cost] ==== CASE: instrument_stu_s1 ====
-[cost]   Rasterising country polygon (pais.shp)
-[cost]   Rasterising rails (selected subset)
-[cost]     Selected 328 / 565 segments
-[cost]     Rail pixels (value=1): 30521
 [cost]   Rasterising roads (selected subset)
 [cost]     Selected 582 / 1741 segments
 [cost]     Road pixels (value=1): 40777
+[cost]   Rasterising navigation layer
+[cost]     Navigable river segments (cursos_de_agua): 1128
+[cost]     Strait of Magellan polygons (cuerpos_de_agua): 3
+[cost]     Navigation pixels (value=1): 13016
 [cost]   Projecting HMI to base raster
 [cost]     HMI pixels with value (not NA): 3191580
 [cost]   Combining layers (sector=agricultural)
-[cost]   Validation OK: rail_only=0.4650 road_only=1.0000 both=0.4650
-[cost]   Cost summary: min=0.465  mean=142.91  max=773.11  N=1915827
-[cost]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/01_cost_rasters/ucost_instrument_stu_s1.tif
-
-[cost] ==== CASE: instrument_lcp_mst_s1 ====
-[cost]   Rasterising country polygon (pais.shp)
-[cost]   Rasterising rails (selected subset)
-[cost]     Selected 565 / 565 segments
-[cost]     Rail pixels (value=1): 59254
-[cost]   Rasterising hypothetical LCP-MST road network
-[cost]     Hypo road pixels (value=1): 15148
-[cost]   Projecting HMI to base raster
-[cost]     HMI pixels with value (not NA): 3191580
-[cost]   Combining layers (sector=agricultural)
-[cost]   Validation OK: rail_only=0.4650 road_only=1.0000 both=0.4650
-[cost]   Cost summary: min=0.465  mean=141.98  max=773.11  N=1915872
-[cost]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/01_cost_rasters/ucost_instrument_lcp_mst_s1.tif
+[cost]   Validation OK: nav=0.6210  rail_only=0.4650  road_only=1.0000  both=0.4650
+[cost]   Cost summary: min=0.465  mean=139.71  max=773.11  N=1922809
+[cost]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/01_cost_rasters/ucost_actual_1960_s1.tif
 
 [cost] ==== CASE: actual_1960_s2 ====
 [cost]   Rasterising country polygon (pais.shp)
@@ -151,12 +56,54 @@ Cases to build: actual_1986_s1, instrument_stu_s1, instrument_lcp_mst_s1, actual
 [cost]   Rasterising roads (selected subset)
 [cost]     Selected 582 / 1741 segments
 [cost]     Road pixels (value=1): 40777
+[cost]   Rasterising navigation layer
+[cost]     Navigable river segments (cursos_de_agua): 1128
+[cost]     Strait of Magellan polygons (cuerpos_de_agua): 3
+[cost]     Navigation pixels (value=1): 13016
 [cost]   Projecting HMI to base raster
 [cost]     HMI pixels with value (not NA): 3191580
 [cost]   Combining layers (sector=manufacturing)
-[cost]   Validation OK: rail_only=13.4900 road_only=8.2660 both=8.2660
-[cost]   Cost summary: min=8.266  mean=141.27  max=773.11  N=1915855
+[cost]   Validation OK: nav=0.6210  rail_only=13.4900  road_only=8.2660  both=8.2660
+[cost]   Cost summary: min=0.621  mean=140.21  max=773.11  N=1922809
 [cost]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/01_cost_rasters/ucost_actual_1960_s2.tif
+
+[cost] ==== CASE: actual_1986_s0 ====
+[cost]   Rasterising country polygon (pais.shp)
+[cost]   Rasterising rails (selected subset)
+[cost]     Selected 424 / 565 segments
+[cost]     Rail pixels (value=1): 46250
+[cost]   Rasterising roads (selected subset)
+[cost]     Selected 1506 / 1741 segments
+[cost]     Road pixels (value=1): 111456
+[cost]   Rasterising navigation layer
+[cost]     Navigable river segments (cursos_de_agua): 1128
+[cost]     Strait of Magellan polygons (cuerpos_de_agua): 3
+[cost]     Navigation pixels (value=1): 13016
+[cost]   Projecting HMI to base raster
+[cost]     HMI pixels with value (not NA): 3191580
+[cost]   Combining layers (sector=overall)
+[cost]   Validation OK: nav=0.6210  rail_only=1.8740  road_only=1.7770  both=1.7770
+[cost]   Cost summary: min=0.621  mean=136.00  max=773.11  N=1922945
+[cost]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/01_cost_rasters/ucost_actual_1986_s0.tif
+
+[cost] ==== CASE: actual_1986_s1 ====
+[cost]   Rasterising country polygon (pais.shp)
+[cost]   Rasterising rails (selected subset)
+[cost]     Selected 424 / 565 segments
+[cost]     Rail pixels (value=1): 46250
+[cost]   Rasterising roads (selected subset)
+[cost]     Selected 1506 / 1741 segments
+[cost]     Road pixels (value=1): 111456
+[cost]   Rasterising navigation layer
+[cost]     Navigable river segments (cursos_de_agua): 1128
+[cost]     Strait of Magellan polygons (cuerpos_de_agua): 3
+[cost]     Navigation pixels (value=1): 13016
+[cost]   Projecting HMI to base raster
+[cost]     HMI pixels with value (not NA): 3191580
+[cost]   Combining layers (sector=agricultural)
+[cost]   Validation OK: nav=0.6210  rail_only=0.4650  road_only=1.0000  both=0.4650
+[cost]   Cost summary: min=0.465  mean=135.93  max=773.11  N=1922945
+[cost]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/01_cost_rasters/ucost_actual_1986_s1.tif
 
 [cost] ==== CASE: actual_1986_s2 ====
 [cost]   Rasterising country polygon (pais.shp)
@@ -166,12 +113,54 @@ Cases to build: actual_1986_s1, instrument_stu_s1, instrument_lcp_mst_s1, actual
 [cost]   Rasterising roads (selected subset)
 [cost]     Selected 1506 / 1741 segments
 [cost]     Road pixels (value=1): 111456
+[cost]   Rasterising navigation layer
+[cost]     Navigable river segments (cursos_de_agua): 1128
+[cost]     Strait of Magellan polygons (cuerpos_de_agua): 3
+[cost]     Navigation pixels (value=1): 13016
 [cost]   Projecting HMI to base raster
 [cost]     HMI pixels with value (not NA): 3191580
 [cost]   Combining layers (sector=manufacturing)
-[cost]   Validation OK: rail_only=13.4900 road_only=8.2660 both=8.2660
-[cost]   Cost summary: min=8.266  mean=137.58  max=773.11  N=1916005
+[cost]   Validation OK: nav=0.6210  rail_only=13.4900  road_only=8.2660  both=8.2660
+[cost]   Cost summary: min=0.621  mean=136.56  max=773.11  N=1922945
 [cost]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/01_cost_rasters/ucost_actual_1986_s2.tif
+
+[cost] ==== CASE: instrument_stu_s0 ====
+[cost]   Rasterising country polygon (pais.shp)
+[cost]   Rasterising rails (selected subset)
+[cost]     Selected 328 / 565 segments
+[cost]     Rail pixels (value=1): 30521
+[cost]   Rasterising roads (selected subset)
+[cost]     Selected 582 / 1741 segments
+[cost]     Road pixels (value=1): 40777
+[cost]   Rasterising navigation layer
+[cost]     Navigable river segments (cursos_de_agua): 1128
+[cost]     Strait of Magellan polygons (cuerpos_de_agua): 3
+[cost]     Navigation pixels (value=1): 13016
+[cost]   Projecting HMI to base raster
+[cost]     HMI pixels with value (not NA): 3191580
+[cost]   Combining layers (sector=overall)
+[cost]   Validation OK: nav=0.6210  rail_only=1.8740  road_only=1.7770  both=1.7770
+[cost]   Cost summary: min=0.621  mean=141.88  max=773.11  N=1922785
+[cost]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/01_cost_rasters/ucost_instrument_stu_s0.tif
+
+[cost] ==== CASE: instrument_stu_s1 ====
+[cost]   Rasterising country polygon (pais.shp)
+[cost]   Rasterising rails (selected subset)
+[cost]     Selected 328 / 565 segments
+[cost]     Rail pixels (value=1): 30521
+[cost]   Rasterising roads (selected subset)
+[cost]     Selected 582 / 1741 segments
+[cost]     Road pixels (value=1): 40777
+[cost]   Rasterising navigation layer
+[cost]     Navigable river segments (cursos_de_agua): 1128
+[cost]     Strait of Magellan polygons (cuerpos_de_agua): 3
+[cost]     Navigation pixels (value=1): 13016
+[cost]   Projecting HMI to base raster
+[cost]     HMI pixels with value (not NA): 3191580
+[cost]   Combining layers (sector=agricultural)
+[cost]   Validation OK: nav=0.6210  rail_only=0.4650  road_only=1.0000  both=0.4650
+[cost]   Cost summary: min=0.465  mean=141.84  max=773.11  N=1922785
+[cost]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/01_cost_rasters/ucost_instrument_stu_s1.tif
 
 [cost] ==== CASE: instrument_stu_s2 ====
 [cost]   Rasterising country polygon (pais.shp)
@@ -181,12 +170,52 @@ Cases to build: actual_1986_s1, instrument_stu_s1, instrument_lcp_mst_s1, actual
 [cost]   Rasterising roads (selected subset)
 [cost]     Selected 582 / 1741 segments
 [cost]     Road pixels (value=1): 40777
+[cost]   Rasterising navigation layer
+[cost]     Navigable river segments (cursos_de_agua): 1128
+[cost]     Strait of Magellan polygons (cuerpos_de_agua): 3
+[cost]     Navigation pixels (value=1): 13016
 [cost]   Projecting HMI to base raster
 [cost]     HMI pixels with value (not NA): 3191580
 [cost]   Combining layers (sector=manufacturing)
-[cost]   Validation OK: rail_only=13.4900 road_only=8.2660 both=8.2660
-[cost]   Cost summary: min=8.266  mean=143.24  max=773.11  N=1915827
+[cost]   Validation OK: nav=0.6210  rail_only=13.4900  road_only=8.2660  both=8.2660
+[cost]   Cost summary: min=0.621  mean=142.17  max=773.11  N=1922785
 [cost]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/01_cost_rasters/ucost_instrument_stu_s2.tif
+
+[cost] ==== CASE: instrument_lcp_mst_s0 ====
+[cost]   Rasterising country polygon (pais.shp)
+[cost]   Rasterising rails (selected subset)
+[cost]     Selected 565 / 565 segments
+[cost]     Rail pixels (value=1): 59254
+[cost]   Rasterising hypothetical LCP-MST road network
+[cost]     Hypo road pixels (value=1): 15148
+[cost]   Rasterising navigation layer
+[cost]     Navigable river segments (cursos_de_agua): 1128
+[cost]     Strait of Magellan polygons (cuerpos_de_agua): 3
+[cost]     Navigation pixels (value=1): 13016
+[cost]   Projecting HMI to base raster
+[cost]     HMI pixels with value (not NA): 3191580
+[cost]   Combining layers (sector=overall)
+[cost]   Validation OK: nav=0.6210  rail_only=1.8740  road_only=1.7770  both=1.7770
+[cost]   Cost summary: min=0.621  mean=140.97  max=773.11  N=1922795
+[cost]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/01_cost_rasters/ucost_instrument_lcp_mst_s0.tif
+
+[cost] ==== CASE: instrument_lcp_mst_s1 ====
+[cost]   Rasterising country polygon (pais.shp)
+[cost]   Rasterising rails (selected subset)
+[cost]     Selected 565 / 565 segments
+[cost]     Rail pixels (value=1): 59254
+[cost]   Rasterising hypothetical LCP-MST road network
+[cost]     Hypo road pixels (value=1): 15148
+[cost]   Rasterising navigation layer
+[cost]     Navigable river segments (cursos_de_agua): 1128
+[cost]     Strait of Magellan polygons (cuerpos_de_agua): 3
+[cost]     Navigation pixels (value=1): 13016
+[cost]   Projecting HMI to base raster
+[cost]     HMI pixels with value (not NA): 3191580
+[cost]   Combining layers (sector=agricultural)
+[cost]   Validation OK: nav=0.6210  rail_only=0.4650  road_only=1.0000  both=0.4650
+[cost]   Cost summary: min=0.465  mean=140.92  max=773.11  N=1922795
+[cost]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/01_cost_rasters/ucost_instrument_lcp_mst_s1.tif
 
 [cost] ==== CASE: instrument_lcp_mst_s2 ====
 [cost]   Rasterising country polygon (pais.shp)
@@ -195,11 +224,15 @@ Cases to build: actual_1986_s1, instrument_stu_s1, instrument_lcp_mst_s1, actual
 [cost]     Rail pixels (value=1): 59254
 [cost]   Rasterising hypothetical LCP-MST road network
 [cost]     Hypo road pixels (value=1): 15148
+[cost]   Rasterising navigation layer
+[cost]     Navigable river segments (cursos_de_agua): 1128
+[cost]     Strait of Magellan polygons (cuerpos_de_agua): 3
+[cost]     Navigation pixels (value=1): 13016
 [cost]   Projecting HMI to base raster
 [cost]     HMI pixels with value (not NA): 3191580
 [cost]   Combining layers (sector=manufacturing)
-[cost]   Validation OK: rail_only=13.4900 road_only=8.2660 both=8.2660
-[cost]   Cost summary: min=8.266  mean=142.43  max=773.11  N=1915872
+[cost]   Validation OK: nav=0.6210  rail_only=13.4900  road_only=8.2660  both=8.2660
+[cost]   Cost summary: min=0.621  mean=141.37  max=773.11  N=1922795
 [cost]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/01_cost_rasters/ucost_instrument_lcp_mst_s2.tif
 ========================================================================
 03a_build_cost_raster.R  |  Complete.

--- a/logs/03b_transition_grids.log
+++ b/logs/03b_transition_grids.log
@@ -7,134 +7,104 @@ Warning messages:
 ========================================================================
 03b_transition_grids.R  |  cost raster → gdistance transition
 ========================================================================
-Cases to process: actual_1960_s0
+Cases to process: actual_1960_s0, actual_1960_s1, actual_1960_s2, actual_1986_s0, actual_1986_s1, actual_1986_s2, instrument_lcp_mst_s0, instrument_lcp_mst_s1, instrument_lcp_mst_s2, instrument_stu_s0, instrument_stu_s1, instrument_stu_s2
 
 
 [trans] ==== CASE: actual_1960_s0 ====
 [trans]   Reading /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/01_cost_rasters/ucost_actual_1960_s0.tif
 [trans]   Building 8-neighbour transition (1/mean(cost))
-[trans]   transition() took 33.2 s
+[trans]   transition() took 43.1 s
 [trans]   Applying geoCorrection (diagonal edges)
-[trans]   geoCorrection() took 3.8 s
+[trans]   geoCorrection() took 4.4 s
 [trans]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/02_transition_grids/transition_actual_1960_s0.rds
-========================================================================
-03b_transition_grids.R  |  Complete.
-========================================================================
-
-Warning messages:
-1: package ‘sp’ was built under R version 4.5.2 
-2: package ‘igraph’ was built under R version 4.5.2 
-[config.R] rootdir = /Users/diegogp/Desktop/Diego/Trains/new_repo
-[config.R] Configuration loaded successfully.
-
-========================================================================
-03b_transition_grids.R  |  cost raster → gdistance transition
-========================================================================
-Cases to process: actual_1986_s0, instrument_stu_s0, instrument_lcp_mst_s0
-
-
-[trans] ==== CASE: actual_1986_s0 ====
-[trans]   Reading /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/01_cost_rasters/ucost_actual_1986_s0.tif
-[trans]   Building 8-neighbour transition (1/mean(cost))
-[trans]   transition() took 28.8 s
-[trans]   Applying geoCorrection (diagonal edges)
-[trans]   geoCorrection() took 3.3 s
-[trans]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/02_transition_grids/transition_actual_1986_s0.rds
-
-[trans] ==== CASE: instrument_stu_s0 ====
-[trans]   Reading /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/01_cost_rasters/ucost_instrument_stu_s0.tif
-[trans]   Building 8-neighbour transition (1/mean(cost))
-[trans]   transition() took 27.1 s
-[trans]   Applying geoCorrection (diagonal edges)
-[trans]   geoCorrection() took 2.4 s
-[trans]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/02_transition_grids/transition_instrument_stu_s0.rds
-
-[trans] ==== CASE: instrument_lcp_mst_s0 ====
-[trans]   Reading /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/01_cost_rasters/ucost_instrument_lcp_mst_s0.tif
-[trans]   Building 8-neighbour transition (1/mean(cost))
-[trans]   transition() took 27.2 s
-[trans]   Applying geoCorrection (diagonal edges)
-[trans]   geoCorrection() took 2.7 s
-[trans]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/02_transition_grids/transition_instrument_lcp_mst_s0.rds
-========================================================================
-03b_transition_grids.R  |  Complete.
-========================================================================
-
-Warning messages:
-1: package ‘sp’ was built under R version 4.5.2 
-2: package ‘igraph’ was built under R version 4.5.2 
-[config.R] rootdir = /Users/diegogp/Desktop/Diego/Trains/new_repo
-[config.R] Configuration loaded successfully.
-
-========================================================================
-03b_transition_grids.R  |  cost raster → gdistance transition
-========================================================================
-Cases to process: actual_1960_s1, actual_1986_s1, instrument_stu_s1, instrument_lcp_mst_s1, actual_1960_s2, actual_1986_s2, instrument_stu_s2, instrument_lcp_mst_s2
-
 
 [trans] ==== CASE: actual_1960_s1 ====
 [trans]   Reading /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/01_cost_rasters/ucost_actual_1960_s1.tif
 [trans]   Building 8-neighbour transition (1/mean(cost))
-[trans]   transition() took 47.5 s
+[trans]   transition() took 40.4 s
 [trans]   Applying geoCorrection (diagonal edges)
-[trans]   geoCorrection() took 3.7 s
+[trans]   geoCorrection() took 3.4 s
 [trans]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/02_transition_grids/transition_actual_1960_s1.rds
-
-[trans] ==== CASE: actual_1986_s1 ====
-[trans]   Reading /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/01_cost_rasters/ucost_actual_1986_s1.tif
-[trans]   Building 8-neighbour transition (1/mean(cost))
-[trans]   transition() took 31.2 s
-[trans]   Applying geoCorrection (diagonal edges)
-[trans]   geoCorrection() took 2.8 s
-[trans]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/02_transition_grids/transition_actual_1986_s1.rds
-
-[trans] ==== CASE: instrument_stu_s1 ====
-[trans]   Reading /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/01_cost_rasters/ucost_instrument_stu_s1.tif
-[trans]   Building 8-neighbour transition (1/mean(cost))
-[trans]   transition() took 31.1 s
-[trans]   Applying geoCorrection (diagonal edges)
-[trans]   geoCorrection() took 2.7 s
-[trans]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/02_transition_grids/transition_instrument_stu_s1.rds
-
-[trans] ==== CASE: instrument_lcp_mst_s1 ====
-[trans]   Reading /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/01_cost_rasters/ucost_instrument_lcp_mst_s1.tif
-[trans]   Building 8-neighbour transition (1/mean(cost))
-[trans]   transition() took 27.3 s
-[trans]   Applying geoCorrection (diagonal edges)
-[trans]   geoCorrection() took 2.4 s
-[trans]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/02_transition_grids/transition_instrument_lcp_mst_s1.rds
 
 [trans] ==== CASE: actual_1960_s2 ====
 [trans]   Reading /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/01_cost_rasters/ucost_actual_1960_s2.tif
 [trans]   Building 8-neighbour transition (1/mean(cost))
-[trans]   transition() took 27.4 s
+[trans]   transition() took 40.0 s
 [trans]   Applying geoCorrection (diagonal edges)
-[trans]   geoCorrection() took 2.8 s
+[trans]   geoCorrection() took 3.8 s
 [trans]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/02_transition_grids/transition_actual_1960_s2.rds
+
+[trans] ==== CASE: actual_1986_s0 ====
+[trans]   Reading /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/01_cost_rasters/ucost_actual_1986_s0.tif
+[trans]   Building 8-neighbour transition (1/mean(cost))
+[trans]   transition() took 40.1 s
+[trans]   Applying geoCorrection (diagonal edges)
+[trans]   geoCorrection() took 3.4 s
+[trans]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/02_transition_grids/transition_actual_1986_s0.rds
+
+[trans] ==== CASE: actual_1986_s1 ====
+[trans]   Reading /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/01_cost_rasters/ucost_actual_1986_s1.tif
+[trans]   Building 8-neighbour transition (1/mean(cost))
+[trans]   transition() took 59.0 s
+[trans]   Applying geoCorrection (diagonal edges)
+[trans]   geoCorrection() took 5.1 s
+[trans]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/02_transition_grids/transition_actual_1986_s1.rds
 
 [trans] ==== CASE: actual_1986_s2 ====
 [trans]   Reading /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/01_cost_rasters/ucost_actual_1986_s2.tif
 [trans]   Building 8-neighbour transition (1/mean(cost))
-[trans]   transition() took 27.4 s
+[trans]   transition() took 41.3 s
 [trans]   Applying geoCorrection (diagonal edges)
-[trans]   geoCorrection() took 2.4 s
+[trans]   geoCorrection() took 3.4 s
 [trans]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/02_transition_grids/transition_actual_1986_s2.rds
 
-[trans] ==== CASE: instrument_stu_s2 ====
-[trans]   Reading /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/01_cost_rasters/ucost_instrument_stu_s2.tif
+[trans] ==== CASE: instrument_lcp_mst_s0 ====
+[trans]   Reading /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/01_cost_rasters/ucost_instrument_lcp_mst_s0.tif
 [trans]   Building 8-neighbour transition (1/mean(cost))
-[trans]   transition() took 30.2 s
+[trans]   transition() took 46.5 s
 [trans]   Applying geoCorrection (diagonal edges)
-[trans]   geoCorrection() took 2.9 s
-[trans]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/02_transition_grids/transition_instrument_stu_s2.rds
+[trans]   geoCorrection() took 3.9 s
+[trans]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/02_transition_grids/transition_instrument_lcp_mst_s0.rds
+
+[trans] ==== CASE: instrument_lcp_mst_s1 ====
+[trans]   Reading /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/01_cost_rasters/ucost_instrument_lcp_mst_s1.tif
+[trans]   Building 8-neighbour transition (1/mean(cost))
+[trans]   transition() took 41.3 s
+[trans]   Applying geoCorrection (diagonal edges)
+[trans]   geoCorrection() took 3.4 s
+[trans]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/02_transition_grids/transition_instrument_lcp_mst_s1.rds
 
 [trans] ==== CASE: instrument_lcp_mst_s2 ====
 [trans]   Reading /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/01_cost_rasters/ucost_instrument_lcp_mst_s2.tif
 [trans]   Building 8-neighbour transition (1/mean(cost))
-[trans]   transition() took 27.5 s
+[trans]   transition() took 46.6 s
 [trans]   Applying geoCorrection (diagonal edges)
-[trans]   geoCorrection() took 2.4 s
+[trans]   geoCorrection() took 3.3 s
 [trans]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/02_transition_grids/transition_instrument_lcp_mst_s2.rds
+
+[trans] ==== CASE: instrument_stu_s0 ====
+[trans]   Reading /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/01_cost_rasters/ucost_instrument_stu_s0.tif
+[trans]   Building 8-neighbour transition (1/mean(cost))
+[trans]   transition() took 40.4 s
+[trans]   Applying geoCorrection (diagonal edges)
+[trans]   geoCorrection() took 3.9 s
+[trans]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/02_transition_grids/transition_instrument_stu_s0.rds
+
+[trans] ==== CASE: instrument_stu_s1 ====
+[trans]   Reading /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/01_cost_rasters/ucost_instrument_stu_s1.tif
+[trans]   Building 8-neighbour transition (1/mean(cost))
+[trans]   transition() took 40.5 s
+[trans]   Applying geoCorrection (diagonal edges)
+[trans]   geoCorrection() took 3.6 s
+[trans]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/02_transition_grids/transition_instrument_stu_s1.rds
+
+[trans] ==== CASE: instrument_stu_s2 ====
+[trans]   Reading /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/01_cost_rasters/ucost_instrument_stu_s2.tif
+[trans]   Building 8-neighbour transition (1/mean(cost))
+[trans]   transition() took 50.0 s
+[trans]   Applying geoCorrection (diagonal edges)
+[trans]   geoCorrection() took 4.3 s
+[trans]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/02_transition_grids/transition_instrument_stu_s2.rds
 ========================================================================
 03b_transition_grids.R  |  Complete.
 ========================================================================

--- a/logs/03c_compute_taus.log
+++ b/logs/03c_compute_taus.log
@@ -6,22 +6,23 @@ Warning messages:
 [config.R] Configuration loaded successfully.
 
 ========================================================================
-03c_compute_taus.R  |  Dijkstra on 312 district centroids
+03c_compute_taus_parallel.R  |  ncores = 4, 6 cases
 ========================================================================
-Cases: actual_1960_s0
+  actual_1960_s0
+  actual_1960_s1
+  actual_1960_s2
+  actual_1986_s0
+  actual_1986_s1
+  actual_1986_s2
+[tau] Loading district centroids
 
-[tau] Loading and centroid-ing district polygons
-[tau]   312 districts loaded
-
-[tau] ==== CASE: actual_1960_s0 ====
-[tau]   Reading /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/02_transition_grids/transition_actual_1960_s0.rds
-[tau]   Running gdistance::costDistance (312x312 Dijkstra)
-[tau]   costDistance() took 184.0 s
-Error in if (max_asym > 1e-06) { : missing value where TRUE/FALSE needed
-Calls: main -> compute_one_case
-In addition: Warning message:
-st_centroid assumes attributes are constant over geometries 
-Execution halted
+All cases done in 15.4 minutes.
+  OK    actual_1960_s0  519s  (median τ = 4440412, BA→Córdoba τ = 2649776, 0 Inf)
+  OK    actual_1960_s1  528s  (median τ = 3132547, BA→Córdoba τ = 1631465, 0 Inf)
+  OK    actual_1960_s2  441s  (median τ = 11384739, BA→Córdoba τ = 6962265, 0 Inf)
+  OK    actual_1986_s0  560s  (median τ = 3090342, BA→Córdoba τ = 1366749, 0 Inf)
+  OK    actual_1986_s1  478s  (median τ = 2012242, BA→Córdoba τ = 481408, 0 Inf)
+  OK    actual_1986_s2  402s  (median τ = 8361468, BA→Córdoba τ = 5646248, 0 Inf)
 Warning messages:
 1: package ‘sf’ was built under R version 4.5.2 
 2: package ‘sp’ was built under R version 4.5.2 
@@ -30,107 +31,20 @@ Warning messages:
 [config.R] Configuration loaded successfully.
 
 ========================================================================
-03c_compute_taus.R  |  Dijkstra on 312 district centroids
+03c_compute_taus_parallel.R  |  ncores = 4, 6 cases
 ========================================================================
-Cases: actual_1986_s0, instrument_stu_s0, instrument_lcp_mst_s0
+  instrument_stu_s0
+  instrument_stu_s1
+  instrument_stu_s2
+  instrument_lcp_mst_s0
+  instrument_lcp_mst_s1
+  instrument_lcp_mst_s2
+[tau] Loading district centroids
 
-[tau] Loading and centroid-ing district polygons
-[tau]   312 districts loaded
-
-[tau] ==== CASE: actual_1986_s0 ====
-[tau]   Reading /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/02_transition_grids/transition_actual_1986_s0.rds
-[tau]   Running gdistance::costDistance (312x312 Dijkstra)
-[tau]   costDistance() took 293.8 s
-[tau]   1240 Inf entries (disconnected; e.g. TdF on land-only surface)
-[tau]   eyeball BA (32002001) → Córdoba (32014014): τ = 1639445.2
-[tau]   τ summary (finite): min=9504.489  median=3308872.3  mean=3853716.1  max=26585406.4  (Inf pairs: 620)
-[tau]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/03_taus/tau_actual_1986_s0.parquet (48516 rows)
-
-[tau] ==== CASE: instrument_stu_s0 ====
-[tau]   Reading /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/02_transition_grids/transition_instrument_stu_s0.rds
-[tau]   Running gdistance::costDistance (312x312 Dijkstra)
-[tau]   costDistance() took 215.1 s
-[tau]   1240 Inf entries (disconnected; e.g. TdF on land-only surface)
-[tau]   eyeball BA (32002001) → Córdoba (32014014): τ = 2964422.0
-[tau]   τ summary (finite): min=9504.489  median=7145695.4  mean=11184987.3  max=90172896.9  (Inf pairs: 620)
-[tau]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/03_taus/tau_instrument_stu_s0.parquet (48516 rows)
-
-[tau] ==== CASE: instrument_lcp_mst_s0 ====
-[tau]   Reading /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/02_transition_grids/transition_instrument_lcp_mst_s0.rds
-[tau]   Running gdistance::costDistance (312x312 Dijkstra)
-[tau]   costDistance() took 214.0 s
-[tau]   eyeball BA (32002001) → Córdoba (32014014): τ = 3060435.9
-[tau]   τ summary (finite): min=13073.774  median=5125550.0  mean=8325550.2  max=74653151.5  (Inf pairs: 0)
-[tau]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/03_taus/tau_instrument_lcp_mst_s0.parquet (48516 rows)
-========================================================================
-03c_compute_taus.R  |  Complete.
-========================================================================
-
-Warning messages:
-1: st_centroid assumes attributes are constant over geometries 
-2: In compute_one_case(case, centroids) :
-  [tau] Asymmetry > 1e-6: max |τ_ij - τ_ji| = 1.64658e-06
-3: In compute_one_case(case, centroids) :
-  [tau] Asymmetry > 1e-6: max |τ_ij - τ_ji| = 7.48783e-06
-4: In compute_one_case(case, centroids) :
-  [tau] Asymmetry > 1e-6: max |τ_ij - τ_ji| = 4.4331e-06
-[config.R] rootdir = /Users/diegogp/Desktop/Diego/Trains/new_repo
-[config.R] Configuration loaded successfully.
-
-========================================================================
-03c_compute_taus_parallel.R  |  ncores = 4
-========================================================================
-Cases (4): actual_1960_s1, actual_1986_s1, instrument_stu_s1, instrument_lcp_mst_s1
-
-
-========================================================================
-03c_compute_taus.R  |  Dijkstra on 312 district centroids
-========================================================================
-Cases: 4, actual_1960_s1, actual_1986_s1, instrument_stu_s1, instrument_lcp_mst_s1
-
-[tau] Loading and centroid-ing district polygons
-
-========================================================================
-03c_compute_taus.R  |  Dijkstra on 312 district centroids
-========================================================================
-Cases: 4, actual_1960_s1, actual_1986_s1, instrument_stu_s1, instrument_lcp_mst_s1
-
-[tau] Loading and centroid-ing district polygons
-
-========================================================================
-03c_compute_taus.R  |  Dijkstra on 312 district centroids
-========================================================================
-Cases: 4, actual_1960_s1, actual_1986_s1, instrument_stu_s1, instrument_lcp_mst_s1
-
-[tau] Loading and centroid-ing district polygons
-
-========================================================================
-03c_compute_taus.R  |  Dijkstra on 312 district centroids
-========================================================================
-Cases: 4, actual_1960_s1, actual_1986_s1, instrument_stu_s1, instrument_lcp_mst_s1
-
-[tau] Loading and centroid-ing district polygons
-[tau]   312 districts loaded
-[tau]   312 districts loaded
-[tau]   312 districts loaded
-[tau]   312 districts loaded
-
-[tau] ==== CASE: 4 ====
-
-[tau] ==== CASE: 4 ====
-
-[tau] ==== CASE: 4 ====
-
-[tau] ==== CASE: 4 ====
-
-All cases done in 0.1 minutes.
-Status summary:
-  actual_1960_s1: FAIL
-  actual_1986_s1: FAIL
-  instrument_stu_s1: FAIL
-  instrument_lcp_mst_s1: FAIL
-Error in main() : 4 cases failed
-In addition: Warning message:
-In mclapply(cases, run_one_case, mc.cores = ncores, mc.preschedule = FALSE,  :
-  4 function calls resulted in an error
-Execution halted
+All cases done in 12.9 minutes.
+  OK    instrument_stu_s0  419s  (median τ = 5944318, BA→Córdoba τ = 2676906, 0 Inf)
+  OK    instrument_stu_s1  423s  (median τ = 4513426, BA→Córdoba τ = 1631465, 0 Inf)
+  OK    instrument_stu_s2  383s  (median τ = 13036118, BA→Córdoba τ = 6999915, 0 Inf)
+  OK    instrument_lcp_mst_s0  443s  (median τ = 4676508, BA→Córdoba τ = 2900820, 0 Inf)
+  OK    instrument_lcp_mst_s1  389s  (median τ = 3405625, BA→Córdoba τ = 1631465, 0 Inf)
+  OK    instrument_lcp_mst_s2  347s  (median τ = 12602962, BA→Córdoba τ = 10366208, 0 Inf)

--- a/logs/04_market_access.log
+++ b/logs/04_market_access.log
@@ -11,188 +11,170 @@ Elasticities: θ_low = 4.550, θ_high = 8.110
 
 [ma] ==== CASE: actual_1960_s0 (elow, θ=4.550) ====
 [ma]   τ file has 312 districts (48516 pairs)
-[ma]   MA computed for 312 districts; 2 have logMA = -Inf (MA = 0)
-[ma]   logMA -Inf for: 32094001, 32094002
-[ma]   MA summary (MA>0): min=2.971e-28 median=1.251e-22 max=2.566e-13
-[ma]   logMA summary (finite): min=-63.38  mean=-49.61  max=-28.99
+[ma]   MA computed for 312 districts; 0 have logMA = -Inf (MA = 0)
+[ma]   MA summary (MA>0): min=3.843e-28 median=1.481e-22 max=2.566e-13
+[ma]   logMA summary (finite): min=-63.13  mean=-49.03  max=-28.99
 [ma]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/04_market_access/ma_actual_1960_s0_elow.parquet
 
 [ma] ==== CASE: actual_1960_s0 (ehigh, θ=8.110) ====
 [ma]   τ file has 312 districts (48516 pairs)
-[ma]   MA computed for 312 districts; 2 have logMA = -Inf (MA = 0)
-[ma]   logMA -Inf for: 32094001, 32094002
-[ma]   MA summary (MA>0): min=6.223e-54 median=8.045e-45 max=1.547e-27
-[ma]   logMA summary (finite): min=-122.51  mean=-99.75  max=-61.73
+[ma]   MA computed for 312 districts; 0 have logMA = -Inf (MA = 0)
+[ma]   MA summary (MA>0): min=3.674e-55 median=1.166e-44 max=1.547e-27
+[ma]   logMA summary (finite): min=-125.34  mean=-98.92  max=-61.73
 [ma]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/04_market_access/ma_actual_1960_s0_ehigh.parquet
 
 [ma] ==== CASE: actual_1960_s1 (elow, θ=4.550) ====
 [ma]   τ file has 312 districts (48516 pairs)
-[ma]   MA computed for 312 districts; 2 have logMA = -Inf (MA = 0)
-[ma]   logMA -Inf for: 32094001, 32094002
-[ma]   MA summary (MA>0): min=3.306e-28 median=8.620e-22 max=3.591e-11
-[ma]   logMA summary (finite): min=-63.28  mean=-47.33  max=-24.05
+[ma]   MA computed for 312 districts; 0 have logMA = -Inf (MA = 0)
+[ma]   MA summary (MA>0): min=6.594e-28 median=1.001e-21 max=3.591e-11
+[ma]   logMA summary (finite): min=-62.59  mean=-46.83  max=-24.05
 [ma]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/04_market_access/ma_actual_1960_s1_elow.parquet
 
 [ma] ==== CASE: actual_1960_s1 (ehigh, θ=8.110) ====
 [ma]   τ file has 312 districts (48516 pairs)
-[ma]   MA computed for 312 districts; 2 have logMA = -Inf (MA = 0)
-[ma]   logMA -Inf for: 32094001, 32094002
-[ma]   MA summary (MA>0): min=6.356e-54 median=1.314e-43 max=1.041e-23
-[ma]   logMA summary (finite): min=-122.49  mean=-96.10  max=-52.92
+[ma]   MA computed for 312 districts; 0 have logMA = -Inf (MA = 0)
+[ma]   MA summary (MA>0): min=9.572e-55 median=1.524e-43 max=1.041e-23
+[ma]   logMA summary (finite): min=-124.38  mean=-95.35  max=-52.92
 [ma]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/04_market_access/ma_actual_1960_s1_ehigh.parquet
 
 [ma] ==== CASE: actual_1960_s2 (elow, θ=4.550) ====
 [ma]   τ file has 312 districts (48516 pairs)
-[ma]   MA computed for 312 districts; 2 have logMA = -Inf (MA = 0)
-[ma]   logMA -Inf for: 32094001, 32094002
-[ma]   MA summary (MA>0): min=1.937e-28 median=2.784e-24 max=8.264e-17
-[ma]   logMA summary (finite): min=-63.81  mean=-53.72  max=-37.03
+[ma]   MA computed for 312 districts; 0 have logMA = -Inf (MA = 0)
+[ma]   MA summary (MA>0): min=3.383e-29 median=4.421e-24 max=8.265e-17
+[ma]   logMA summary (finite): min=-65.56  mean=-52.93  max=-37.03
 [ma]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/04_market_access/ma_actual_1960_s2_elow.parquet
 
 [ma] ==== CASE: actual_1960_s2 (ehigh, θ=8.110) ====
 [ma]   τ file has 312 districts (48516 pairs)
-[ma]   MA computed for 312 districts; 2 have logMA = -Inf (MA = 0)
-[ma]   logMA -Inf for: 32094001, 32094002
-[ma]   MA summary (MA>0): min=1.824e-54 median=4.288e-47 max=9.474e-34
-[ma]   logMA summary (finite): min=-123.74  mean=-106.05  max=-76.04
+[ma]   MA computed for 312 districts; 0 have logMA = -Inf (MA = 0)
+[ma]   MA summary (MA>0): min=7.026e-57 median=6.163e-47 max=9.474e-34
+[ma]   logMA summary (finite): min=-129.30  mean=-105.04  max=-76.04
 [ma]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/04_market_access/ma_actual_1960_s2_ehigh.parquet
 
 [ma] ==== CASE: actual_1986_s0 (elow, θ=4.550) ====
 [ma]   τ file has 312 districts (48516 pairs)
-[ma]   MA computed for 312 districts; 2 have logMA = -Inf (MA = 0)
-[ma]   logMA -Inf for: 32094001, 32094002
-[ma]   MA summary (MA>0): min=8.222e-27 median=5.445e-22 max=2.601e-13
-[ma]   logMA summary (finite): min=-60.06  mean=-47.78  max=-28.98
+[ma]   MA computed for 312 districts; 0 have logMA = -Inf (MA = 0)
+[ma]   MA summary (MA>0): min=9.428e-27 median=8.647e-22 max=2.601e-13
+[ma]   logMA summary (finite): min=-59.93  mean=-47.47  max=-28.98
 [ma]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/04_market_access/ma_actual_1986_s0_elow.parquet
 
 [ma] ==== CASE: actual_1986_s0 (ehigh, θ=8.110) ====
 [ma]   τ file has 312 districts (48516 pairs)
-[ma]   MA computed for 312 districts; 2 have logMA = -Inf (MA = 0)
-[ma]   logMA -Inf for: 32094001, 32094002
-[ma]   MA summary (MA>0): min=8.640e-53 median=2.077e-43 max=1.548e-27
-[ma]   logMA summary (finite): min=-119.88  mean=-96.27  max=-61.73
+[ma]   MA computed for 312 districts; 0 have logMA = -Inf (MA = 0)
+[ma]   MA summary (MA>0): min=1.104e-52 median=3.813e-43 max=1.548e-27
+[ma]   logMA summary (finite): min=-119.64  mean=-95.85  max=-61.73
 [ma]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/04_market_access/ma_actual_1986_s0_ehigh.parquet
 
 [ma] ==== CASE: actual_1986_s1 (elow, θ=4.550) ====
 [ma]   τ file has 312 districts (48516 pairs)
-[ma]   MA computed for 312 districts; 2 have logMA = -Inf (MA = 0)
-[ma]   logMA -Inf for: 32094001, 32094002
-[ma]   MA summary (MA>0): min=1.177e-26 median=7.071e-21 max=3.592e-11
-[ma]   logMA summary (finite): min=-59.70  mean=-45.38  max=-24.05
+[ma]   MA computed for 312 districts; 0 have logMA = -Inf (MA = 0)
+[ma]   MA summary (MA>0): min=1.194e-26 median=7.970e-21 max=3.592e-11
+[ma]   logMA summary (finite): min=-59.69  mean=-45.26  max=-24.05
 [ma]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/04_market_access/ma_actual_1986_s1_elow.parquet
 
 [ma] ==== CASE: actual_1986_s1 (ehigh, θ=8.110) ====
 [ma]   τ file has 312 districts (48516 pairs)
-[ma]   MA computed for 312 districts; 2 have logMA = -Inf (MA = 0)
-[ma]   logMA -Inf for: 32094001, 32094002
-[ma]   MA summary (MA>0): min=1.627e-52 median=5.808e-42 max=1.041e-23
-[ma]   logMA summary (finite): min=-119.25  mean=-92.55  max=-52.92
+[ma]   MA computed for 312 districts; 0 have logMA = -Inf (MA = 0)
+[ma]   MA summary (MA>0): min=1.666e-52 median=8.815e-42 max=1.041e-23
+[ma]   logMA summary (finite): min=-119.22  mean=-92.34  max=-52.92
 [ma]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/04_market_access/ma_actual_1986_s1_ehigh.parquet
 
 [ma] ==== CASE: actual_1986_s2 (elow, θ=4.550) ====
 [ma]   τ file has 312 districts (48516 pairs)
-[ma]   MA computed for 312 districts; 2 have logMA = -Inf (MA = 0)
-[ma]   logMA -Inf for: 32094001, 32094002
-[ma]   MA summary (MA>0): min=1.679e-27 median=1.175e-23 max=8.404e-17
-[ma]   logMA summary (finite): min=-61.65  mean=-51.97  max=-37.02
+[ma]   MA computed for 312 districts; 0 have logMA = -Inf (MA = 0)
+[ma]   MA summary (MA>0): min=3.580e-27 median=2.096e-23 max=8.404e-17
+[ma]   logMA summary (finite): min=-60.89  mean=-51.36  max=-37.02
 [ma]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/04_market_access/ma_actual_1986_s2_elow.parquet
 
 [ma] ==== CASE: actual_1986_s2 (ehigh, θ=8.110) ====
 [ma]   τ file has 312 districts (48516 pairs)
-[ma]   MA computed for 312 districts; 2 have logMA = -Inf (MA = 0)
-[ma]   logMA -Inf for: 32094001, 32094002
-[ma]   MA summary (MA>0): min=5.834e-54 median=5.640e-46 max=9.610e-34
-[ma]   logMA summary (finite): min=-122.58  mean=-102.89  max=-76.03
+[ma]   MA computed for 312 districts; 0 have logMA = -Inf (MA = 0)
+[ma]   MA summary (MA>0): min=2.132e-53 median=1.205e-45 max=9.610e-34
+[ma]   logMA summary (finite): min=-121.28  mean=-102.13  max=-76.03
 [ma]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/04_market_access/ma_actual_1986_s2_ehigh.parquet
 
 [ma] ==== CASE: instrument_lcp_mst_s0 (elow, θ=4.550) ====
 [ma]   τ file has 312 districts (48516 pairs)
 [ma]   MA computed for 312 districts; 0 have logMA = -Inf (MA = 0)
-[ma]   MA summary (MA>0): min=2.264e-28 median=1.205e-22 max=7.021e-14
-[ma]   logMA summary (finite): min=-63.66  mean=-50.10  max=-30.29
+[ma]   MA summary (MA>0): min=4.675e-27 median=1.411e-22 max=7.021e-14
+[ma]   logMA summary (finite): min=-60.63  mean=-49.53  max=-30.29
 [ma]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/04_market_access/ma_instrument_lcp_mst_s0_elow.parquet
 
 [ma] ==== CASE: instrument_lcp_mst_s0 (ehigh, θ=8.110) ====
 [ma]   τ file has 312 districts (48516 pairs)
 [ma]   MA computed for 312 districts; 0 have logMA = -Inf (MA = 0)
-[ma]   MA summary (MA>0): min=6.019e-54 median=6.055e-45 max=1.551e-28
-[ma]   logMA summary (finite): min=-122.54  mean=-100.73  max=-64.03
+[ma]   MA summary (MA>0): min=3.230e-53 median=7.250e-45 max=1.551e-28
+[ma]   logMA summary (finite): min=-120.86  mean=-99.90  max=-64.03
 [ma]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/04_market_access/ma_instrument_lcp_mst_s0_ehigh.parquet
 
 [ma] ==== CASE: instrument_lcp_mst_s1 (elow, θ=4.550) ====
 [ma]   τ file has 312 districts (48516 pairs)
 [ma]   MA computed for 312 districts; 0 have logMA = -Inf (MA = 0)
-[ma]   MA summary (MA>0): min=2.409e-28 median=7.856e-22 max=3.584e-11
-[ma]   logMA summary (finite): min=-63.59  mean=-47.95  max=-24.05
+[ma]   MA summary (MA>0): min=7.353e-27 median=8.168e-22 max=3.584e-11
+[ma]   logMA summary (finite): min=-60.17  mean=-47.50  max=-24.05
 [ma]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/04_market_access/ma_instrument_lcp_mst_s1_elow.parquet
 
 [ma] ==== CASE: instrument_lcp_mst_s1 (ehigh, θ=8.110) ====
 [ma]   τ file has 312 districts (48516 pairs)
 [ma]   MA computed for 312 districts; 0 have logMA = -Inf (MA = 0)
-[ma]   MA summary (MA>0): min=6.043e-54 median=1.050e-43 max=1.041e-23
-[ma]   logMA summary (finite): min=-122.54  mean=-97.29  max=-52.92
+[ma]   MA summary (MA>0): min=7.193e-53 median=1.136e-43 max=1.041e-23
+[ma]   logMA summary (finite): min=-120.06  mean=-96.58  max=-52.92
 [ma]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/04_market_access/ma_instrument_lcp_mst_s1_ehigh.parquet
 
 [ma] ==== CASE: instrument_lcp_mst_s2 (elow, θ=4.550) ====
 [ma]   τ file has 312 districts (48516 pairs)
 [ma]   MA computed for 312 districts; 0 have logMA = -Inf (MA = 0)
-[ma]   MA summary (MA>0): min=1.637e-28 median=1.331e-24 max=1.892e-17
-[ma]   logMA summary (finite): min=-63.98  mean=-54.37  max=-38.51
+[ma]   MA summary (MA>0): min=3.139e-28 median=1.973e-24 max=1.892e-17
+[ma]   logMA summary (finite): min=-63.33  mean=-53.61  max=-38.51
 [ma]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/04_market_access/ma_instrument_lcp_mst_s2_elow.parquet
 
 [ma] ==== CASE: instrument_lcp_mst_s2 (ehigh, θ=8.110) ====
 [ma]   τ file has 312 districts (48516 pairs)
 [ma]   MA computed for 312 districts; 0 have logMA = -Inf (MA = 0)
-[ma]   MA summary (MA>0): min=4.031e-55 median=8.986e-48 max=6.657e-35
-[ma]   logMA summary (finite): min=-125.25  mean=-107.31  max=-78.69
+[ma]   MA summary (MA>0): min=4.643e-55 median=1.492e-47 max=6.657e-35
+[ma]   logMA summary (finite): min=-125.11  mean=-106.33  max=-78.69
 [ma]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/04_market_access/ma_instrument_lcp_mst_s2_ehigh.parquet
 
 [ma] ==== CASE: instrument_stu_s0 (elow, θ=4.550) ====
 [ma]   τ file has 312 districts (48516 pairs)
-[ma]   MA computed for 312 districts; 2 have logMA = -Inf (MA = 0)
-[ma]   logMA -Inf for: 32094001, 32094002
-[ma]   MA summary (MA>0): min=1.612e-28 median=3.726e-23 max=2.566e-13
-[ma]   logMA summary (finite): min=-63.99  mean=-50.92  max=-28.99
+[ma]   MA computed for 312 districts; 0 have logMA = -Inf (MA = 0)
+[ma]   MA summary (MA>0): min=1.685e-28 median=4.251e-23 max=2.566e-13
+[ma]   logMA summary (finite): min=-63.95  mean=-50.27  max=-28.99
 [ma]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/04_market_access/ma_instrument_stu_s0_elow.parquet
 
 [ma] ==== CASE: instrument_stu_s0 (ehigh, θ=8.110) ====
 [ma]   τ file has 312 districts (48516 pairs)
-[ma]   MA computed for 312 districts; 2 have logMA = -Inf (MA = 0)
-[ma]   logMA -Inf for: 32094001, 32094002
-[ma]   MA summary (MA>0): min=8.416e-56 median=1.030e-45 max=1.547e-27
-[ma]   logMA summary (finite): min=-126.81  mean=-102.09  max=-61.73
+[ma]   MA computed for 312 districts; 0 have logMA = -Inf (MA = 0)
+[ma]   MA summary (MA>0): min=8.847e-56 median=1.370e-45 max=1.547e-27
+[ma]   logMA summary (finite): min=-126.76  mean=-101.14  max=-61.73
 [ma]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/04_market_access/ma_instrument_stu_s0_ehigh.parquet
 
 [ma] ==== CASE: instrument_stu_s1 (elow, θ=4.550) ====
 [ma]   τ file has 312 districts (48516 pairs)
-[ma]   MA computed for 312 districts; 2 have logMA = -Inf (MA = 0)
-[ma]   logMA -Inf for: 32094001, 32094002
-[ma]   MA summary (MA>0): min=2.106e-28 median=2.508e-22 max=3.587e-11
-[ma]   logMA summary (finite): min=-63.73  mean=-49.04  max=-24.05
+[ma]   MA computed for 312 districts; 0 have logMA = -Inf (MA = 0)
+[ma]   MA summary (MA>0): min=2.142e-28 median=2.744e-22 max=3.587e-11
+[ma]   logMA summary (finite): min=-63.71  mean=-48.44  max=-24.05
 [ma]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/04_market_access/ma_instrument_stu_s1_elow.parquet
 
 [ma] ==== CASE: instrument_stu_s1 (ehigh, θ=8.110) ====
 [ma]   τ file has 312 districts (48516 pairs)
-[ma]   MA computed for 312 districts; 2 have logMA = -Inf (MA = 0)
-[ma]   logMA -Inf for: 32094001, 32094002
-[ma]   MA summary (MA>0): min=1.320e-55 median=1.454e-44 max=1.041e-23
-[ma]   logMA summary (finite): min=-126.36  mean=-99.15  max=-52.92
+[ma]   MA computed for 312 districts; 0 have logMA = -Inf (MA = 0)
+[ma]   MA summary (MA>0): min=1.348e-55 median=1.528e-44 max=1.041e-23
+[ma]   logMA summary (finite): min=-126.34  mean=-98.22  max=-52.92
 [ma]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/04_market_access/ma_instrument_stu_s1_ehigh.parquet
 
 [ma] ==== CASE: instrument_stu_s2 (elow, θ=4.550) ====
 [ma]   τ file has 312 districts (48516 pairs)
-[ma]   MA computed for 312 districts; 2 have logMA = -Inf (MA = 0)
-[ma]   logMA -Inf for: 32094001, 32094002
-[ma]   MA summary (MA>0): min=5.700e-29 median=1.259e-24 max=8.264e-17
-[ma]   logMA summary (finite): min=-65.03  mean=-54.43  max=-37.03
+[ma]   MA computed for 312 districts; 0 have logMA = -Inf (MA = 0)
+[ma]   MA summary (MA>0): min=2.653e-29 median=2.155e-24 max=8.265e-17
+[ma]   logMA summary (finite): min=-65.80  mean=-53.57  max=-37.03
 [ma]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/04_market_access/ma_instrument_stu_s2_elow.parquet
 
 [ma] ==== CASE: instrument_stu_s2 (ehigh, θ=8.110) ====
 [ma]   τ file has 312 districts (48516 pairs)
-[ma]   MA computed for 312 districts; 2 have logMA = -Inf (MA = 0)
-[ma]   logMA -Inf for: 32094001, 32094002
-[ma]   MA summary (MA>0): min=1.989e-56 median=1.265e-47 max=9.474e-34
-[ma]   logMA summary (finite): min=-128.26  mean=-107.39  max=-76.04
+[ma]   MA computed for 312 districts; 0 have logMA = -Inf (MA = 0)
+[ma]   MA summary (MA>0): min=5.396e-57 median=1.956e-47 max=9.474e-34
+[ma]   logMA summary (finite): min=-129.56  mean=-106.27  max=-76.04
 [ma]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/04_market_access/ma_instrument_stu_s2_ehigh.parquet
 ========================================================================
 04_market_access.R  |  Complete.

--- a/logs/06_merge_ma_into_panel.log
+++ b/logs/06_merge_ma_into_panel.log
@@ -4,45 +4,27 @@
 ========================================================================
 06_merge_ma_into_panel.R  |  merge MA into wide panel
 ========================================================================
-[panel] Starting panel: 312 × 125
-[panel] Removing 7 stale MA columns: logMA_actual_1960_s0_elow, logMA_actual_1986_s0_elow, logMA_instrument_stu_s0_elow, logMA_instrument_lcp_mst_s0_elow, chg_logMA_86_60_s0_elow, chg_logMA_stu_s0_elow, chg_logMA_lcp_mst_s0_elow
-[panel] actual_1960_s0_elow                  2 districts with logMA=-Inf recoded to NA
-[panel] actual_1960_s0_ehigh                 2 districts with logMA=-Inf recoded to NA
-[panel] actual_1960_s1_elow                  2 districts with logMA=-Inf recoded to NA
-[panel] actual_1960_s1_ehigh                 2 districts with logMA=-Inf recoded to NA
-[panel] actual_1960_s2_elow                  2 districts with logMA=-Inf recoded to NA
-[panel] actual_1960_s2_ehigh                 2 districts with logMA=-Inf recoded to NA
-[panel] actual_1986_s0_elow                  2 districts with logMA=-Inf recoded to NA
-[panel] actual_1986_s0_ehigh                 2 districts with logMA=-Inf recoded to NA
-[panel] actual_1986_s1_elow                  2 districts with logMA=-Inf recoded to NA
-[panel] actual_1986_s1_ehigh                 2 districts with logMA=-Inf recoded to NA
-[panel] actual_1986_s2_elow                  2 districts with logMA=-Inf recoded to NA
-[panel] actual_1986_s2_ehigh                 2 districts with logMA=-Inf recoded to NA
-[panel] instrument_stu_s0_elow               2 districts with logMA=-Inf recoded to NA
-[panel] instrument_stu_s0_ehigh              2 districts with logMA=-Inf recoded to NA
-[panel] instrument_stu_s1_elow               2 districts with logMA=-Inf recoded to NA
-[panel] instrument_stu_s1_ehigh              2 districts with logMA=-Inf recoded to NA
-[panel] instrument_stu_s2_elow               2 districts with logMA=-Inf recoded to NA
-[panel] instrument_stu_s2_ehigh              2 districts with logMA=-Inf recoded to NA
+[panel] Starting panel: 312 × 160
+[panel] Removing 42 stale MA columns: logMA_actual_1960_s0_elow, logMA_actual_1960_s0_ehigh, logMA_actual_1960_s1_elow, logMA_actual_1960_s1_ehigh, logMA_actual_1960_s2_elow, logMA_actual_1960_s2_ehigh, logMA_actual_1986_s0_elow, logMA_actual_1986_s0_ehigh, logMA_actual_1986_s1_elow, logMA_actual_1986_s1_ehigh, logMA_actual_1986_s2_elow, logMA_actual_1986_s2_ehigh, logMA_instrument_stu_s0_elow, logMA_instrument_stu_s0_ehigh, logMA_instrument_stu_s1_elow, logMA_instrument_stu_s1_ehigh, logMA_instrument_stu_s2_elow, logMA_instrument_stu_s2_ehigh, logMA_instrument_lcp_mst_s0_elow, logMA_instrument_lcp_mst_s0_ehigh, logMA_instrument_lcp_mst_s1_elow, logMA_instrument_lcp_mst_s1_ehigh, logMA_instrument_lcp_mst_s2_elow, logMA_instrument_lcp_mst_s2_ehigh, chg_logMA_86_60_s0_elow, chg_logMA_stu_s0_elow, chg_logMA_lcp_mst_s0_elow, chg_logMA_86_60_s0_ehigh, chg_logMA_stu_s0_ehigh, chg_logMA_lcp_mst_s0_ehigh, chg_logMA_86_60_s1_elow, chg_logMA_stu_s1_elow, chg_logMA_lcp_mst_s1_elow, chg_logMA_86_60_s1_ehigh, chg_logMA_stu_s1_ehigh, chg_logMA_lcp_mst_s1_ehigh, chg_logMA_86_60_s2_elow, chg_logMA_stu_s2_elow, chg_logMA_lcp_mst_s2_elow, chg_logMA_86_60_s2_ehigh, chg_logMA_stu_s2_ehigh, chg_logMA_lcp_mst_s2_ehigh
 [panel] 18 change variables built:
-  chg_logMA_86_60_s0_elow                   N=310  mean=+1.837  sd=2.791
-  chg_logMA_stu_s0_elow                     N=310  mean=-1.305  sd=2.253
-  chg_logMA_lcp_mst_s0_elow                 N=310  mean=-0.444  sd=2.564
-  chg_logMA_86_60_s0_ehigh                  N=310  mean=+3.479  sd=5.560
-  chg_logMA_stu_s0_ehigh                    N=310  mean=-2.342  sd=4.404
-  chg_logMA_lcp_mst_s0_ehigh                N=310  mean=-0.887  sd=5.216
-  chg_logMA_86_60_s1_elow                   N=310  mean=+1.950  sd=3.666
-  chg_logMA_stu_s1_elow                     N=310  mean=-1.713  sd=3.092
-  chg_logMA_lcp_mst_s1_elow                 N=310  mean=-0.570  sd=3.288
-  chg_logMA_86_60_s1_ehigh                  N=310  mean=+3.550  sd=6.966
-  chg_logMA_stu_s1_ehigh                    N=310  mean=-3.052  sd=5.766
-  chg_logMA_lcp_mst_s1_ehigh                N=310  mean=-1.101  sd=6.361
-  chg_logMA_86_60_s2_elow                   N=310  mean=+1.752  sd=1.811
-  chg_logMA_stu_s2_elow                     N=310  mean=-0.707  sd=1.222
-  chg_logMA_lcp_mst_s2_elow                 N=310  mean=-0.596  sd=1.879
-  chg_logMA_86_60_s2_ehigh                  N=310  mean=+3.159  sd=3.617
-  chg_logMA_stu_s2_ehigh                    N=310  mean=-1.345  sd=2.548
-  chg_logMA_lcp_mst_s2_ehigh                N=310  mean=-1.161  sd=3.879
+  chg_logMA_86_60_s0_elow                   N=312  mean=+1.559  sd=2.483
+  chg_logMA_stu_s0_elow                     N=312  mean=-1.240  sd=2.225
+  chg_logMA_lcp_mst_s0_elow                 N=312  mean=-0.494  sd=2.479
+  chg_logMA_86_60_s0_ehigh                  N=312  mean=+3.069  sd=5.140
+  chg_logMA_stu_s0_ehigh                    N=312  mean=-2.223  sd=4.318
+  chg_logMA_lcp_mst_s0_ehigh                N=312  mean=-0.979  sd=5.017
+  chg_logMA_86_60_s1_elow                   N=312  mean=+1.571  sd=3.301
+  chg_logMA_stu_s1_elow                     N=312  mean=-1.612  sd=3.023
+  chg_logMA_lcp_mst_s1_elow                 N=312  mean=-0.663  sd=3.175
+  chg_logMA_86_60_s1_ehigh                  N=312  mean=+3.004  sd=6.481
+  chg_logMA_stu_s1_ehigh                    N=312  mean=-2.875  sd=5.635
+  chg_logMA_lcp_mst_s1_ehigh                N=312  mean=-1.232  sd=6.187
+  chg_logMA_86_60_s2_elow                   N=312  mean=+1.573  sd=1.601
+  chg_logMA_stu_s2_elow                     N=312  mean=-0.636  sd=1.227
+  chg_logMA_lcp_mst_s2_elow                 N=312  mean=-0.682  sd=1.730
+  chg_logMA_86_60_s2_ehigh                  N=312  mean=+2.911  sd=3.377
+  chg_logMA_stu_s2_ehigh                    N=312  mean=-1.237  sd=2.507
+  chg_logMA_lcp_mst_s2_ehigh                N=312  mean=-1.290  sd=3.610
 [panel] Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/05_panel/departments_wide_panel.parquet (312 × 160)
 [panel] Manifest: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/05_panel/data_file_manifest.log
 ========================================================================


### PR DESCRIPTION
Closes #34

Extends the cost-raster build so navigable rivers and the Strait of Magellan get `cost_nav[sector]` (0.621 pesos/ton-km in sector 0), overriding rail/road/land. Matches the old-pipeline order of precedence. Completes the water side of the cost surface that Phase 1/2a deliberately skipped.

## Navigation polygon construction

1. **Rivers**: `cursos_de_agua.shp` filtered to `navegabili == "SI"` (1,128 navigable segments per IGN's own flag), buffered by 1 km.
2. **Strait of Magellan**: `cuerpos_de_agua.shp` filtered to `nombre == "DE MAGALLANES"` (3 polygons), buffered by **5 km**. The larger buffer is needed because the IGN polygons trace the water itself; in the 1.2 km raster that leaves gaps between the water and coastlines on both sides, and Dijkstra on 8-connected cells can't bridge those gaps. A 5 km buffer extends the polygon across the shorelines on both sides so at least one raster cell per coast becomes navigable. Without it TdF stays disconnected from the mainland.
3. Union of 1 + 2, rasterized to a binary nav layer.

The two inclusions are the only hand-curated data decisions in the nav layer. River navigability comes from IGN; Magellan is a single named override.

## Cost formula updated

```
if navigable:             cost_nav[sector]         (NEW — takes precedence)
elif rail and road:       cost_mininfra[sector]
elif rail only:           cost_rail[sector]
elif road only:           cost_road[sector]
elif in Argentina + HMI:  cost_land × HMI
else:                     NA (hard barrier)
```

Navigation is allowed outside the country polygon (rivers that form borders, Magellan strait sits in ocean). Only non-navigation, non-network pixels are masked to NA when outside `pais.shp`.

## Results

**First-stage F and IV (uncontrolled, elow):**

| Sector | Phase | F(stu) | F(lcp) | F(both) | OLS | IV-LP | IV-Hypo |
|---|---|---:|---:|---:|---:|---:|---:|
| s0 | 2a | 17.84 | 20.07 | 23.90 | 0.067 | 0.030 | -0.010 |
| s0 | **2b** | **26.23** | **21.49** | **29.05** | **0.051** | **0.026** | **+0.012** |
| s1 | 2a | 36.77 | 20.79 | 34.69 | 0.044 | 0.014 | -0.011 |
| s1 | **2b** | **48.11** | **21.15** | **40.94** | **0.031** | **0.017** | **-0.002** |
| s2 | 2a | 0.29 | 60.05 | 33.56 | 0.104 | 0.400 | 0.033 |
| s2 | **2b** | **3.05** | **53.83** | **31.94** | **0.089** | **0.152** | **0.041** |

Headline improvements:

- **First-stage F strengthens everywhere for the LP instrument.** s0 goes 17.8 → 26.2; s1 goes 36.8 → 48.1; s2 goes 0.29 → 3.05 (still weak for manufacturing, but 10× stronger — consistent with the economic intuition that rail matters less for manufacturing).
- **Tierra del Fuego is now connected.** All 312 districts have finite τ and logMA in every one of the 24 MA columns. Was NA for TdF in Phase 1/2a due to land-only disconnection.
- **IV-Hypo turns positive at s0** (was −0.010, now +0.012). Still small and insignificant, but directionally consistent with the other instruments.
- **OLS shrinks slightly** (0.067 → 0.051 at s0 elow) — navigation absorbs some of the MA-change variance.

## Runtime

End-to-end rebuild of all 12 cases with navigation:

- Cost rasters: ~6 min (12 × 30 s)
- Transition grids: ~10 min (12 × 50 s)
- Tau matrices: ~28 min (2 batches of 6 cases × 4-core parallel)
- MAs (24 combos): ~2 min
- Panel merge: <1 s

Total: ~46 min.

## Verified

- All 12 cost rasters validate against their sector's cost parameters (`cost_nav[sector]`, `cost_rail[sector]`, `cost_road[sector]`, `cost_mininfra[sector]`).
- All 12 τ matrices have 0 Inf pairs (vs 620 in Phase 1/2a).
- BA → Córdoba τ drops from 2,937,292 (Phase 2a) to 2,649,776 (Phase 2b, −10%) as the Paraná water route becomes available.
- All regression N now 312 for s0/s1/s2 change variables (was 310 with TdF missing).
- Panel manifest updated with the multi-sector × multi-elasticity NOTE.

## Out of scope

- **Phase 2c**: additional hypothetical-road instrument variants (euc_mst, euc, lcp).
- **Phase 3**: counterfactual rasters (rail-only-change, road-only-change).
- **Port-to-port LCP nav refinement**: the old pipeline routed navigation through 45 IGN ports via LCPs. The Phase 2b approach (buffered polygons) is simpler and captures the main cost gradient. If routing artifacts appear (e.g. goods boarding ferries mid-strait), upgrade to the port-LCP approach in a follow-up.