### PR TITLE
Phase 3: counterfactual cost rasters (rail-only / road-only shock)

### DIFF
--- a/code/pipeline/03a_build_cost_raster.R
+++ b/code/pipeline/03a_build_cost_raster.R
@@ -37,8 +37,8 @@
 #       elif in Argentina + HMI:  cost_land × HMI    (constant across sectors)
 #       else (outside Argentina): NA (hard barrier for Dijkstra)
 #
-# CASES (Phase 1 + 2a + 2b + 2c):
-#   Seven network specs × three sectors = twenty-one cases.
+# CASES (Phase 1 + 2a + 2b + 2c + 3):
+#   Nine network specs × three sectors = twenty-seven cases.
 #
 #   Network specs:
 #     actual_1960         — 1960 rails + 1954 roads + HMI + nav
@@ -48,9 +48,11 @@
 #     instrument_euc_mst  — 1960 rails + Euclidean-MST hypothetical roads
 #     instrument_lcp      — 1960 rails + bilateral-LCP hypothetical roads
 #     instrument_euc      — 1960 rails + bilateral-Euclidean hypothetical roads
+#     cf_only_rail        — 1986 rails + 1954 roads  (isolates rail shock)
+#     cf_only_road        — 1960 rails + 1986 roads  (isolates road shock)
 #
 #   Each of the above is generated at sector s0, s1, s2 (case label
-#   `<network>_<sector>`, e.g. `actual_1960_s1`).
+#   `<network>_<sector>`, e.g. `cf_only_rail_s1`).
 #
 # HYPOTHETICAL-NETWORK CAVEAT:
 #   The LCP-MST hypothetical road network was routed on a Faber (2014)
@@ -130,6 +132,23 @@ case_registry <- function() {
             road_sel = NULL,
             use_hypo = TRUE,
             hypo_file = "euc_network.gpkg"
+        ),
+        # ---- Counterfactual cases (Phase 3) --------------------------------
+        # cf_only_rail: rails_1986 + roads_1954. Freezes roads at baseline
+        # so Δlog MA vs actual_1960 isolates the rail shock.
+        cf_only_rail = list(
+            rail_sel = function(r) r$status1979 == 1,
+            road_sel = function(r) r$type2      %in% c(1, 5, 7),
+            use_hypo = FALSE,
+            hypo_file = NULL
+        ),
+        # cf_only_road: rails_1960 + roads_1986. Freezes rails at baseline
+        # so Δlog MA vs actual_1960 isolates the road shock.
+        cf_only_road = list(
+            rail_sel = function(r) r$status1979 %in% c(1, 2, 3),
+            road_sel = function(r) r$type2      %in% c(1, 2, 3, 5),
+            use_hypo = FALSE,
+            hypo_file = NULL
         )
     )
 

--- a/code/pipeline/06_merge_ma_into_panel.R
+++ b/code/pipeline/06_merge_ma_into_panel.R
@@ -12,16 +12,18 @@
 # PRODUCES:
 #   data/derived/05_panel/departments_wide_panel.parquet    (overwritten)
 #
-#   New columns (Phase 1 + Phase 2a + Phase 2b + Phase 2c):
-#     logMA_<case>_<s>_<e>           — 42 level columns
-#     chg_logMA_<timing>_<s>_<e>     — 36 change columns
+#   New columns (Phase 1 + Phase 2a + Phase 2b + Phase 2c + Phase 3):
+#     logMA_<case>_<s>_<e>           — 54 level columns
+#     chg_logMA_<timing>_<s>_<e>     — 48 change columns
 #   where:
 #     case ∈ {actual_1960, actual_1986, instrument_stu,
 #             instrument_lcp_mst, instrument_euc_mst,
-#             instrument_lcp, instrument_euc}
+#             instrument_lcp, instrument_euc,
+#             cf_only_rail, cf_only_road}
 #     s    ∈ {s0, s1, s2}
 #     e    ∈ {elow, ehigh}
-#     timing ∈ {86_60, stu, lcp_mst, euc_mst, lcp, euc}
+#     timing ∈ {86_60, stu, lcp_mst, euc_mst, lcp, euc,
+#               only_rail, only_road}
 #
 # NAMING CONVENTION:
 #   logMA_<case>_<s>_<e>
@@ -55,7 +57,8 @@ build_ma_cases_spec <- function() {
     network_specs <- c("actual_1960", "actual_1986",
                        "instrument_stu",
                        "instrument_lcp_mst", "instrument_euc_mst",
-                       "instrument_lcp",     "instrument_euc")
+                       "instrument_lcp",     "instrument_euc",
+                       "cf_only_rail",       "cf_only_road")
     sectors       <- c("s0", "s1", "s2")
     elasticities  <- c("elow", "ehigh")
 
