### PR TITLE
Phase 2c: add euc_mst / lcp / euc hypothetical-road instruments

### DIFF
--- a/code/pipeline/03a_build_cost_raster.R
+++ b/code/pipeline/03a_build_cost_raster.R
@@ -37,14 +37,17 @@
 #       elif in Argentina + HMI:  cost_land × HMI    (constant across sectors)
 #       else (outside Argentina): NA (hard barrier for Dijkstra)
 #
-# CASES (Phase 1 + 2a):
-#   Four network specs × three sectors = twelve cases.
+# CASES (Phase 1 + 2a + 2b + 2c):
+#   Seven network specs × three sectors = twenty-one cases.
 #
 #   Network specs:
-#     actual_1960        — 1960 rails + 1954 roads + HMI
-#     actual_1986        — 1986 rails + 1986 roads + HMI
-#     instrument_stu     — non-studied rails only + 1954 roads + HMI
-#     instrument_lcp_mst — 1960 rails + LCP-MST hypothetical roads + HMI
+#     actual_1960         — 1960 rails + 1954 roads + HMI + nav
+#     actual_1986         — 1986 rails + 1986 roads + HMI + nav
+#     instrument_stu      — non-studied rails only + 1954 roads + HMI + nav
+#     instrument_lcp_mst  — 1960 rails + LCP-MST hypothetical roads + HMI + nav
+#     instrument_euc_mst  — 1960 rails + Euclidean-MST hypothetical roads
+#     instrument_lcp      — 1960 rails + bilateral-LCP hypothetical roads
+#     instrument_euc      — 1960 rails + bilateral-Euclidean hypothetical roads
 #
 #   Each of the above is generated at sector s0, s1, s2 (case label
 #   `<network>_<sector>`, e.g. `actual_1960_s1`).
@@ -88,23 +91,45 @@ case_registry <- function() {
         actual_1960 = list(
             rail_sel = function(r) r$status1979 %in% c(1, 2, 3),
             road_sel = function(r) r$type2      %in% c(1, 5, 7),
-            use_hypo = FALSE
+            use_hypo = FALSE,
+            hypo_file = NULL
         ),
         actual_1986 = list(
             rail_sel = function(r) r$status1979 == 1,
             road_sel = function(r) r$type2      %in% c(1, 2, 3, 5),
-            use_hypo = FALSE
+            use_hypo = FALSE,
+            hypo_file = NULL
         ),
         instrument_stu = list(
             rail_sel = function(r) r$status1979 %in% c(1, 2, 3) &
                                     r$studied_co == 0,
             road_sel = function(r) r$type2      %in% c(1, 5, 7),
-            use_hypo = FALSE
+            use_hypo = FALSE,
+            hypo_file = NULL
         ),
         instrument_lcp_mst = list(
             rail_sel = function(r) r$status1979 %in% c(1, 2, 3),
             road_sel = NULL,       # hypothetical network takes road slot
-            use_hypo = TRUE
+            use_hypo = TRUE,
+            hypo_file = "lcp_mst.gpkg"
+        ),
+        instrument_euc_mst = list(
+            rail_sel = function(r) r$status1979 %in% c(1, 2, 3),
+            road_sel = NULL,
+            use_hypo = TRUE,
+            hypo_file = "euc_mst.gpkg"
+        ),
+        instrument_lcp = list(
+            rail_sel = function(r) r$status1979 %in% c(1, 2, 3),
+            road_sel = NULL,
+            use_hypo = TRUE,
+            hypo_file = "lcp_network.gpkg"
+        ),
+        instrument_euc = list(
+            rail_sel = function(r) r$status1979 %in% c(1, 2, 3),
+            road_sel = NULL,
+            use_hypo = TRUE,
+            hypo_file = "euc_network.gpkg"
         )
     )
 