@@ -162,12 +165,14 @@ merge_one_case <- function(panel, case, elas, suffix) {
 # ---------------------------------------------------------------------------
 add_change_vars <- function(panel) {
     timings <- c(
-        "86_60"   = "logMA_actual_1986",
-        "stu"     = "logMA_instrument_stu",
-        "lcp_mst" = "logMA_instrument_lcp_mst",
-        "euc_mst" = "logMA_instrument_euc_mst",
-        "lcp"     = "logMA_instrument_lcp",
-        "euc"     = "logMA_instrument_euc"
+        "86_60"     = "logMA_actual_1986",
+        "stu"       = "logMA_instrument_stu",
+        "lcp_mst"   = "logMA_instrument_lcp_mst",
+        "euc_mst"   = "logMA_instrument_euc_mst",
+        "lcp"       = "logMA_instrument_lcp",
+        "euc"       = "logMA_instrument_euc",
+        "only_rail" = "logMA_cf_only_rail",
+        "only_road" = "logMA_cf_only_road"
     )
     for (s in c("s0", "s1", "s2")) {
         for (e in c("elow", "ehigh")) {

--- a/data/derived/05_panel/data_file_manifest.log
+++ b/data/derived/05_panel/data_file_manifest.log
@@ -1,12 +1,12 @@
 Data file manifest — 05_build_panel.R + 06_merge_ma_into_panel.R
-Regenerated: 2026-05-10 09:25:37.399453
+Regenerated: 2026-05-10 10:22:31.614024
 rootdir: /Users/diegogp/Desktop/Diego/Trains/new_repo
 
 ============================================================ 
 FILE: departments_wide_panel.parquet
 ============================================================ 
 Rows: 312
-Columns: 196
+Columns: 220
 Key: geolev2
 
 NOTE ON logMA/chg_logMA COLUMNS:
@@ -186,39 +186,63 @@ Summary of every variable:
   logMA_instrument_euc_s1_ehigh    N=312  mean=-82.8  sd=14.2  min=-119  max=-52.6  NA=0
   logMA_instrument_euc_s2_elow     N=312  mean=-48.9  sd=5.15  min=-62.1  max=-35.7  NA=0
   logMA_instrument_euc_s2_ehigh    N=312  mean=-97.4  sd=9.59  min=-123  max=-73.9  NA=0
+  logMA_cf_only_rail_s0_elow       N=312  mean=-49.4  sd=6  min=-63.1  max=-29  NA=0
+  logMA_cf_only_rail_s0_ehigh      N=312  mean=-99.6  sd=11.5  min=-125  max=-61.7  NA=0
+  logMA_cf_only_rail_s1_elow       N=312  mean=-47.4  sd=7.09  min=-62.6  max=-24.1  NA=0
+  logMA_cf_only_rail_s1_ehigh      N=312  mean=-96.4  sd=13.5  min=-124  max=-52.9  NA=0
+  logMA_cf_only_rail_s2_elow       N=312  mean=-53.1  sd=5.03  min=-65.6  max=-37  NA=0
+  logMA_cf_only_rail_s2_ehigh      N=312  mean=-105  sd=9.4  min=-129  max=-76  NA=0
+  logMA_cf_only_road_s0_elow       N=312  mean=-47.3  sd=5.5  min=-59.9  max=-29  NA=0
+  logMA_cf_only_road_s0_ehigh      N=312  mean=-95.5  sd=10.6  min=-120  max=-61.7  NA=0
+  logMA_cf_only_road_s1_elow       N=312  mean=-44.9  sd=6.63  min=-59.7  max=-24  NA=0
+  logMA_cf_only_road_s1_ehigh      N=312  mean=-91.7  sd=12.7  min=-119  max=-52.9  NA=0
+  logMA_cf_only_road_s2_elow       N=312  mean=-51.3  sd=4.52  min=-60.9  max=-37  NA=0
+  logMA_cf_only_road_s2_ehigh      N=312  mean=-102  sd=8.41  min=-121  max=-76  NA=0
   chg_logMA_86_60_s0_elow          N=312  mean=1.56  sd=2.48  min=-7.18  max=9.58  NA=0
   chg_logMA_stu_s0_elow            N=312  mean=-1.24  sd=2.22  min=-12.5  max=-3.5e-06  NA=0
   chg_logMA_lcp_mst_s0_elow        N=312  mean=-0.494  sd=2.48  min=-15.8  max=8.86  NA=0
   chg_logMA_euc_mst_s0_elow        N=312  mean=-0.64  sd=2.4  min=-17.7  max=11.6  NA=0
   chg_logMA_lcp_s0_elow            N=312  mean=0.71  sd=3.33  min=-15.7  max=11.9  NA=0
   chg_logMA_euc_s0_elow            N=312  mean=5.47  sd=4.61  min=-17  max=16.4  NA=0
+  chg_logMA_only_rail_s0_elow      N=312  mean=-0.397  sd=1.35  min=-11.3  max=-1.17e-06  NA=0
+  chg_logMA_only_road_s0_elow      N=312  mean=1.75  sd=2.24  min=-3.49  max=9.6  NA=0
   chg_logMA_86_60_s0_ehigh         N=312  mean=3.07  sd=5.14  min=-14.5  max=18.1  NA=0
   chg_logMA_stu_s0_ehigh           N=312  mean=-2.22  sd=4.32  min=-23.5  max=-3.47e-10  NA=0
   chg_logMA_lcp_mst_s0_ehigh       N=312  mean=-0.979  sd=5.02  min=-29  max=17.2  NA=0
   chg_logMA_euc_mst_s0_ehigh       N=312  mean=-1.41  sd=4.81  min=-33.2  max=22.2  NA=0
   chg_logMA_lcp_s0_ehigh           N=312  mean=1.44  sd=6.83  min=-29  max=25  NA=0
   chg_logMA_euc_s0_ehigh           N=312  mean=11  sd=9.43  min=-32.8  max=32.8  NA=0
+  chg_logMA_only_rail_s0_ehigh     N=312  mean=-0.728  sd=2.61  min=-21.7  max=-1e-10  NA=0
+  chg_logMA_only_road_s0_ehigh     N=312  mean=3.44  sd=4.69  min=-9.27  max=18.1  NA=0
   chg_logMA_86_60_s1_elow          N=312  mean=1.57  sd=3.3  min=-12.8  max=11.8  NA=0
   chg_logMA_stu_s1_elow            N=312  mean=-1.61  sd=3.02  min=-16.8  max=-3.05e-06  NA=0
   chg_logMA_lcp_mst_s1_elow        N=312  mean=-0.663  sd=3.17  min=-17.1  max=10.7  NA=0
   chg_logMA_euc_mst_s1_elow        N=312  mean=-0.903  sd=3.13  min=-18.8  max=15.8  NA=0
   chg_logMA_lcp_s1_elow            N=312  mean=0.666  sd=4.28  min=-16.9  max=14.9  NA=0
   chg_logMA_euc_s1_elow            N=312  mean=6.36  sd=5.83  min=-18.3  max=17.8  NA=0
+  chg_logMA_only_rail_s1_elow      N=312  mean=-0.557  sd=1.94  min=-14.4  max=-5.42e-05  NA=0
+  chg_logMA_only_road_s1_elow      N=312  mean=1.9  sd=2.89  min=-6.8  max=11.8  NA=0
   chg_logMA_86_60_s1_ehigh         N=312  mean=3  sd=6.48  min=-24.9  max=21.3  NA=0
   chg_logMA_stu_s1_ehigh           N=312  mean=-2.88  sd=5.63  min=-31.3  max=-1.7e-10  NA=0
   chg_logMA_lcp_mst_s1_ehigh       N=312  mean=-1.23  sd=6.19  min=-33  max=21.7  NA=0
   chg_logMA_euc_mst_s1_ehigh       N=312  mean=-1.73  sd=6.1  min=-36.8  max=29.9  NA=0
   chg_logMA_lcp_s1_ehigh           N=312  mean=1.35  sd=8.45  min=-33  max=27.8  NA=0
   chg_logMA_euc_s1_ehigh           N=312  mean=12.5  sd=11.6  min=-36.2  max=36.3  NA=0
+  chg_logMA_only_rail_s1_ehigh     N=312  mean=-1.02  sd=3.67  min=-27.8  max=-5.7e-08  NA=0
+  chg_logMA_only_road_s1_ehigh     N=312  mean=3.61  sd=5.71  min=-15.8  max=23.6  NA=0
   chg_logMA_86_60_s2_elow          N=312  mean=1.57  sd=1.6  min=-1.99  max=6.66  NA=0
   chg_logMA_stu_s2_elow            N=312  mean=-0.636  sd=1.23  min=-6.42  max=-6.6e-07  NA=0
   chg_logMA_lcp_mst_s2_elow        N=312  mean=-0.682  sd=1.73  min=-9.6  max=6.66  NA=0
   chg_logMA_euc_mst_s2_elow        N=312  mean=-0.693  sd=1.71  min=-11.8  max=6.3  NA=0
   chg_logMA_lcp_s2_elow            N=312  mean=0.565  sd=2.36  min=-9.59  max=7.75  NA=0
   chg_logMA_euc_s2_elow            N=312  mean=4.03  sd=3.05  min=-11.6  max=12.1  NA=0
+  chg_logMA_only_rail_s2_elow      N=312  mean=-0.197  sd=0.649  min=-5.76  max=-1.6e-07  NA=0
+  chg_logMA_only_road_s2_elow      N=312  mean=1.65  sd=1.54  min=-0.965  max=6.67  NA=0
   chg_logMA_86_60_s2_ehigh         N=312  mean=2.91  sd=3.38  min=-4.23  max=14  NA=0
   chg_logMA_stu_s2_ehigh           N=312  mean=-1.24  sd=2.51  min=-14.6  max=-4.97e-11  NA=0
   chg_logMA_lcp_mst_s2_ehigh       N=312  mean=-1.29  sd=3.61  min=-17.3  max=13.1  NA=0
   chg_logMA_euc_mst_s2_ehigh       N=312  mean=-1.56  sd=3.42  min=-21.5  max=12.7  NA=0
   chg_logMA_lcp_s2_ehigh           N=312  mean=0.905  sd=4.9  min=-17.3  max=16.1  NA=0
   chg_logMA_euc_s2_ehigh           N=312  mean=7.63  sd=6.28  min=-21.3  max=22.4  NA=0
+  chg_logMA_only_rail_s2_ehigh     N=312  mean=-0.388  sd=1.33  min=-11.5  max=-9.28e-12  NA=0
+  chg_logMA_only_road_s2_ehigh     N=312  mean=3.08  sd=3.25  min=-3.24  max=14  NA=0

--- a/logs/03a_build_cost_raster.log
+++ b/logs/03a_build_cost_raster.log
@@ -415,3 +415,113 @@ Cases to build: instrument_euc_mst_s0, instrument_euc_mst_s1, instrument_euc_mst
 03a_build_cost_raster.R  |  Complete.
 ========================================================================
 
+Warning messages:
+1: package ‘sf’ was built under R version 4.5.2 
+2: package ‘terra’ was built under R version 4.5.2 
+[config.R] rootdir = /Users/diegogp/Desktop/Diego/Trains/new_repo
+[config.R] Configuration loaded successfully.
+
+========================================================================
+03a_build_cost_raster.R  |  Phase 2b, with navigation, sectors 0/1/2
+========================================================================
+Cases to build: cf_only_rail_s1, cf_only_rail_s2, cf_only_road_s0, cf_only_road_s1, cf_only_road_s2
+
+
+[cost] ==== CASE: cf_only_rail_s1 ====
+[cost]   Rasterising country polygon (pais.shp)
+[cost]   Rasterising rails (selected subset)
+[cost]     Selected 424 / 565 segments
+[cost]     Rail pixels (value=1): 46250
+[cost]   Rasterising roads (selected subset)
+[cost]     Selected 582 / 1741 segments
+[cost]     Road pixels (value=1): 40777
+[cost]   Rasterising navigation layer
+[cost]     Navigable river segments (cursos_de_agua): 1128
+[cost]     Strait of Magellan polygons (cuerpos_de_agua): 3
+[cost]     Navigation pixels (value=1): 13016
+[cost]   Projecting HMI to base raster
+[cost]     HMI pixels with value (not NA): 3191580
+[cost]   Combining layers (sector=agricultural)
+[cost]   Validation OK: nav=0.6210  rail_only=0.4650  road_only=1.0000  both=0.4650
+[cost]   Cost summary: min=0.465  mean=140.66  max=773.11  N=1922780
+[cost]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/01_cost_rasters/ucost_cf_only_rail_s1.tif
+
+[cost] ==== CASE: cf_only_rail_s2 ====
+[cost]   Rasterising country polygon (pais.shp)
+[cost]   Rasterising rails (selected subset)
+[cost]     Selected 424 / 565 segments
+[cost]     Rail pixels (value=1): 46250
+[cost]   Rasterising roads (selected subset)
+[cost]     Selected 582 / 1741 segments
+[cost]     Road pixels (value=1): 40777
+[cost]   Rasterising navigation layer
+[cost]     Navigable river segments (cursos_de_agua): 1128
+[cost]     Strait of Magellan polygons (cuerpos_de_agua): 3
+[cost]     Navigation pixels (value=1): 13016
+[cost]   Projecting HMI to base raster
+[cost]     HMI pixels with value (not NA): 3191580
+[cost]   Combining layers (sector=manufacturing)
+[cost]   Validation OK: nav=0.6210  rail_only=13.4900  road_only=8.2660  both=8.2660
+[cost]   Cost summary: min=0.621  mean=141.08  max=773.11  N=1922780
+[cost]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/01_cost_rasters/ucost_cf_only_rail_s2.tif
+
+[cost] ==== CASE: cf_only_road_s0 ====
+[cost]   Rasterising country polygon (pais.shp)
+[cost]   Rasterising rails (selected subset)
+[cost]     Selected 565 / 565 segments
+[cost]     Rail pixels (value=1): 59254
+[cost]   Rasterising roads (selected subset)
+[cost]     Selected 1506 / 1741 segments
+[cost]     Road pixels (value=1): 111456
+[cost]   Rasterising navigation layer
+[cost]     Navigable river segments (cursos_de_agua): 1128
+[cost]     Strait of Magellan polygons (cuerpos_de_agua): 3
+[cost]     Navigation pixels (value=1): 13016
+[cost]   Projecting HMI to base raster
+[cost]     HMI pixels with value (not NA): 3191580
+[cost]   Combining layers (sector=overall)
+[cost]   Validation OK: nav=0.6210  rail_only=1.8740  road_only=1.7770  both=1.7770
+[cost]   Cost summary: min=0.621  mean=135.20  max=773.11  N=1922974
+[cost]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/01_cost_rasters/ucost_cf_only_road_s0.tif
+
+[cost] ==== CASE: cf_only_road_s1 ====
+[cost]   Rasterising country polygon (pais.shp)
+[cost]   Rasterising rails (selected subset)
+[cost]     Selected 565 / 565 segments
+[cost]     Rail pixels (value=1): 59254
+[cost]   Rasterising roads (selected subset)
+[cost]     Selected 1506 / 1741 segments
+[cost]     Road pixels (value=1): 111456
+[cost]   Rasterising navigation layer
+[cost]     Navigable river segments (cursos_de_agua): 1128
+[cost]     Strait of Magellan polygons (cuerpos_de_agua): 3
+[cost]     Navigation pixels (value=1): 13016
+[cost]   Projecting HMI to base raster
+[cost]     HMI pixels with value (not NA): 3191580
+[cost]   Combining layers (sector=agricultural)
+[cost]   Validation OK: nav=0.6210  rail_only=0.4650  road_only=1.0000  both=0.4650
+[cost]   Cost summary: min=0.465  mean=135.12  max=773.11  N=1922974
+[cost]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/01_cost_rasters/ucost_cf_only_road_s1.tif
+
+[cost] ==== CASE: cf_only_road_s2 ====
+[cost]   Rasterising country polygon (pais.shp)
+[cost]   Rasterising rails (selected subset)
+[cost]     Selected 565 / 565 segments
+[cost]     Rail pixels (value=1): 59254
+[cost]   Rasterising roads (selected subset)
+[cost]     Selected 1506 / 1741 segments
+[cost]     Road pixels (value=1): 111456
+[cost]   Rasterising navigation layer
+[cost]     Navigable river segments (cursos_de_agua): 1128
+[cost]     Strait of Magellan polygons (cuerpos_de_agua): 3
+[cost]     Navigation pixels (value=1): 13016
+[cost]   Projecting HMI to base raster
+[cost]     HMI pixels with value (not NA): 3191580
+[cost]   Combining layers (sector=manufacturing)
+[cost]   Validation OK: nav=0.6210  rail_only=13.4900  road_only=8.2660  both=8.2660
+[cost]   Cost summary: min=0.621  mean=135.81  max=773.11  N=1922974
+[cost]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/01_cost_rasters/ucost_cf_only_road_s2.tif
+========================================================================
+03a_build_cost_raster.R  |  Complete.
+========================================================================
+

--- a/logs/03b_transition_grids.log
+++ b/logs/03b_transition_grids.log
@@ -196,3 +196,66 @@ Cases to process: instrument_euc_mst_s0, instrument_euc_mst_s1, instrument_euc_m
 03b_transition_grids.R  |  Complete.
 ========================================================================
 
+Warning messages:
+1: package ‘sp’ was built under R version 4.5.2 
+2: package ‘igraph’ was built under R version 4.5.2 
+[config.R] rootdir = /Users/diegogp/Desktop/Diego/Trains/new_repo
+[config.R] Configuration loaded successfully.
+
+========================================================================
+03b_transition_grids.R  |  cost raster → gdistance transition
+========================================================================
+Cases to process: cf_only_rail_s0, cf_only_rail_s1, cf_only_rail_s2, cf_only_road_s0, cf_only_road_s1, cf_only_road_s2
+
+
+[trans] ==== CASE: cf_only_rail_s0 ====
+[trans]   Reading /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/01_cost_rasters/ucost_cf_only_rail_s0.tif
+[trans]   Building 8-neighbour transition (1/mean(cost))
+[trans]   transition() took 48.2 s
+[trans]   Applying geoCorrection (diagonal edges)
+[trans]   geoCorrection() took 4.7 s
+[trans]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/02_transition_grids/transition_cf_only_rail_s0.rds
+
+[trans] ==== CASE: cf_only_rail_s1 ====
+[trans]   Reading /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/01_cost_rasters/ucost_cf_only_rail_s1.tif
+[trans]   Building 8-neighbour transition (1/mean(cost))
+[trans]   transition() took 44.5 s
+[trans]   Applying geoCorrection (diagonal edges)
+[trans]   geoCorrection() took 4.0 s
+[trans]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/02_transition_grids/transition_cf_only_rail_s1.rds
+
+[trans] ==== CASE: cf_only_rail_s2 ====
+[trans]   Reading /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/01_cost_rasters/ucost_cf_only_rail_s2.tif
+[trans]   Building 8-neighbour transition (1/mean(cost))
+[trans]   transition() took 43.9 s
+[trans]   Applying geoCorrection (diagonal edges)
+[trans]   geoCorrection() took 4.8 s
+[trans]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/02_transition_grids/transition_cf_only_rail_s2.rds
+
+[trans] ==== CASE: cf_only_road_s0 ====
+[trans]   Reading /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/01_cost_rasters/ucost_cf_only_road_s0.tif
+[trans]   Building 8-neighbour transition (1/mean(cost))
+[trans]   transition() took 43.8 s
+[trans]   Applying geoCorrection (diagonal edges)
+[trans]   geoCorrection() took 4.0 s
+[trans]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/02_transition_grids/transition_cf_only_road_s0.rds
+
+[trans] ==== CASE: cf_only_road_s1 ====
+[trans]   Reading /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/01_cost_rasters/ucost_cf_only_road_s1.tif
+[trans]   Building 8-neighbour transition (1/mean(cost))
+[trans]   transition() took 44.4 s
+[trans]   Applying geoCorrection (diagonal edges)
+[trans]   geoCorrection() took 3.8 s
+[trans]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/02_transition_grids/transition_cf_only_road_s1.rds
+
+[trans] ==== CASE: cf_only_road_s2 ====
+[trans]   Reading /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/01_cost_rasters/ucost_cf_only_road_s2.tif
+[trans]   Building 8-neighbour transition (1/mean(cost))
+[trans]   transition() took 42.3 s
+[trans]   Applying geoCorrection (diagonal edges)
+[trans]   geoCorrection() took 3.5 s
+[trans]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/02_transition_grids/transition_cf_only_road_s2.rds
+========================================================================
+03b_transition_grids.R  |  Complete.
+========================================================================
+

--- a/logs/03c_compute_taus.log
+++ b/logs/03c_compute_taus.log
@@ -92,3 +92,28 @@ All cases done in 5.7 minutes.
   OK    instrument_euc_s0  338s  (median τ = 1728282, BA→Córdoba τ = 1147490, 0 Inf)
   OK    instrument_euc_s1  334s  (median τ = 742586, BA→Córdoba τ = 453479, 0 Inf)
   OK    instrument_euc_s2  321s  (median τ = 6286744, BA→Córdoba τ = 4507972, 0 Inf)
+Warning messages:
+1: package ‘sf’ was built under R version 4.5.2 
+2: package ‘sp’ was built under R version 4.5.2 
+3: package ‘igraph’ was built under R version 4.5.2 
+[config.R] rootdir = /Users/diegogp/Desktop/Diego/Trains/new_repo
+[config.R] Configuration loaded successfully.
+
+========================================================================
+03c_compute_taus_parallel.R  |  ncores = 4, 6 cases
+========================================================================
+  cf_only_rail_s0
+  cf_only_rail_s1
+  cf_only_rail_s2
+  cf_only_road_s0
+  cf_only_road_s1
+  cf_only_road_s2
+[tau] Loading district centroids
+
+All cases done in 15.2 minutes.
+  OK    cf_only_rail_s0  552s  (median τ = 4770800, BA→Córdoba τ = 2676906, 0 Inf)
+  OK    cf_only_rail_s1  565s  (median τ = 3404423, BA→Córdoba τ = 1631465, 0 Inf)
+  OK    cf_only_rail_s2  475s  (median τ = 11780923, BA→Córdoba τ = 6999915, 0 Inf)
+  OK    cf_only_road_s0  598s  (median τ = 3033069, BA→Córdoba τ = 1365217, 0 Inf)
+  OK    cf_only_road_s1  432s  (median τ = 1931658, BA→Córdoba τ = 481408, 0 Inf)
+  OK    cf_only_road_s2  352s  (median τ = 8303270, BA→Córdoba τ = 5646248, 0 Inf)

--- a/logs/04_market_access.log
+++ b/logs/04_market_access.log
@@ -320,3 +320,101 @@ Elasticities: θ_low = 4.550, θ_high = 8.110
 04_market_access.R  |  Complete.
 ========================================================================
 
+[config.R] rootdir = /Users/diegogp/Desktop/Diego/Trains/new_repo
+[config.R] Configuration loaded successfully.
+
+========================================================================
+04_market_access.R  |  MA_i = sum_{j≠i} Pop_j / τ_ij^θ
+========================================================================
+Cases: cf_only_rail_s0, cf_only_rail_s1, cf_only_rail_s2, cf_only_road_s0, cf_only_road_s1, cf_only_road_s2
+
+Elasticities: θ_low = 4.550, θ_high = 8.110
+[ma] Loaded 1960 pop: 309 districts, total=13,551,523
+
+[ma] ==== CASE: cf_only_rail_s0 (elow, θ=4.550) ====
+[ma]   τ file has 312 districts (48516 pairs)
+[ma]   MA computed for 312 districts; 0 have logMA = -Inf (MA = 0)
+[ma]   MA summary (MA>0): min=3.802e-28 median=1.038e-22 max=2.566e-13
+[ma]   logMA summary (finite): min=-63.14  mean=-49.43  max=-28.99
+[ma]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/04_market_access/ma_cf_only_rail_s0_elow.parquet
+
+[ma] ==== CASE: cf_only_rail_s0 (ehigh, θ=8.110) ====
+[ma]   τ file has 312 districts (48516 pairs)
+[ma]   MA computed for 312 districts; 0 have logMA = -Inf (MA = 0)
+[ma]   MA summary (MA>0): min=3.615e-55 median=5.428e-45 max=1.547e-27
+[ma]   logMA summary (finite): min=-125.36  mean=-99.65  max=-61.73
+[ma]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/04_market_access/ma_cf_only_rail_s0_ehigh.parquet
+
+[ma] ==== CASE: cf_only_rail_s1 (elow, θ=4.550) ====
+[ma]   τ file has 312 districts (48516 pairs)
+[ma]   MA computed for 312 districts; 0 have logMA = -Inf (MA = 0)
+[ma]   MA summary (MA>0): min=6.521e-28 median=7.510e-22 max=3.591e-11
+[ma]   logMA summary (finite): min=-62.60  mean=-47.39  max=-24.05
+[ma]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/04_market_access/ma_cf_only_rail_s1_elow.parquet
+
+[ma] ==== CASE: cf_only_rail_s1 (ehigh, θ=8.110) ====
+[ma]   τ file has 312 districts (48516 pairs)
+[ma]   MA computed for 312 districts; 0 have logMA = -Inf (MA = 0)
+[ma]   MA summary (MA>0): min=9.414e-55 median=1.004e-43 max=1.041e-23
+[ma]   logMA summary (finite): min=-124.40  mean=-96.37  max=-52.92
+[ma]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/04_market_access/ma_cf_only_rail_s1_ehigh.parquet
+
+[ma] ==== CASE: cf_only_rail_s2 (elow, θ=4.550) ====
+[ma]   τ file has 312 districts (48516 pairs)
+[ma]   MA computed for 312 districts; 0 have logMA = -Inf (MA = 0)
+[ma]   MA summary (MA>0): min=3.358e-29 median=3.461e-24 max=8.264e-17
+[ma]   logMA summary (finite): min=-65.56  mean=-53.13  max=-37.03
+[ma]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/04_market_access/ma_cf_only_rail_s2_elow.parquet
+
+[ma] ==== CASE: cf_only_rail_s2 (ehigh, θ=8.110) ====
+[ma]   τ file has 312 districts (48516 pairs)
+[ma]   MA computed for 312 districts; 0 have logMA = -Inf (MA = 0)
+[ma]   MA summary (MA>0): min=6.947e-57 median=5.372e-47 max=9.474e-34
+[ma]   logMA summary (finite): min=-129.31  mean=-105.43  max=-76.04
+[ma]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/04_market_access/ma_cf_only_rail_s2_ehigh.parquet
+
+[ma] ==== CASE: cf_only_road_s0 (elow, θ=4.550) ====
+[ma]   τ file has 312 districts (48516 pairs)
+[ma]   MA computed for 312 districts; 0 have logMA = -Inf (MA = 0)
+[ma]   MA summary (MA>0): min=9.472e-27 median=9.928e-22 max=2.602e-13
+[ma]   logMA summary (finite): min=-59.92  mean=-47.28  max=-28.98
+[ma]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/04_market_access/ma_cf_only_road_s0_elow.parquet
+
+[ma] ==== CASE: cf_only_road_s0 (ehigh, θ=8.110) ====
+[ma]   τ file has 312 districts (48516 pairs)
+[ma]   MA computed for 312 districts; 0 have logMA = -Inf (MA = 0)
+[ma]   MA summary (MA>0): min=1.112e-52 median=5.438e-43 max=1.548e-27
+[ma]   logMA summary (finite): min=-119.63  mean=-95.47  max=-61.73
+[ma]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/04_market_access/ma_cf_only_road_s0_ehigh.parquet
+
+[ma] ==== CASE: cf_only_road_s1 (elow, θ=4.550) ====
+[ma]   τ file has 312 districts (48516 pairs)
+[ma]   MA computed for 312 districts; 0 have logMA = -Inf (MA = 0)
+[ma]   MA summary (MA>0): min=1.214e-26 median=9.321e-21 max=3.592e-11
+[ma]   logMA summary (finite): min=-59.67  mean=-44.93  max=-24.05
+[ma]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/04_market_access/ma_cf_only_road_s1_elow.parquet
+
+[ma] ==== CASE: cf_only_road_s1 (ehigh, θ=8.110) ====
+[ma]   τ file has 312 districts (48516 pairs)
+[ma]   MA computed for 312 districts; 0 have logMA = -Inf (MA = 0)
+[ma]   MA summary (MA>0): min=1.718e-52 median=1.083e-41 max=1.041e-23
+[ma]   logMA summary (finite): min=-119.19  mean=-91.74  max=-52.92
+[ma]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/04_market_access/ma_cf_only_road_s1_ehigh.parquet
+
+[ma] ==== CASE: cf_only_road_s2 (elow, θ=4.550) ====
+[ma]   τ file has 312 districts (48516 pairs)
+[ma]   MA computed for 312 districts; 0 have logMA = -Inf (MA = 0)
+[ma]   MA summary (MA>0): min=3.589e-27 median=2.294e-23 max=8.405e-17
+[ma]   logMA summary (finite): min=-60.89  mean=-51.28  max=-37.02
+[ma]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/04_market_access/ma_cf_only_road_s2_elow.parquet
+
+[ma] ==== CASE: cf_only_road_s2 (ehigh, θ=8.110) ====
+[ma]   τ file has 312 districts (48516 pairs)
+[ma]   MA computed for 312 districts; 0 have logMA = -Inf (MA = 0)
+[ma]   MA summary (MA>0): min=2.140e-53 median=1.410e-45 max=9.610e-34
+[ma]   logMA summary (finite): min=-121.28  mean=-101.96  max=-76.03
+[ma]   Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/04_market_access/ma_cf_only_road_s2_ehigh.parquet
+========================================================================
+04_market_access.R  |  Complete.
+========================================================================
+

--- a/logs/06_merge_ma_into_panel.log
+++ b/logs/06_merge_ma_into_panel.log
@@ -4,46 +4,58 @@
 ========================================================================
 06_merge_ma_into_panel.R  |  merge MA into wide panel
 ========================================================================
-[panel] Starting panel: 312 × 160
-[panel] Removing 42 stale MA columns: logMA_actual_1960_s0_elow, logMA_actual_1960_s0_ehigh, logMA_actual_1960_s1_elow, logMA_actual_1960_s1_ehigh, logMA_actual_1960_s2_elow, logMA_actual_1960_s2_ehigh, logMA_actual_1986_s0_elow, logMA_actual_1986_s0_ehigh, logMA_actual_1986_s1_elow, logMA_actual_1986_s1_ehigh, logMA_actual_1986_s2_elow, logMA_actual_1986_s2_ehigh, logMA_instrument_stu_s0_elow, logMA_instrument_stu_s0_ehigh, logMA_instrument_stu_s1_elow, logMA_instrument_stu_s1_ehigh, logMA_instrument_stu_s2_elow, logMA_instrument_stu_s2_ehigh, logMA_instrument_lcp_mst_s0_elow, logMA_instrument_lcp_mst_s0_ehigh, logMA_instrument_lcp_mst_s1_elow, logMA_instrument_lcp_mst_s1_ehigh, logMA_instrument_lcp_mst_s2_elow, logMA_instrument_lcp_mst_s2_ehigh, chg_logMA_86_60_s0_elow, chg_logMA_stu_s0_elow, chg_logMA_lcp_mst_s0_elow, chg_logMA_86_60_s0_ehigh, chg_logMA_stu_s0_ehigh, chg_logMA_lcp_mst_s0_ehigh, chg_logMA_86_60_s1_elow, chg_logMA_stu_s1_elow, chg_logMA_lcp_mst_s1_elow, chg_logMA_86_60_s1_ehigh, chg_logMA_stu_s1_ehigh, chg_logMA_lcp_mst_s1_ehigh, chg_logMA_86_60_s2_elow, chg_logMA_stu_s2_elow, chg_logMA_lcp_mst_s2_elow, chg_logMA_86_60_s2_ehigh, chg_logMA_stu_s2_ehigh, chg_logMA_lcp_mst_s2_ehigh
-[panel] 36 change variables built:
+[panel] Starting panel: 312 × 196
+[panel] Removing 78 stale MA columns: logMA_actual_1960_s0_elow, logMA_actual_1960_s0_ehigh, logMA_actual_1960_s1_elow, logMA_actual_1960_s1_ehigh, logMA_actual_1960_s2_elow, logMA_actual_1960_s2_ehigh, logMA_actual_1986_s0_elow, logMA_actual_1986_s0_ehigh, logMA_actual_1986_s1_elow, logMA_actual_1986_s1_ehigh, logMA_actual_1986_s2_elow, logMA_actual_1986_s2_ehigh, logMA_instrument_stu_s0_elow, logMA_instrument_stu_s0_ehigh, logMA_instrument_stu_s1_elow, logMA_instrument_stu_s1_ehigh, logMA_instrument_stu_s2_elow, logMA_instrument_stu_s2_ehigh, logMA_instrument_lcp_mst_s0_elow, logMA_instrument_lcp_mst_s0_ehigh, logMA_instrument_lcp_mst_s1_elow, logMA_instrument_lcp_mst_s1_ehigh, logMA_instrument_lcp_mst_s2_elow, logMA_instrument_lcp_mst_s2_ehigh, logMA_instrument_euc_mst_s0_elow, logMA_instrument_euc_mst_s0_ehigh, logMA_instrument_euc_mst_s1_elow, logMA_instrument_euc_mst_s1_ehigh, logMA_instrument_euc_mst_s2_elow, logMA_instrument_euc_mst_s2_ehigh, logMA_instrument_lcp_s0_elow, logMA_instrument_lcp_s0_ehigh, logMA_instrument_lcp_s1_elow, logMA_instrument_lcp_s1_ehigh, logMA_instrument_lcp_s2_elow, logMA_instrument_lcp_s2_ehigh, logMA_instrument_euc_s0_elow, logMA_instrument_euc_s0_ehigh, logMA_instrument_euc_s1_elow, logMA_instrument_euc_s1_ehigh, logMA_instrument_euc_s2_elow, logMA_instrument_euc_s2_ehigh, chg_logMA_86_60_s0_elow, chg_logMA_stu_s0_elow, chg_logMA_lcp_mst_s0_elow, chg_logMA_euc_mst_s0_elow, chg_logMA_lcp_s0_elow, chg_logMA_euc_s0_elow, chg_logMA_86_60_s0_ehigh, chg_logMA_stu_s0_ehigh, chg_logMA_lcp_mst_s0_ehigh, chg_logMA_euc_mst_s0_ehigh, chg_logMA_lcp_s0_ehigh, chg_logMA_euc_s0_ehigh, chg_logMA_86_60_s1_elow, chg_logMA_stu_s1_elow, chg_logMA_lcp_mst_s1_elow, chg_logMA_euc_mst_s1_elow, chg_logMA_lcp_s1_elow, chg_logMA_euc_s1_elow, chg_logMA_86_60_s1_ehigh, chg_logMA_stu_s1_ehigh, chg_logMA_lcp_mst_s1_ehigh, chg_logMA_euc_mst_s1_ehigh, chg_logMA_lcp_s1_ehigh, chg_logMA_euc_s1_ehigh, chg_logMA_86_60_s2_elow, chg_logMA_stu_s2_elow, chg_logMA_lcp_mst_s2_elow, chg_logMA_euc_mst_s2_elow, chg_logMA_lcp_s2_elow, chg_logMA_euc_s2_elow, chg_logMA_86_60_s2_ehigh, chg_logMA_stu_s2_ehigh, chg_logMA_lcp_mst_s2_ehigh, chg_logMA_euc_mst_s2_ehigh, chg_logMA_lcp_s2_ehigh, chg_logMA_euc_s2_ehigh
+[panel] 48 change variables built:
   chg_logMA_86_60_s0_elow                        N=312  mean=+1.559  sd=2.483
   chg_logMA_stu_s0_elow                          N=312  mean=-1.240  sd=2.225
   chg_logMA_lcp_mst_s0_elow                      N=312  mean=-0.494  sd=2.479
   chg_logMA_euc_mst_s0_elow                      N=312  mean=-0.640  sd=2.401
   chg_logMA_lcp_s0_elow                          N=312  mean=+0.710  sd=3.332
   chg_logMA_euc_s0_elow                          N=312  mean=+5.473  sd=4.613
+  chg_logMA_only_rail_s0_elow                    N=312  mean=-0.397  sd=1.352
+  chg_logMA_only_road_s0_elow                    N=312  mean=+1.749  sd=2.242
   chg_logMA_86_60_s0_ehigh                       N=312  mean=+3.069  sd=5.140
   chg_logMA_stu_s0_ehigh                         N=312  mean=-2.223  sd=4.318
   chg_logMA_lcp_mst_s0_ehigh                     N=312  mean=-0.979  sd=5.017
   chg_logMA_euc_mst_s0_ehigh                     N=312  mean=-1.407  sd=4.808
   chg_logMA_lcp_s0_ehigh                         N=312  mean=+1.439  sd=6.827
   chg_logMA_euc_s0_ehigh                         N=312  mean=+10.961  sd=9.429
+  chg_logMA_only_rail_s0_ehigh                   N=312  mean=-0.728  sd=2.614
+  chg_logMA_only_road_s0_ehigh                   N=312  mean=+3.444  sd=4.685
   chg_logMA_86_60_s1_elow                        N=312  mean=+1.571  sd=3.301
   chg_logMA_stu_s1_elow                          N=312  mean=-1.612  sd=3.023
   chg_logMA_lcp_mst_s1_elow                      N=312  mean=-0.663  sd=3.175
   chg_logMA_euc_mst_s1_elow                      N=312  mean=-0.903  sd=3.125
   chg_logMA_lcp_s1_elow                          N=312  mean=+0.666  sd=4.284
   chg_logMA_euc_s1_elow                          N=312  mean=+6.355  sd=5.827
+  chg_logMA_only_rail_s1_elow                    N=312  mean=-0.557  sd=1.943
+  chg_logMA_only_road_s1_elow                    N=312  mean=+1.900  sd=2.889
   chg_logMA_86_60_s1_ehigh                       N=312  mean=+3.004  sd=6.481
   chg_logMA_stu_s1_ehigh                         N=312  mean=-2.875  sd=5.635
   chg_logMA_lcp_mst_s1_ehigh                     N=312  mean=-1.232  sd=6.187
   chg_logMA_euc_mst_s1_ehigh                     N=312  mean=-1.731  sd=6.105
   chg_logMA_lcp_s1_ehigh                         N=312  mean=+1.355  sd=8.446
   chg_logMA_euc_s1_ehigh                         N=312  mean=+12.533  sd=11.579
+  chg_logMA_only_rail_s1_ehigh                   N=312  mean=-1.023  sd=3.669
+  chg_logMA_only_road_s1_ehigh                   N=312  mean=+3.608  sd=5.712
   chg_logMA_86_60_s2_elow                        N=312  mean=+1.573  sd=1.601
   chg_logMA_stu_s2_elow                          N=312  mean=-0.636  sd=1.227
   chg_logMA_lcp_mst_s2_elow                      N=312  mean=-0.682  sd=1.730
   chg_logMA_euc_mst_s2_elow                      N=312  mean=-0.693  sd=1.711
   chg_logMA_lcp_s2_elow                          N=312  mean=+0.565  sd=2.360
   chg_logMA_euc_s2_elow                          N=312  mean=+4.033  sd=3.055
+  chg_logMA_only_rail_s2_elow                    N=312  mean=-0.197  sd=0.649
+  chg_logMA_only_road_s2_elow                    N=312  mean=+1.654  sd=1.537
   chg_logMA_86_60_s2_ehigh                       N=312  mean=+2.911  sd=3.377
   chg_logMA_stu_s2_ehigh                         N=312  mean=-1.237  sd=2.507
   chg_logMA_lcp_mst_s2_ehigh                     N=312  mean=-1.290  sd=3.610
   chg_logMA_euc_mst_s2_ehigh                     N=312  mean=-1.564  sd=3.425
   chg_logMA_lcp_s2_ehigh                         N=312  mean=+0.905  sd=4.903
   chg_logMA_euc_s2_ehigh                         N=312  mean=+7.626  sd=6.276
-[panel] Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/05_panel/departments_wide_panel.parquet (312 × 196)
+  chg_logMA_only_rail_s2_ehigh                   N=312  mean=-0.388  sd=1.329
+  chg_logMA_only_road_s2_ehigh                   N=312  mean=+3.080  sd=3.249
+[panel] Saved: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/05_panel/departments_wide_panel.parquet (312 × 220)
 [panel] Manifest: /Users/diegogp/Desktop/Diego/Trains/new_repo/data/derived/05_panel/data_file_manifest.log
 ========================================================================
 06_merge_ma_into_panel.R  |  Complete.


### PR DESCRIPTION
Closes #38

Final phase of the tau rebuild. Adds two counterfactual network cases that decompose the 1960→1986 transport shock into its rail-contraction and road-expansion components.

## New cases

| Case | Rails | Roads | Purpose |
|---|---|---|---|
| \`cf_only_rail\` | 1986 | 1954 | Isolates the rail shock (roads frozen at baseline) |
| \`cf_only_road\` | 1960 | 1986 | Isolates the road shock (rails frozen at baseline) |

Each × 3 sectors × 2 elasticities = **12 new MA columns**. Panel now 312 × 220 (was 196).

## New change variables

- \`chg_logMA_only_rail_<s>_<e> = logMA_cf_only_rail − logMA_actual_1960\`
- \`chg_logMA_only_road_<s>_<e> = logMA_cf_only_road − logMA_actual_1960\`

## Headline decomposition (Δlog MA means, elow)

| Sector | Actual 86−60 | only_rail | only_road | rail+road |
|---|---:|---:|---:|---:|
| s0 (overall) | +1.56 | **−0.40** | **+1.75** | +1.35 |
| s1 (agriculture) | +1.57 | **−0.56** | **+1.90** | +1.34 |
| s2 (manufacturing) | +1.57 | **−0.20** | **+1.65** | +1.45 |

### Four substantive findings

1. **Road expansion dominates** the aggregate MA increase (~+1.7 log units vs rail contraction at −0.2 to −0.6).
2. **Agriculture's rail-side loss is the largest** (−0.56), consistent with rail's comparative advantage at high cargo density.
3. **Manufacturing's rail-side loss is the smallest** (−0.20) — roads dominate for low-density goods, so losing rail matters less.
4. **`rail + road` < `actual` across all sectors** — the sum of isolated components is slightly below the joint effect, reflecting a positive interaction: road expansion matters more when rail is also contracting (substitution).

## BA → Córdoba τ sanity check

| Case | τ |
|---|---:|
| actual_1960 | 2,649,776 |
| cf_only_rail | 2,676,906 (rail contracts, roads unchanged → slight ↑) |
| cf_only_road | 1,365,217 (rails unchanged, roads expand → big ↓) |
| actual_1986 | 1,366,749 |

`cf_only_road` is virtually identical to `actual_1986` for this pair — road expansion captures essentially all the cost reduction.

## Changes

- \`03a_build_cost_raster.R\`: two new entries in \`base_specs\` with explicit rail/road year selectors. Header case list updated to show all 9 network specs.
- \`06_merge_ma_into_panel.R\`: \`network_specs\` list adds both \`cf_*\`; \`timings\` list adds \`only_rail\` and \`only_road\`.

## Verified

- 6 new cost rasters validate against sector parameters (nav, rail, road, mininfra).
- 6 new taus have 0 Inf pairs (TdF stays reachable via navigation).
- All 12 new MA columns computed; all 12 new change variables have N=312.
- Manifest updated automatically; sizes match expectations.

## Runtime

- 6 cost rasters: ~3 min
- 6 transition grids: ~5 min  
- 6 taus (parallel, 4 cores): ~15 min
- 12 MAs: ~2 min
- Panel merge: <1 s

Total: ~25 min.

## Tau rebuild complete

With Phase 3 merged, all planned cost-raster cases exist:

- **9 network specs** (2 actual + 4 instruments + 3 counterfactuals):
  actual_1960, actual_1986,
  instrument_stu, instrument_lcp_mst, instrument_euc_mst, instrument_lcp, instrument_euc,
  cf_only_rail, cf_only_road
- **3 cost sectors** (s0, s1, s2)
- **2 elasticities** (elow, ehigh)
- **54 logMA columns, 48 chg_logMA columns, 312 districts all connected**

Next: downstream regressions.