@@ -250,7 +275,7 @@ rasterize_rails <- function(base, sel) {
 # ---------------------------------------------------------------------------
 rasterize_roads_or_hypo <- function(base, spec) {
     if (isTRUE(spec$use_hypo)) {
-        return(rasterize_hypo(base))
+        return(rasterize_hypo(base, spec$hypo_file))
     }
     if (is.null(spec$road_sel)) {
         # Empty road raster (no roads at all)
@@ -282,10 +307,11 @@ rasterize_roads <- function(base, sel) {
     r
 }
 
-rasterize_hypo <- function(base) {
-    message("[cost]   Rasterising hypothetical LCP-MST road network")
+rasterize_hypo <- function(base, hypo_file) {
+    message(sprintf("[cost]   Rasterising hypothetical network (%s)",
+                    hypo_file))
     hypo_path <- file.path(
-        dir_derived, "02_hypothetical_networks", "lcp_mst.gpkg"
+        dir_derived, "02_hypothetical_networks", hypo_file
     )
     if (!file.exists(hypo_path)) {
         stop("Hypo network not found at: ", hypo_path)
@@ -294,7 +320,7 @@ rasterize_hypo <- function(base) {
     hypo <- sf::st_make_valid(hypo)
 
     hypo_proj <- sf::st_transform(hypo, crs = crs_raster)
-    hypo_buf  <- sf::st_buffer(hypo_proj, dist = 1000)
+    hypo_buf  <- sf::st_buffer(hypo_proj, dist = nav_linear_buffer_m)
     hypo_buf  <- sf::st_union(hypo_buf)
 
     r <- terra::rasterize(terra::vect(hypo_buf), base, field = 1L,

--- a/code/pipeline/06_merge_ma_into_panel.R
+++ b/code/pipeline/06_merge_ma_into_panel.R
@@ -12,14 +12,16 @@
 # PRODUCES:
 #   data/derived/05_panel/departments_wide_panel.parquet    (overwritten)
 #
-#   New columns (Phase 1 + Phase 2a):
-#     logMA_<case>_<s>_<e>           — 24 level columns
-#     chg_logMA_<timing>_<s>_<e>     — 18 change columns
+#   New columns (Phase 1 + Phase 2a + Phase 2b + Phase 2c):
+#     logMA_<case>_<s>_<e>           — 42 level columns
+#     chg_logMA_<timing>_<s>_<e>     — 36 change columns
 #   where:
-#     case ∈ {actual_1960, actual_1986, instrument_stu, instrument_lcp_mst}
+#     case ∈ {actual_1960, actual_1986, instrument_stu,
+#             instrument_lcp_mst, instrument_euc_mst,
+#             instrument_lcp, instrument_euc}
 #     s    ∈ {s0, s1, s2}
 #     e    ∈ {elow, ehigh}
-#     timing ∈ {86_60, stu, lcp_mst}
+#     timing ∈ {86_60, stu, lcp_mst, euc_mst, lcp, euc}
 #
 # NAMING CONVENTION:
 #   logMA_<case>_<s>_<e>
@@ -51,7 +53,9 @@ suppressPackageStartupMessages({
 # ---------------------------------------------------------------------------
 build_ma_cases_spec <- function() {
     network_specs <- c("actual_1960", "actual_1986",
-                       "instrument_stu", "instrument_lcp_mst")
+                       "instrument_stu",
+                       "instrument_lcp_mst", "instrument_euc_mst",
+                       "instrument_lcp",     "instrument_euc")
     sectors       <- c("s0", "s1", "s2")
     elasticities  <- c("elow", "ehigh")
 
@@ -160,7 +164,10 @@ add_change_vars <- function(panel) {
     timings <- c(
         "86_60"   = "logMA_actual_1986",
         "stu"     = "logMA_instrument_stu",
-        "lcp_mst" = "logMA_instrument_lcp_mst"
+        "lcp_mst" = "logMA_instrument_lcp_mst",
+        "euc_mst" = "logMA_instrument_euc_mst",
+        "lcp"     = "logMA_instrument_lcp",
+        "euc"     = "logMA_instrument_euc"
     )
     for (s in c("s0", "s1", "s2")) {
         for (e in c("elow", "ehigh")) {
@@ -175,13 +182,13 @@ add_change_vars <- function(panel) {
         }
     }
 
-    # Log the 18 change variables in a compact table
+    # Log the change variables
     chg_cols <- grep("^chg_logMA_", names(panel), value = TRUE)
     message(sprintf("[panel] %d change variables built:", length(chg_cols)))
     for (v in chg_cols) {
         vals <- panel[[v]]
         n_valid <- sum(!is.na(vals))
-        message(sprintf("  %-40s  N=%d  mean=%+.3f  sd=%.3f",
+        message(sprintf("  %-45s  N=%d  mean=%+.3f  sd=%.3f",
                         v, n_valid,
                         mean(vals, na.rm = TRUE),
                         sd(vals, na.rm = TRUE)))

--- a/data/derived/05_panel/data_file_manifest.log
+++ b/data/derived/05_panel/data_file_manifest.log
@@ -1,12 +1,12 @@
 Data file manifest — 05_build_panel.R + 06_merge_ma_into_panel.R
-Regenerated: 2026-05-10 08:44:15.071006
+Regenerated: 2026-05-10 09:25:37.399453
 rootdir: /Users/diegogp/Desktop/Diego/Trains/new_repo
 
 ============================================================ 
 FILE: departments_wide_panel.parquet
 ============================================================ 
 Rows: 312
-Columns: 160
+Columns: 196
 Key: geolev2
 
 NOTE ON logMA/chg_logMA COLUMNS:
@@ -168,21 +168,57 @@ Summary of every variable:
   logMA_instrument_lcp_mst_s1_ehigh N=312  mean=-96.6  sd=13.1  min=-120  max=-52.9  NA=0
   logMA_instrument_lcp_mst_s2_elow N=312  mean=-53.6  sd=4.81  min=-63.3  max=-38.5  NA=0
   logMA_instrument_lcp_mst_s2_ehigh N=312  mean=-106  sd=9.01  min=-125  max=-78.7  NA=0
+  logMA_instrument_euc_mst_s0_elow N=312  mean=-49.7  sd=5.94  min=-61.6  max=-30.3  NA=0
+  logMA_instrument_euc_mst_s0_ehigh N=312  mean=-100  sd=11.3  min=-122  max=-64  NA=0
+  logMA_instrument_euc_mst_s1_elow N=312  mean=-47.7  sd=7.14  min=-61.3  max=-24.1  NA=0
+  logMA_instrument_euc_mst_s1_ehigh N=312  mean=-97.1  sd=13.5  min=-122  max=-52.9  NA=0
+  logMA_instrument_euc_mst_s2_elow N=312  mean=-53.6  sd=4.91  min=-63.4  max=-38.2  NA=0
+  logMA_instrument_euc_mst_s2_ehigh N=312  mean=-107  sd=9.16  min=-125  max=-78.2  NA=0
+  logMA_instrument_lcp_s0_elow     N=312  mean=-48.3  sd=5.66  min=-60.5  max=-30.3  NA=0
+  logMA_instrument_lcp_s0_ehigh    N=312  mean=-97.5  sd=11  min=-121  max=-64  NA=0
+  logMA_instrument_lcp_s1_elow     N=312  mean=-46.2  sd=6.88  min=-60.1  max=-24.1  NA=0
+  logMA_instrument_lcp_s1_ehigh    N=312  mean=-94  sd=13.2  min=-120  max=-52.9  NA=0
+  logMA_instrument_lcp_s2_elow     N=312  mean=-52.4  sd=4.57  min=-62.6  max=-38.5  NA=0
+  logMA_instrument_lcp_s2_ehigh    N=312  mean=-104  sd=8.75  min=-124  max=-78.7  NA=0
+  logMA_instrument_euc_s0_elow     N=312  mean=-43.6  sd=6.25  min=-59.9  max=-28.7  NA=0
+  logMA_instrument_euc_s0_ehigh    N=312  mean=-88  sd=12  min=-120  max=-61.4  NA=0
+  logMA_instrument_euc_s1_elow     N=312  mean=-40.5  sd=7.39  min=-59.4  max=-24  NA=0
+  logMA_instrument_euc_s1_ehigh    N=312  mean=-82.8  sd=14.2  min=-119  max=-52.6  NA=0
+  logMA_instrument_euc_s2_elow     N=312  mean=-48.9  sd=5.15  min=-62.1  max=-35.7  NA=0
+  logMA_instrument_euc_s2_ehigh    N=312  mean=-97.4  sd=9.59  min=-123  max=-73.9  NA=0
   chg_logMA_86_60_s0_elow          N=312  mean=1.56  sd=2.48  min=-7.18  max=9.58  NA=0
   chg_logMA_stu_s0_elow            N=312  mean=-1.24  sd=2.22  min=-12.5  max=-3.5e-06  NA=0
   chg_logMA_lcp_mst_s0_elow        N=312  mean=-0.494  sd=2.48  min=-15.8  max=8.86  NA=0
+  chg_logMA_euc_mst_s0_elow        N=312  mean=-0.64  sd=2.4  min=-17.7  max=11.6  NA=0
+  chg_logMA_lcp_s0_elow            N=312  mean=0.71  sd=3.33  min=-15.7  max=11.9  NA=0
+  chg_logMA_euc_s0_elow            N=312  mean=5.47  sd=4.61  min=-17  max=16.4  NA=0
   chg_logMA_86_60_s0_ehigh         N=312  mean=3.07  sd=5.14  min=-14.5  max=18.1  NA=0
   chg_logMA_stu_s0_ehigh           N=312  mean=-2.22  sd=4.32  min=-23.5  max=-3.47e-10  NA=0
   chg_logMA_lcp_mst_s0_ehigh       N=312  mean=-0.979  sd=5.02  min=-29  max=17.2  NA=0
+  chg_logMA_euc_mst_s0_ehigh       N=312  mean=-1.41  sd=4.81  min=-33.2  max=22.2  NA=0
+  chg_logMA_lcp_s0_ehigh           N=312  mean=1.44  sd=6.83  min=-29  max=25  NA=0
+  chg_logMA_euc_s0_ehigh           N=312  mean=11  sd=9.43  min=-32.8  max=32.8  NA=0
   chg_logMA_86_60_s1_elow          N=312  mean=1.57  sd=3.3  min=-12.8  max=11.8  NA=0
   chg_logMA_stu_s1_elow            N=312  mean=-1.61  sd=3.02  min=-16.8  max=-3.05e-06  NA=0
   chg_logMA_lcp_mst_s1_elow        N=312  mean=-0.663  sd=3.17  min=-17.1  max=10.7  NA=0
+  chg_logMA_euc_mst_s1_elow        N=312  mean=-0.903  sd=3.13  min=-18.8  max=15.8  NA=0
+  chg_logMA_lcp_s1_elow            N=312  mean=0.666  sd=4.28  min=-16.9  max=14.9  NA=0
+  chg_logMA_euc_s1_elow            N=312  mean=6.36  sd=5.83  min=-18.3  max=17.8  NA=0
   chg_logMA_86_60_s1_ehigh         N=312  mean=3  sd=6.48  min=-24.9  max=21.3  NA=0
   chg_logMA_stu_s1_ehigh           N=312  mean=-2.88  sd=5.63  min=-31.3  max=-1.7e-10  NA=0
   chg_logMA_lcp_mst_s1_ehigh       N=312  mean=-1.23  sd=6.19  min=-33  max=21.7  NA=0
+  chg_logMA_euc_mst_s1_ehigh       N=312  mean=-1.73  sd=6.1  min=-36.8  max=29.9  NA=0
+  chg_logMA_lcp_s1_ehigh           N=312  mean=1.35  sd=8.45  min=-33  max=27.8  NA=0
+  chg_logMA_euc_s1_ehigh           N=312  mean=12.5  sd=11.6  min=-36.2  max=36.3  NA=0
   chg_logMA_86_60_s2_elow          N=312  mean=1.57  sd=1.6  min=-1.99  max=6.66  NA=0
   chg_logMA_stu_s2_elow            N=312  mean=-0.636  sd=1.23  min=-6.42  max=-6.6e-07  NA=0
   chg_logMA_lcp_mst_s2_elow        N=312  mean=-0.682  sd=1.73  min=-9.6  max=6.66  NA=0
+  chg_logMA_euc_mst_s2_elow        N=312  mean=-0.693  sd=1.71  min=-11.8  max=6.3  NA=0
+  chg_logMA_lcp_s2_elow            N=312  mean=0.565  sd=2.36  min=-9.59  max=7.75  NA=0
+  chg_logMA_euc_s2_elow            N=312  mean=4.03  sd=3.05  min=-11.6  max=12.1  NA=0
   chg_logMA_86_60_s2_ehigh         N=312  mean=2.91  sd=3.38  min=-4.23  max=14  NA=0
   chg_logMA_stu_s2_ehigh           N=312  mean=-1.24  sd=2.51  min=-14.6  max=-4.97e-11  NA=0
   chg_logMA_lcp_mst_s2_ehigh       N=312  mean=-1.29  sd=3.61  min=-17.3  max=13.1  NA=0
+  chg_logMA_euc_mst_s2_ehigh       N=312  mean=-1.56  sd=3.42  min=-21.5  max=12.7  NA=0
+  chg_logMA_lcp_s2_ehigh           N=312  mean=0.905  sd=4.9  min=-17.3  max=16.1  NA=0
+  chg_logMA_euc_s2_ehigh           N=312  mean=7.63  sd=6.28  min=-21.3  max=22.4  NA=0

--- a/logs/03a_build_cost_raster.log
+++ b/logs/03a_build_cost_raster.log
@@ -238,3 +238,180 @@ Cases to build: actual_1960_s0, actual_1960_s1, actual_1960_s2, actual_1986_s0, 
 03a_build_cost_raster.R  |  Complete.
 ========================================================================
 
+Warning messages:
+1: package ‘sf’ was built under R version 4.5.2 
+2: package ‘terra’ was built under R version 4.5.2 
+[config.R] rootdir = /Users/diegogp/Desktop/Diego/Trains/new_repo
+[config.R] Configuration loaded successfully.
+
+========================================================================
+03a_build_cost_raster.R  |  Phase 2b, with navigation, sectors 0/1/2
+========================================================================
+Cases to build: instrument_euc_mst_s0, instrument_euc_mst_s1, instrument_euc_mst_s2, instrument_lcp_s0, instrument_lcp_s1, instrument_lcp_s2, instrument_euc_s0, instrument_euc_s1, instrument_euc_s2
+
+
+[cost] ==== CASE: instrument_euc_mst_s0 ====
+[cost]   Rasterising country polygon (pais.shp)
+[cost]   Rasterising rails (selected subset)
+[cost]     Selected 565 / 565 segments
+[cost]     Rail pixels (value=1): 59254
+[cost]   Rasterising hypothetical network (euc_mst.gpkg)
+[cost]     Hypo road pixels (value=1): 10613
+[cost]   Rasterising navigation layer
+[cost]     Navigable river segments (cursos_de_agua): 1128
+[cost]     Strait of Magellan polygons (cuerpos_de_agua): 3
+[cost]     Navigation pixels (value=1): 13016
+[cost]   Projecting HMI to base raster
+[cost]     HMI pixels with value (not NA): 3191580
+[cost]   Combining layers (sector=overall)
+[cost]   Validation OK: nav=0.6210  rail_only=1.8740  road_only=1.7770  both=1.7770
+[cost]   Cost summary: min=0.621  mean=141.33  max=773.11  N=1923708
+[cost]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/01_cost_rasters/ucost_instrument_euc_mst_s0.tif
+
+[cost] ==== CASE: instrument_euc_mst_s1 ====
+[cost]   Rasterising country polygon (pais.shp)
+[cost]   Rasterising rails (selected subset)
+[cost]     Selected 565 / 565 segments
+[cost]     Rail pixels (value=1): 59254
+[cost]   Rasterising hypothetical network (euc_mst.gpkg)
+[cost]     Hypo road pixels (value=1): 10613
+[cost]   Rasterising navigation layer
+[cost]     Navigable river segments (cursos_de_agua): 1128
+[cost]     Strait of Magellan polygons (cuerpos_de_agua): 3
+[cost]     Navigation pixels (value=1): 13016
+[cost]   Projecting HMI to base raster
+[cost]     HMI pixels with value (not NA): 3191580
+[cost]   Combining layers (sector=agricultural)
+[cost]   Validation OK: nav=0.6210  rail_only=0.4650  road_only=1.0000  both=0.4650
+[cost]   Cost summary: min=0.465  mean=141.28  max=773.11  N=1923708
+[cost]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/01_cost_rasters/ucost_instrument_euc_mst_s1.tif
+
+[cost] ==== CASE: instrument_euc_mst_s2 ====
+[cost]   Rasterising country polygon (pais.shp)
+[cost]   Rasterising rails (selected subset)
+[cost]     Selected 565 / 565 segments
+[cost]     Rail pixels (value=1): 59254
+[cost]   Rasterising hypothetical network (euc_mst.gpkg)
+[cost]     Hypo road pixels (value=1): 10613
+[cost]   Rasterising navigation layer
+[cost]     Navigable river segments (cursos_de_agua): 1128
+[cost]     Strait of Magellan polygons (cuerpos_de_agua): 3
+[cost]     Navigation pixels (value=1): 13016
+[cost]   Projecting HMI to base raster
+[cost]     HMI pixels with value (not NA): 3191580
+[cost]   Combining layers (sector=manufacturing)
+[cost]   Validation OK: nav=0.6210  rail_only=13.4900  road_only=8.2660  both=8.2660
+[cost]   Cost summary: min=0.621  mean=141.72  max=773.11  N=1923708
+[cost]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/01_cost_rasters/ucost_instrument_euc_mst_s2.tif
+
+[cost] ==== CASE: instrument_lcp_s0 ====
+[cost]   Rasterising country polygon (pais.shp)
+[cost]   Rasterising rails (selected subset)
+[cost]     Selected 565 / 565 segments
+[cost]     Rail pixels (value=1): 59254
+[cost]   Rasterising hypothetical network (lcp_network.gpkg)
+[cost]     Hypo road pixels (value=1): 94661
+[cost]   Rasterising navigation layer
+[cost]     Navigable river segments (cursos_de_agua): 1128
+[cost]     Strait of Magellan polygons (cuerpos_de_agua): 3
+[cost]     Navigation pixels (value=1): 13016
+[cost]   Projecting HMI to base raster
+[cost]     HMI pixels with value (not NA): 3191580
+[cost]   Combining layers (sector=overall)
+[cost]   Validation OK: nav=0.6210  rail_only=1.8740  road_only=1.7770  both=1.7770
+[cost]   Cost summary: min=0.621  mean=134.78  max=773.11  N=1922878
+[cost]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/01_cost_rasters/ucost_instrument_lcp_s0.tif
+
+[cost] ==== CASE: instrument_lcp_s1 ====
+[cost]   Rasterising country polygon (pais.shp)
+[cost]   Rasterising rails (selected subset)
+[cost]     Selected 565 / 565 segments
+[cost]     Rail pixels (value=1): 59254
+[cost]   Rasterising hypothetical network (lcp_network.gpkg)
+[cost]     Hypo road pixels (value=1): 94661
+[cost]   Rasterising navigation layer
+[cost]     Navigable river segments (cursos_de_agua): 1128
+[cost]     Strait of Magellan polygons (cuerpos_de_agua): 3
+[cost]     Navigation pixels (value=1): 13016
+[cost]   Projecting HMI to base raster
+[cost]     HMI pixels with value (not NA): 3191580
+[cost]   Combining layers (sector=agricultural)
+[cost]   Validation OK: nav=0.6210  rail_only=0.4650  road_only=1.0000  both=0.4650
+[cost]   Cost summary: min=0.465  mean=134.70  max=773.11  N=1922878
+[cost]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/01_cost_rasters/ucost_instrument_lcp_s1.tif
+
+[cost] ==== CASE: instrument_lcp_s2 ====
+[cost]   Rasterising country polygon (pais.shp)
+[cost]   Rasterising rails (selected subset)
+[cost]     Selected 565 / 565 segments
+[cost]     Rail pixels (value=1): 59254
+[cost]   Rasterising hypothetical network (lcp_network.gpkg)
+[cost]     Hypo road pixels (value=1): 94661
+[cost]   Rasterising navigation layer
+[cost]     Navigable river segments (cursos_de_agua): 1128
+[cost]     Strait of Magellan polygons (cuerpos_de_agua): 3
+[cost]     Navigation pixels (value=1): 13016
+[cost]   Projecting HMI to base raster
+[cost]     HMI pixels with value (not NA): 3191580
+[cost]   Combining layers (sector=manufacturing)
+[cost]   Validation OK: nav=0.6210  rail_only=13.4900  road_only=8.2660  both=8.2660
+[cost]   Cost summary: min=0.621  mean=135.42  max=773.11  N=1922878
+[cost]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/01_cost_rasters/ucost_instrument_lcp_s2.tif
+
+[cost] ==== CASE: instrument_euc_s0 ====
+[cost]   Rasterising country polygon (pais.shp)
+[cost]   Rasterising rails (selected subset)
+[cost]     Selected 565 / 565 segments
+[cost]     Rail pixels (value=1): 59254
+[cost]   Rasterising hypothetical network (euc_network.gpkg)
+[cost]     Hypo road pixels (value=1): 851566
+[cost]   Rasterising navigation layer
+[cost]     Navigable river segments (cursos_de_agua): 1128
+[cost]     Strait of Magellan polygons (cuerpos_de_agua): 3
+[cost]     Navigation pixels (value=1): 13016
+[cost]   Projecting HMI to base raster
+[cost]     HMI pixels with value (not NA): 3191580
+[cost]   Combining layers (sector=overall)
+[cost]   Validation OK: nav=0.6210  rail_only=1.8740  road_only=1.7770  both=1.7770
+[cost]   Cost summary: min=0.621  mean=78.59  max=773.11  N=1982213
+[cost]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/01_cost_rasters/ucost_instrument_euc_s0.tif
+
+[cost] ==== CASE: instrument_euc_s1 ====
+[cost]   Rasterising country polygon (pais.shp)
+[cost]   Rasterising rails (selected subset)
+[cost]     Selected 565 / 565 segments
+[cost]     Rail pixels (value=1): 59254
+[cost]   Rasterising hypothetical network (euc_network.gpkg)
+[cost]     Hypo road pixels (value=1): 851566
+[cost]   Rasterising navigation layer
+[cost]     Navigable river segments (cursos_de_agua): 1128
+[cost]     Strait of Magellan polygons (cuerpos_de_agua): 3
+[cost]     Navigation pixels (value=1): 13016
+[cost]   Projecting HMI to base raster
+[cost]     HMI pixels with value (not NA): 3191580
+[cost]   Combining layers (sector=agricultural)
+[cost]   Validation OK: nav=0.6210  rail_only=0.4650  road_only=1.0000  both=0.4650
+[cost]   Cost summary: min=0.465  mean=78.23  max=773.11  N=1982213
+[cost]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/01_cost_rasters/ucost_instrument_euc_s1.tif
+
+[cost] ==== CASE: instrument_euc_s2 ====
+[cost]   Rasterising country polygon (pais.shp)
+[cost]   Rasterising rails (selected subset)
+[cost]     Selected 565 / 565 segments
+[cost]     Rail pixels (value=1): 59254
+[cost]   Rasterising hypothetical network (euc_network.gpkg)
+[cost]     Hypo road pixels (value=1): 851566
+[cost]   Rasterising navigation layer
+[cost]     Navigable river segments (cursos_de_agua): 1128
+[cost]     Strait of Magellan polygons (cuerpos_de_agua): 3
+[cost]     Navigation pixels (value=1): 13016
+[cost]   Projecting HMI to base raster
+[cost]     HMI pixels with value (not NA): 3191580
+[cost]   Combining layers (sector=manufacturing)
+[cost]   Validation OK: nav=0.6210  rail_only=13.4900  road_only=8.2660  both=8.2660
+[cost]   Cost summary: min=0.621  mean=81.50  max=773.11  N=1982213
+[cost]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/01_cost_rasters/ucost_instrument_euc_s2.tif
+========================================================================
+03a_build_cost_raster.R  |  Complete.
+========================================================================
+

--- a/logs/03b_transition_grids.log
+++ b/logs/03b_transition_grids.log
@@ -109,3 +109,90 @@ Cases to process: actual_1960_s0, actual_1960_s1, actual_1960_s2, actual_1986_s0
 03b_transition_grids.R  |  Complete.
 ========================================================================
 
+Warning messages:
+1: package ‘sp’ was built under R version 4.5.2 
+2: package ‘igraph’ was built under R version 4.5.2 
+[config.R] rootdir = /Users/diegogp/Desktop/Diego/Trains/new_repo
+[config.R] Configuration loaded successfully.
+
+========================================================================
+03b_transition_grids.R  |  cost raster → gdistance transition
+========================================================================
+Cases to process: instrument_euc_mst_s0, instrument_euc_mst_s1, instrument_euc_mst_s2, instrument_lcp_s0, instrument_lcp_s1, instrument_lcp_s2, instrument_euc_s0, instrument_euc_s1, instrument_euc_s2
+
+
+[trans] ==== CASE: instrument_euc_mst_s0 ====
+[trans]   Reading /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/01_cost_rasters/ucost_instrument_euc_mst_s0.tif
+[trans]   Building 8-neighbour transition (1/mean(cost))
+[trans]   transition() took 41.1 s
+[trans]   Applying geoCorrection (diagonal edges)
+[trans]   geoCorrection() took 4.4 s
+[trans]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/02_transition_grids/transition_instrument_euc_mst_s0.rds
+
+[trans] ==== CASE: instrument_euc_mst_s1 ====
+[trans]   Reading /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/01_cost_rasters/ucost_instrument_euc_mst_s1.tif
+[trans]   Building 8-neighbour transition (1/mean(cost))
+[trans]   transition() took 40.0 s
+[trans]   Applying geoCorrection (diagonal edges)
+[trans]   geoCorrection() took 3.3 s
+[trans]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/02_transition_grids/transition_instrument_euc_mst_s1.rds
+
+[trans] ==== CASE: instrument_euc_mst_s2 ====
+[trans]   Reading /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/01_cost_rasters/ucost_instrument_euc_mst_s2.tif
+[trans]   Building 8-neighbour transition (1/mean(cost))
+[trans]   transition() took 39.2 s
+[trans]   Applying geoCorrection (diagonal edges)
+[trans]   geoCorrection() took 3.8 s
+[trans]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/02_transition_grids/transition_instrument_euc_mst_s2.rds
+
+[trans] ==== CASE: instrument_lcp_s0 ====
+[trans]   Reading /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/01_cost_rasters/ucost_instrument_lcp_s0.tif
+[trans]   Building 8-neighbour transition (1/mean(cost))
+[trans]   transition() took 39.4 s
+[trans]   Applying geoCorrection (diagonal edges)
+[trans]   geoCorrection() took 3.3 s
+[trans]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/02_transition_grids/transition_instrument_lcp_s0.rds
+
+[trans] ==== CASE: instrument_lcp_s1 ====
+[trans]   Reading /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/01_cost_rasters/ucost_instrument_lcp_s1.tif
+[trans]   Building 8-neighbour transition (1/mean(cost))
+[trans]   transition() took 39.2 s
+[trans]   Applying geoCorrection (diagonal edges)
+[trans]   geoCorrection() took 3.5 s
+[trans]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/02_transition_grids/transition_instrument_lcp_s1.rds
+
+[trans] ==== CASE: instrument_lcp_s2 ====
+[trans]   Reading /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/01_cost_rasters/ucost_instrument_lcp_s2.tif
+[trans]   Building 8-neighbour transition (1/mean(cost))
+[trans]   transition() took 39.6 s
+[trans]   Applying geoCorrection (diagonal edges)
+[trans]   geoCorrection() took 3.2 s
+[trans]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/02_transition_grids/transition_instrument_lcp_s2.rds
+
+[trans] ==== CASE: instrument_euc_s0 ====
+[trans]   Reading /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/01_cost_rasters/ucost_instrument_euc_s0.tif
+[trans]   Building 8-neighbour transition (1/mean(cost))
+[trans]   transition() took 39.8 s
+[trans]   Applying geoCorrection (diagonal edges)
+[trans]   geoCorrection() took 4.0 s
+[trans]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/02_transition_grids/transition_instrument_euc_s0.rds
+
+[trans] ==== CASE: instrument_euc_s1 ====
+[trans]   Reading /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/01_cost_rasters/ucost_instrument_euc_s1.tif
+[trans]   Building 8-neighbour transition (1/mean(cost))
+[trans]   transition() took 40.0 s
+[trans]   Applying geoCorrection (diagonal edges)
+[trans]   geoCorrection() took 3.4 s
+[trans]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/02_transition_grids/transition_instrument_euc_s1.rds
+
+[trans] ==== CASE: instrument_euc_s2 ====
+[trans]   Reading /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/01_cost_rasters/ucost_instrument_euc_s2.tif
+[trans]   Building 8-neighbour transition (1/mean(cost))
+[trans]   transition() took 39.8 s
+[trans]   Applying geoCorrection (diagonal edges)
+[trans]   geoCorrection() took 3.9 s
+[trans]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/02_transition_grids/transition_instrument_euc_s2.rds
+========================================================================
+03b_transition_grids.R  |  Complete.
+========================================================================
+

--- a/logs/03c_compute_taus.log
+++ b/logs/03c_compute_taus.log
@@ -48,3 +48,47 @@ All cases done in 12.9 minutes.
   OK    instrument_lcp_mst_s0  443s  (median τ = 4676508, BA→Córdoba τ = 2900820, 0 Inf)
   OK    instrument_lcp_mst_s1  389s  (median τ = 3405625, BA→Córdoba τ = 1631465, 0 Inf)
   OK    instrument_lcp_mst_s2  347s  (median τ = 12602962, BA→Córdoba τ = 10366208, 0 Inf)
+Warning messages:
+1: package ‘sf’ was built under R version 4.5.2 
+2: package ‘sp’ was built under R version 4.5.2 
+3: package ‘igraph’ was built under R version 4.5.2 
+[config.R] rootdir = /Users/diegogp/Desktop/Diego/Trains/new_repo
+[config.R] Configuration loaded successfully.
+
+========================================================================
+03c_compute_taus_parallel.R  |  ncores = 4, 6 cases
+========================================================================
+  instrument_euc_mst_s0
+  instrument_euc_mst_s1
+  instrument_euc_mst_s2
+  instrument_lcp_s0
+  instrument_lcp_s1
+  instrument_lcp_s2
+[tau] Loading district centroids
+
+All cases done in 12.1 minutes.
+  OK    instrument_euc_mst_s0  427s  (median τ = 4873940, BA→Córdoba τ = 2856537, 0 Inf)
+  OK    instrument_euc_mst_s1  426s  (median τ = 3702107, BA→Córdoba τ = 1631465, 0 Inf)
+  OK    instrument_euc_mst_s2  388s  (median τ = 12480050, BA→Córdoba τ = 9630887, 0 Inf)
+  OK    instrument_lcp_s0  439s  (median τ = 3567723, BA→Córdoba τ = 2231441, 0 Inf)
+  OK    instrument_lcp_s1  333s  (median τ = 2558844, BA→Córdoba τ = 1251857, 0 Inf)
+  OK    instrument_lcp_s2  299s  (median τ = 9142525, BA→Córdoba τ = 7260026, 0 Inf)
+Warning messages:
+1: package ‘sf’ was built under R version 4.5.2 
+2: package ‘sp’ was built under R version 4.5.2 
+3: package ‘igraph’ was built under R version 4.5.2 
+[config.R] rootdir = /Users/diegogp/Desktop/Diego/Trains/new_repo
+[config.R] Configuration loaded successfully.
+
+========================================================================
+03c_compute_taus_parallel.R  |  ncores = 3, 3 cases
+========================================================================
+  instrument_euc_s0
+  instrument_euc_s1
+  instrument_euc_s2
+[tau] Loading district centroids
+
+All cases done in 5.7 minutes.
+  OK    instrument_euc_s0  338s  (median τ = 1728282, BA→Córdoba τ = 1147490, 0 Inf)
+  OK    instrument_euc_s1  334s  (median τ = 742586, BA→Córdoba τ = 453479, 0 Inf)
+  OK    instrument_euc_s2  321s  (median τ = 6286744, BA→Córdoba τ = 4507972, 0 Inf)

--- a/logs/04_market_access.log
+++ b/logs/04_market_access.log
@@ -180,3 +180,143 @@ Elasticities: θ_low = 4.550, θ_high = 8.110
 04_market_access.R  |  Complete.
 ========================================================================
 
+[config.R] rootdir = /Users/diegogp/Desktop/Diego/Trains/new_repo
+[config.R] Configuration loaded successfully.
+
+========================================================================
+04_market_access.R  |  MA_i = sum_{j≠i} Pop_j / τ_ij^θ
+========================================================================
+Cases: instrument_euc_mst_s0, instrument_euc_mst_s1, instrument_euc_mst_s2, instrument_lcp_s0, instrument_lcp_s1, instrument_lcp_s2, instrument_euc_s0, instrument_euc_s1, instrument_euc_s2
+
+Elasticities: θ_low = 4.550, θ_high = 8.110
+[ma] Loaded 1960 pop: 309 districts, total=13,551,523
+
+[ma] ==== CASE: instrument_euc_mst_s0 (elow, θ=4.550) ====
+[ma]   τ file has 312 districts (48516 pairs)
+[ma]   MA computed for 312 districts; 0 have logMA = -Inf (MA = 0)
+[ma]   MA summary (MA>0): min=1.772e-27 median=9.376e-23 max=7.232e-14
+[ma]   logMA summary (finite): min=-61.60  mean=-49.67  max=-30.26
+[ma]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/04_market_access/ma_instrument_euc_mst_s0_elow.parquet
+
+[ma] ==== CASE: instrument_euc_mst_s0 (ehigh, θ=8.110) ====
+[ma]   τ file has 312 districts (48516 pairs)
+[ma]   MA computed for 312 districts; 0 have logMA = -Inf (MA = 0)
+[ma]   MA summary (MA>0): min=1.025e-53 median=3.508e-45 max=1.633e-28
+[ma]   logMA summary (finite): min=-122.01  mean=-100.32  max=-63.98
+[ma]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/04_market_access/ma_instrument_euc_mst_s0_ehigh.parquet
+
+[ma] ==== CASE: instrument_euc_mst_s1 (elow, θ=4.550) ====
+[ma]   τ file has 312 districts (48516 pairs)
+[ma]   MA computed for 312 districts; 0 have logMA = -Inf (MA = 0)
+[ma]   MA summary (MA>0): min=2.503e-27 median=5.034e-22 max=3.586e-11
+[ma]   logMA summary (finite): min=-61.25  mean=-47.74  max=-24.05
+[ma]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/04_market_access/ma_instrument_euc_mst_s1_elow.parquet
+
+[ma] ==== CASE: instrument_euc_mst_s1 (ehigh, θ=8.110) ====
+[ma]   τ file has 312 districts (48516 pairs)
+[ma]   MA computed for 312 districts; 0 have logMA = -Inf (MA = 0)
+[ma]   MA summary (MA>0): min=1.487e-53 median=4.660e-44 max=1.041e-23
+[ma]   logMA summary (finite): min=-121.64  mean=-97.08  max=-52.92
+[ma]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/04_market_access/ma_instrument_euc_mst_s1_ehigh.parquet
+
+[ma] ==== CASE: instrument_euc_mst_s2 (elow, θ=4.550) ====
+[ma]   τ file has 312 districts (48516 pairs)
+[ma]   MA computed for 312 districts; 0 have logMA = -Inf (MA = 0)
+[ma]   MA summary (MA>0): min=2.885e-28 median=2.213e-24 max=2.453e-17
+[ma]   logMA summary (finite): min=-63.41  mean=-53.63  max=-38.25
+[ma]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/04_market_access/ma_instrument_euc_mst_s2_elow.parquet
+
+[ma] ==== CASE: instrument_euc_mst_s2 (ehigh, θ=8.110) ====
+[ma]   τ file has 312 districts (48516 pairs)
+[ma]   MA computed for 312 districts; 0 have logMA = -Inf (MA = 0)
+[ma]   MA summary (MA>0): min=3.193e-55 median=1.375e-47 max=1.062e-34
+[ma]   logMA summary (finite): min=-125.48  mean=-106.60  max=-78.23
+[ma]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/04_market_access/ma_instrument_euc_mst_s2_ehigh.parquet
+
+[ma] ==== CASE: instrument_lcp_s0 (elow, θ=4.550) ====
+[ma]   τ file has 312 districts (48516 pairs)
+[ma]   MA computed for 312 districts; 0 have logMA = -Inf (MA = 0)
+[ma]   MA summary (MA>0): min=5.136e-27 median=4.596e-22 max=7.023e-14
+[ma]   logMA summary (finite): min=-60.53  mean=-48.32  max=-30.29
+[ma]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/04_market_access/ma_instrument_lcp_s0_elow.parquet
+
+[ma] ==== CASE: instrument_lcp_s0 (ehigh, θ=8.110) ====
+[ma]   τ file has 312 districts (48516 pairs)
+[ma]   MA computed for 312 districts; 0 have logMA = -Inf (MA = 0)
+[ma]   MA summary (MA>0): min=3.789e-53 median=1.351e-43 max=1.551e-28
+[ma]   logMA summary (finite): min=-120.70  mean=-97.48  max=-64.03
+[ma]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/04_market_access/ma_instrument_lcp_s0_ehigh.parquet
+
+[ma] ==== CASE: instrument_lcp_s1 (elow, θ=4.550) ====
+[ma]   τ file has 312 districts (48516 pairs)
+[ma]   MA computed for 312 districts; 0 have logMA = -Inf (MA = 0)
+[ma]   MA summary (MA>0): min=7.626e-27 median=3.598e-21 max=3.584e-11
+[ma]   logMA summary (finite): min=-60.14  mean=-46.17  max=-24.05
+[ma]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/04_market_access/ma_instrument_lcp_s1_elow.parquet
+
+[ma] ==== CASE: instrument_lcp_s1 (ehigh, θ=8.110) ====
+[ma]   τ file has 312 districts (48516 pairs)
+[ma]   MA computed for 312 districts; 0 have logMA = -Inf (MA = 0)
+[ma]   MA summary (MA>0): min=7.615e-53 median=2.010e-42 max=1.041e-23
+[ma]   logMA summary (finite): min=-120.01  mean=-93.99  max=-52.92
+[ma]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/04_market_access/ma_instrument_lcp_s1_ehigh.parquet
+
+[ma] ==== CASE: instrument_lcp_s2 (elow, θ=4.550) ====
+[ma]   τ file has 312 districts (48516 pairs)
+[ma]   MA computed for 312 districts; 0 have logMA = -Inf (MA = 0)
+[ma]   MA summary (MA>0): min=6.209e-28 median=8.950e-24 max=1.901e-17
+[ma]   logMA summary (finite): min=-62.65  mean=-52.37  max=-38.50
+[ma]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/04_market_access/ma_instrument_lcp_s2_elow.parquet
+
+[ma] ==== CASE: instrument_lcp_s2 (ehigh, θ=8.110) ====
+[ma]   τ file has 312 districts (48516 pairs)
+[ma]   MA computed for 312 districts; 0 have logMA = -Inf (MA = 0)
+[ma]   MA summary (MA>0): min=1.262e-54 median=2.178e-46 max=6.658e-35
+[ma]   logMA summary (finite): min=-124.11  mean=-104.13  max=-78.69
+[ma]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/04_market_access/ma_instrument_lcp_s2_ehigh.parquet
+
+[ma] ==== CASE: instrument_euc_s0 (elow, θ=4.550) ====
+[ma]   τ file has 312 districts (48516 pairs)
+[ma]   MA computed for 312 districts; 0 have logMA = -Inf (MA = 0)
+[ma]   MA summary (MA>0): min=9.492e-27 median=1.566e-19 max=3.392e-13
+[ma]   logMA summary (finite): min=-59.92  mean=-43.56  max=-28.71
+[ma]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/04_market_access/ma_instrument_euc_s0_elow.parquet
+
+[ma] ==== CASE: instrument_euc_s0 (ehigh, θ=8.110) ====
+[ma]   τ file has 312 districts (48516 pairs)
+[ma]   MA computed for 312 districts; 0 have logMA = -Inf (MA = 0)
+[ma]   MA summary (MA>0): min=1.141e-52 median=1.640e-38 max=2.120e-27
+[ma]   logMA summary (finite): min=-119.60  mean=-87.96  max=-61.42
+[ma]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/04_market_access/ma_instrument_euc_s0_ehigh.parquet
+
+[ma] ==== CASE: instrument_euc_s1 (elow, θ=4.550) ====
+[ma]   τ file has 312 districts (48516 pairs)
+[ma]   MA computed for 312 districts; 0 have logMA = -Inf (MA = 0)
+[ma]   MA summary (MA>0): min=1.537e-26 median=4.299e-18 max=3.789e-11
+[ma]   logMA summary (finite): min=-59.44  mean=-40.48  max=-24.00
+[ma]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/04_market_access/ma_instrument_euc_s1_elow.parquet
+
+[ma] ==== CASE: instrument_euc_s1 (ehigh, θ=8.110) ====
+[ma]   τ file has 312 districts (48516 pairs)
+[ma]   MA computed for 312 districts; 0 have logMA = -Inf (MA = 0)
+[ma]   MA summary (MA>0): min=2.625e-52 median=5.932e-36 max=1.402e-23
+[ma]   logMA summary (finite): min=-118.77  mean=-82.81  max=-52.62
+[ma]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/04_market_access/ma_instrument_euc_s1_ehigh.parquet
+
+[ma] ==== CASE: instrument_euc_s2 (elow, θ=4.550) ====
+[ma]   τ file has 312 districts (48516 pairs)
+[ma]   MA computed for 312 districts; 0 have logMA = -Inf (MA = 0)
+[ma]   MA summary (MA>0): min=1.114e-27 median=4.085e-22 max=3.114e-16
+[ma]   logMA summary (finite): min=-62.06  mean=-48.90  max=-35.71
+[ma]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/04_market_access/ma_instrument_euc_s2_elow.parquet
+
+[ma] ==== CASE: instrument_euc_s2 (ehigh, θ=8.110) ====
+[ma]   τ file has 312 districts (48516 pairs)
+[ma]   MA computed for 312 districts; 0 have logMA = -Inf (MA = 0)
+[ma]   MA summary (MA>0): min=3.849e-54 median=5.226e-43 max=8.173e-33
+[ma]   logMA summary (finite): min=-122.99  mean=-97.41  max=-73.88
+[ma]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/04_market_access/ma_instrument_euc_s2_ehigh.parquet
+========================================================================
+04_market_access.R  |  Complete.
+========================================================================
+

--- a/logs/06_merge_ma_into_panel.log
+++ b/logs/06_merge_ma_into_panel.log
@@ -6,26 +6,44 @@
 ========================================================================
 [panel] Starting panel: 312 × 160
 [panel] Removing 42 stale MA columns: logMA_actual_1960_s0_elow, logMA_actual_1960_s0_ehigh, logMA_actual_1960_s1_elow, logMA_actual_1960_s1_ehigh, logMA_actual_1960_s2_elow, logMA_actual_1960_s2_ehigh, logMA_actual_1986_s0_elow, logMA_actual_1986_s0_ehigh, logMA_actual_1986_s1_elow, logMA_actual_1986_s1_ehigh, logMA_actual_1986_s2_elow, logMA_actual_1986_s2_ehigh, logMA_instrument_stu_s0_elow, logMA_instrument_stu_s0_ehigh, logMA_instrument_stu_s1_elow, logMA_instrument_stu_s1_ehigh, logMA_instrument_stu_s2_elow, logMA_instrument_stu_s2_ehigh, logMA_instrument_lcp_mst_s0_elow, logMA_instrument_lcp_mst_s0_ehigh, logMA_instrument_lcp_mst_s1_elow, logMA_instrument_lcp_mst_s1_ehigh, logMA_instrument_lcp_mst_s2_elow, logMA_instrument_lcp_mst_s2_ehigh, chg_logMA_86_60_s0_elow, chg_logMA_stu_s0_elow, chg_logMA_lcp_mst_s0_elow, chg_logMA_86_60_s0_ehigh, chg_logMA_stu_s0_ehigh, chg_logMA_lcp_mst_s0_ehigh, chg_logMA_86_60_s1_elow, chg_logMA_stu_s1_elow, chg_logMA_lcp_mst_s1_elow, chg_logMA_86_60_s1_ehigh, chg_logMA_stu_s1_ehigh, chg_logMA_lcp_mst_s1_ehigh, chg_logMA_86_60_s2_elow, chg_logMA_stu_s2_elow, chg_logMA_lcp_mst_s2_elow, chg_logMA_86_60_s2_ehigh, chg_logMA_stu_s2_ehigh, chg_logMA_lcp_mst_s2_ehigh
-[panel] 18 change variables built:
-  chg_logMA_86_60_s0_elow                   N=312  mean=+1.559  sd=2.483
-  chg_logMA_stu_s0_elow                     N=312  mean=-1.240  sd=2.225
-  chg_logMA_lcp_mst_s0_elow                 N=312  mean=-0.494  sd=2.479
-  chg_logMA_86_60_s0_ehigh                  N=312  mean=+3.069  sd=5.140
-  chg_logMA_stu_s0_ehigh                    N=312  mean=-2.223  sd=4.318
-  chg_logMA_lcp_mst_s0_ehigh                N=312  mean=-0.979  sd=5.017
-  chg_logMA_86_60_s1_elow                   N=312  mean=+1.571  sd=3.301
-  chg_logMA_stu_s1_elow                     N=312  mean=-1.612  sd=3.023
-  chg_logMA_lcp_mst_s1_elow                 N=312  mean=-0.663  sd=3.175
-  chg_logMA_86_60_s1_ehigh                  N=312  mean=+3.004  sd=6.481
-  chg_logMA_stu_s1_ehigh                    N=312  mean=-2.875  sd=5.635
-  chg_logMA_lcp_mst_s1_ehigh                N=312  mean=-1.232  sd=6.187
-  chg_logMA_86_60_s2_elow                   N=312  mean=+1.573  sd=1.601
-  chg_logMA_stu_s2_elow                     N=312  mean=-0.636  sd=1.227
-  chg_logMA_lcp_mst_s2_elow                 N=312  mean=-0.682  sd=1.730
-  chg_logMA_86_60_s2_ehigh                  N=312  mean=+2.911  sd=3.377
-  chg_logMA_stu_s2_ehigh                    N=312  mean=-1.237  sd=2.507
-  chg_logMA_lcp_mst_s2_ehigh                N=312  mean=-1.290  sd=3.610
-[panel] Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/05_panel/departments_wide_panel.parquet (312 × 160)
+[panel] 36 change variables built:
+  chg_logMA_86_60_s0_elow                        N=312  mean=+1.559  sd=2.483
+  chg_logMA_stu_s0_elow                          N=312  mean=-1.240  sd=2.225
+  chg_logMA_lcp_mst_s0_elow                      N=312  mean=-0.494  sd=2.479
+  chg_logMA_euc_mst_s0_elow                      N=312  mean=-0.640  sd=2.401
+  chg_logMA_lcp_s0_elow                          N=312  mean=+0.710  sd=3.332
+  chg_logMA_euc_s0_elow                          N=312  mean=+5.473  sd=4.613
+  chg_logMA_86_60_s0_ehigh                       N=312  mean=+3.069  sd=5.140
+  chg_logMA_stu_s0_ehigh                         N=312  mean=-2.223  sd=4.318
+  chg_logMA_lcp_mst_s0_ehigh                     N=312  mean=-0.979  sd=5.017
+  chg_logMA_euc_mst_s0_ehigh                     N=312  mean=-1.407  sd=4.808
+  chg_logMA_lcp_s0_ehigh                         N=312  mean=+1.439  sd=6.827
+  chg_logMA_euc_s0_ehigh                         N=312  mean=+10.961  sd=9.429
+  chg_logMA_86_60_s1_elow                        N=312  mean=+1.571  sd=3.301
+  chg_logMA_stu_s1_elow                          N=312  mean=-1.612  sd=3.023
+  chg_logMA_lcp_mst_s1_elow                      N=312  mean=-0.663  sd=3.175
+  chg_logMA_euc_mst_s1_elow                      N=312  mean=-0.903  sd=3.125
+  chg_logMA_lcp_s1_elow                          N=312  mean=+0.666  sd=4.284
+  chg_logMA_euc_s1_elow                          N=312  mean=+6.355  sd=5.827
+  chg_logMA_86_60_s1_ehigh                       N=312  mean=+3.004  sd=6.481
+  chg_logMA_stu_s1_ehigh                         N=312  mean=-2.875  sd=5.635
+  chg_logMA_lcp_mst_s1_ehigh                     N=312  mean=-1.232  sd=6.187
+  chg_logMA_euc_mst_s1_ehigh                     N=312  mean=-1.731  sd=6.105
+  chg_logMA_lcp_s1_ehigh                         N=312  mean=+1.355  sd=8.446
+  chg_logMA_euc_s1_ehigh                         N=312  mean=+12.533  sd=11.579
+  chg_logMA_86_60_s2_elow                        N=312  mean=+1.573  sd=1.601
+  chg_logMA_stu_s2_elow                          N=312  mean=-0.636  sd=1.227
+  chg_logMA_lcp_mst_s2_elow                      N=312  mean=-0.682  sd=1.730
+  chg_logMA_euc_mst_s2_elow                      N=312  mean=-0.693  sd=1.711
+  chg_logMA_lcp_s2_elow                          N=312  mean=+0.565  sd=2.360
+  chg_logMA_euc_s2_elow                          N=312  mean=+4.033  sd=3.055
+  chg_logMA_86_60_s2_ehigh                       N=312  mean=+2.911  sd=3.377
+  chg_logMA_stu_s2_ehigh                         N=312  mean=-1.237  sd=2.507
+  chg_logMA_lcp_mst_s2_ehigh                     N=312  mean=-1.290  sd=3.610
+  chg_logMA_euc_mst_s2_ehigh                     N=312  mean=-1.564  sd=3.425
+  chg_logMA_lcp_s2_ehigh                         N=312  mean=+0.905  sd=4.903
+  chg_logMA_euc_s2_ehigh                         N=312  mean=+7.626  sd=6.276
+[panel] Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/05_panel/departments_wide_panel.parquet (312 × 196)
 [panel] Manifest: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/05_panel/data_file_manifest.log
 ========================================================================
 06_merge_ma_into_panel.R  |  Complete.


### PR DESCRIPTION
Closes #36

Completes Phase 2 by adding three more hypothetical-road instrument variants alongside \`instrument_lcp_mst\`:

- \`instrument_euc_mst\` — Euclidean MST
- \`instrument_lcp\` — bilateral LCP (all city pairs, not just MST)
- \`instrument_euc\` — bilateral Euclidean

## Scale

- 7 network specs × 3 sectors × 2 elasticities = **42 MA columns** (was 24)
- 6 timings × 3 sectors × 2 elasticities = **36 change variables** (was 18)
- Panel grows from 160 → **196 columns**.

## Changes

- \`03a_build_cost_raster.R\`: \`rasterize_hypo()\` now takes a filename argument. \`base_specs\` declares \`hypo_file\` per case. The three new networks read \`euc_mst.gpkg\`, \`lcp_network.gpkg\`, \`euc_network.gpkg\` from \`data/derived/02_hypothetical_networks/\`.
- \`06_merge_ma_into_panel.R\`: \`network_specs\` list and \`timings\` list both extended. Output idempotent as before.

## Cost raster pixel counts (hypo-road layer only)

| Network | Pixels |
|---|---:|
| \`lcp_mst\` | 15,148 |
| \`euc_mst\` | 11,876 |
| \`lcp\` | 94,661 |
| \`euc\` | 851,566 |

\`euc\` is dense because it draws \`choose(54, 2) = 1,431\` direct lines between all city pairs. MSTs have only 53 edges each.

## Tau comparison (BA → Córdoba, s0 elow)

| Network | τ |
|---|---:|
| actual_1960 | 2,649,776 |
| lcp_mst | 2,900,820 |
| euc_mst | 2,856,537 |
| lcp | 2,231,441 |
| euc | 1,147,490 |
| actual_1986 | 1,366,749 |

As expected: the dense \`euc\` network is closest to \`actual_1986\` because it covers the most area; MSTs are closer to the sparse 1960 baseline.

## Verified

- All 9 new cost rasters validate against sector cost parameters.
- All 9 new tau matrices have 0 Inf pairs (navigation keeps TdF connected).
- Change variables in the panel: 36, all N = 312.
- Naming convention preserved: \`logMA_<case>_<s>_<e>\`, \`chg_logMA_<timing>_<s>_<e>\`.

## Runtime

- 9 cost rasters: ~5 min
- 9 transition grids: ~8 min
- 9 taus (6 in parallel at 4 cores + 3 in parallel at 3 cores): ~18 min
- 18 MAs: ~2 min
- Panel merge: <1 s

Total: ~33 min.

## Phase 2 status

With 2a (sectors + elasticities), 2b (navigation), 2c (hypothetical variants) all merged, the MA pipeline is complete. Remaining:

- **Phase 3**: counterfactual rasters (\`rails_1986 + roads_1954\`, \`rails_1960 + roads_1986\`) for Block-2 counterfactual analysis — separate methodological step.
- **Downstream**: regressions with geo controls, first-stage tables, main IV tables, robustness.