### PR TITLE
Figures 2 and 4 + Section 3 (Data) first draft

### DIFF
--- a/code/analysis/plot_figure_2.R
+++ b/code/analysis/plot_figure_2.R
@@ -1,0 +1,132 @@
+# ===========================================================================
+# plot_figure_2.R
+#
+# PURPOSE: Paper's Figure 2 — district-level choropleth of the main
+#          treatment variable Δlog MA (actual 1986 − actual 1960),
+#          sector 0 (overall), θ_low = 4.55.
+#
+# READS:
+#   data/derived/05_panel/departments_wide_panel.parquet  (chg_logMA)
+#   data/raw/geo/geo2_ar1970_2010.shp                     (district polygons)
+#
+# PRODUCES:
+#   results/figures/figure_2_ma_change_choropleth.pdf
+#   results/figures/figure_2_ma_change_choropleth.png
+#
+# DESIGN:
+#   - Divergent colour scale centered at zero: blue for districts whose
+#     market access fell, red for districts whose market access rose.
+#     (Almost all districts see MA rise because roads expanded ~190%.)
+#   - Break points chosen to show the distribution's shape. Binned map
+#     rather than continuous because the long positive tail would
+#     otherwise wash out the small-change districts.
+#   - 312 districts, all with finite ΔlogMA after Phase 2b navigation.
+# ===========================================================================
+
+main <- function() {
+    source(file.path(here::here(), "code", "config.R"), echo = FALSE)
+    source(file.path(dir_code, "base", "utils.R"), echo = FALSE)
+
+    if (!dir.exists(dir_figures)) dir.create(dir_figures, recursive = TRUE)
+
+    d <- load_panel_with_geometry()
+
+    for (fmt in c("pdf", "png")) {
+        out <- file.path(
+            dir_figures,
+            sprintf("figure_2_ma_change_choropleth.%s", fmt)
+        )
+        open_device(out, fmt)
+        par(mar = c(0.5, 0.5, 3, 0.5))
+        draw_choropleth(d)
+        dev.off()
+        message("Saved: ", out)
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Device helpers (matches plot_figure_1.R convention)
+# ---------------------------------------------------------------------------
+open_device <- function(path, fmt) {
+    if (fmt == "pdf") {
+        grDevices::pdf(path, width = 7, height = 9)
+    } else if (fmt == "png") {
+        grDevices::png(path, width = 1400, height = 1800, res = 200)
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Load districts and merge the ΔlogMA column
+# ---------------------------------------------------------------------------
+load_panel_with_geometry <- function() {
+    shp <- sf::st_read(
+        file.path(dir_raw_geo, "geo2_ar1970_2010.shp"), quiet = TRUE
+    )
+    shp <- sf::st_make_valid(shp)
+    names(shp)[names(shp) == "GEOLEVEL2"] <- "geolev2"
+    shp$geolev2 <- sub("^0+", "", as.character(shp$geolev2))
+    shp <- shp[!sf::st_is_empty(shp), ]
+    shp <- shp[!(shp$geolev2 %in% geolev2_exclude), ]
+    shp <- shp[!grepl("0000$", shp$geolev2), ]
+
+    panel <- arrow::read_parquet(
+        file.path(dir_derived_panel, "departments_wide_panel.parquet")
+    )
+    panel <- ensure_geolev2_char(panel)
+
+    merge_cols <- c("geolev2", "chg_logMA_86_60_s0_elow")
+    stopifnot(all(merge_cols %in% names(panel)))
+    merge(shp, panel[, merge_cols], by = "geolev2")
+}
+
+# ---------------------------------------------------------------------------
+# Draw the choropleth
+# ---------------------------------------------------------------------------
+draw_choropleth <- function(d) {
+    x <- d$chg_logMA_86_60_s0_elow
+
+    # Diverging binning. Centered at 0.
+    breaks <- c(-Inf, -1, 0, 0.5, 1, 2, 4, Inf)
+    labels <- c("< -1", "(-1, 0]", "(0, 0.5]", "(0.5, 1]",
+                "(1, 2]", "(2, 4]", "> 4")
+    # Blue below 0, red above — diverging palette (colorblind-safe)
+    palette <- c(
+        "< -1"       = "#053061",
+        "(-1, 0]"    = "#4393c3",
+        "(0, 0.5]"   = "#fddbc7",
+        "(0.5, 1]"   = "#f4a582",
+        "(1, 2]"     = "#d6604d",
+        "(2, 4]"     = "#b2182b",
+        "> 4"        = "#67001f"
+    )
+
+    d$cat <- cut(x, breaks = breaks, labels = labels, right = TRUE)
+    d$cat <- factor(as.character(d$cat), levels = labels)
+
+    plot(sf::st_geometry(d),
+         col = palette[d$cat],
+         border = "grey50",
+         lwd = 0.3,
+         main = expression(paste(Delta, "log MA: 1960 ", "\u2192", " 1986")))
+
+    graphics::legend(
+        "bottomleft",
+        legend = labels,
+        fill   = palette,
+        bty    = "n",
+        cex    = 0.85,
+        y.intersp = 1.1,
+        title  = expression(paste(Delta, "log MA"))
+    )
+
+    # Summary stats on the figure
+    ok <- !is.na(x)
+    subtitle <- sprintf(
+        "N = %d districts. Mean = %+.3f, SD = %.3f. %.0f%% positive.",
+        sum(ok), mean(x[ok]), sd(x[ok]),
+        100 * mean(x[ok] > 0)
+    )
+    graphics::mtext(subtitle, side = 1, line = -0.5, cex = 0.75)
+}
+
+main()

--- a/code/analysis/plot_figure_4.R
+++ b/code/analysis/plot_figure_4.R
@@ -1,0 +1,115 @@
+# ===========================================================================
+# plot_figure_4.R
+#
+# PURPOSE: Paper's Figure 4 — two-panel scatter of ΔlogMA against km-level
+#          network changes. Shows what drives the variation in the main
+#          treatment variable.
+#
+#   Panel A: Δ logMA (86-60, s0, elow) vs Δ paved+gravel road km (86-54)
+#   Panel B: Δ logMA (86-60, s0, elow) vs Δ rail km (86-60)
+#
+# READS:
+#   data/derived/05_panel/departments_wide_panel.parquet
+#
+# PRODUCES:
+#   results/figures/figure_4_infra_vs_ma_scatter.pdf
+#   results/figures/figure_4_infra_vs_ma_scatter.png
+#
+# DESIGN:
+#   - Each panel shows the OLS regression line and the correlation r.
+#   - Points use semi-transparent black so clusters are visible.
+#   - h=0 / v=0 reference lines mark the "no change" baselines.
+# ===========================================================================
+
+main <- function() {
+    source(file.path(here::here(), "code", "config.R"), echo = FALSE)
+    source(file.path(dir_code, "base", "utils.R"), echo = FALSE)
+
+    if (!dir.exists(dir_figures)) dir.create(dir_figures, recursive = TRUE)
+
+    d <- arrow::read_parquet(
+        file.path(dir_derived_panel, "departments_wide_panel.parquet")
+    )
+
+    for (fmt in c("pdf", "png")) {
+        out <- file.path(
+            dir_figures,
+            sprintf("figure_4_infra_vs_ma_scatter.%s", fmt)
+        )
+        open_device(out, fmt)
+        par(mfrow = c(1, 2),
+            mar   = c(4.5, 4.5, 3, 1),
+            oma   = c(0, 0, 0, 0))
+
+        draw_panel(d,
+                   x_col = "chg_pav_and_grav_86_54",
+                   y_col = "chg_logMA_86_60_s0_elow",
+                   x_lab = "Change in paved+gravel road km, 1954-1986",
+                   y_lab = expression(paste(Delta, " log MA, 1960-1986")),
+                   title = "(a) Roads")
+
+        draw_panel(d,
+                   x_col = "chg_tot_rails_86_60",
+                   y_col = "chg_logMA_86_60_s0_elow",
+                   x_lab = "Change in rail km, 1960-1986",
+                   y_lab = expression(paste(Delta, " log MA, 1960-1986")),
+                   title = "(b) Rails")
+
+        dev.off()
+        message("Saved: ", out)
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Device helpers
+# ---------------------------------------------------------------------------
+open_device <- function(path, fmt) {
+    if (fmt == "pdf") {
+        grDevices::pdf(path, width = 12, height = 6)
+    } else if (fmt == "png") {
+        grDevices::png(path, width = 2400, height = 1200, res = 200)
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Draw one scatter panel
+# ---------------------------------------------------------------------------
+draw_panel <- function(d, x_col, y_col, x_lab, y_lab, title) {
+    x <- d[[x_col]]
+    y <- d[[y_col]]
+    keep <- !is.na(x) & !is.na(y)
+    x <- x[keep]
+    y <- y[keep]
+    n <- length(x)
+    r <- stats::cor(x, y)
+
+    plot(x, y,
+         pch  = 20,
+         col  = grDevices::adjustcolor("black", alpha.f = 0.55),
+         cex  = 0.9,
+         xlab = x_lab,
+         ylab = y_lab,
+         main = sprintf("%s (N=%d, r=%.3f)", title, n, r))
+    graphics::abline(h = 0, col = "grey70", lty = 2)
+    graphics::abline(v = 0, col = "grey70", lty = 2)
+
+    fit <- stats::lm(y ~ x)
+    graphics::abline(fit, col = "#c00000", lwd = 2)
+
+    b <- stats::coef(fit)
+    se <- summary(fit)$coefficients["x", "Std. Error"]
+    # Adaptive unit: for rail/road in km, b is very small (e-4 range).
+    graphics::legend(
+        "topleft",
+        legend = c(
+            sprintf("OLS slope = %.4g (SE %.4g)", b[2], se),
+            sprintf("Intercept = %.2f", b[1])
+        ),
+        col = c("#c00000", NA),
+        lwd = c(2, NA),
+        bty = "n",
+        cex = 0.85
+    )
+}
+
+main()

--- a/code/analysis/plot_figure_c13.R
+++ b/code/analysis/plot_figure_c13.R
@@ -1,0 +1,148 @@
+# ===========================================================================
+# plot_figure_c13.R
+#
+# PURPOSE: Block-2 figure — three-panel choropleth decomposing the
+#          1960 → 1986 market-access change into its rail and road
+#          components.
+#
+#   Panel A: ΔlogMA_full        (actual total, chg_logMA_86_60_s0_elow)
+#   Panel B: ΔlogMA_only_rail   (rails_86 + roads_54 counterfactual)
+#   Panel C: ΔlogMA_only_road   (rails_60 + roads_86 counterfactual)
+#
+# READS:
+#   data/derived/05_panel/departments_wide_panel.parquet
+#   data/raw/geo/geo2_ar1970_2010.shp
+#
+# PRODUCES:
+#   results/figures/figure_c13_ma_counterfactual_trio.pdf
+#   results/figures/figure_c13_ma_counterfactual_trio.png
+#
+# DESIGN:
+#   - All three panels share the same colour scale so magnitudes are
+#     visually comparable across shocks.
+#   - Break points cover the pooled range (min across the 3 columns,
+#     max across the 3 columns).
+#   - Diverging palette centered at 0 (blue = MA fell, red = MA rose).
+#   - Sector 0, θ_low for the main spec; other specs trivially
+#     reproducible by editing the column names.
+# ===========================================================================
+
+main <- function() {
+    source(file.path(here::here(), "code", "config.R"), echo = FALSE)
+    source(file.path(dir_code, "base", "utils.R"), echo = FALSE)
+
+    if (!dir.exists(dir_figures)) dir.create(dir_figures, recursive = TRUE)
+
+    d <- load_panel_with_geometry()
+
+    # Pooled breakpoints
+    vals <- c(
+        d$chg_logMA_86_60_s0_elow,
+        d$chg_logMA_only_rail_s0_elow,
+        d$chg_logMA_only_road_s0_elow
+    )
+    breaks <- c(-Inf, -2, -1, -0.5, 0, 0.5, 1, 2, 4, Inf)
+    labels <- c("< -2", "(-2, -1]", "(-1, -0.5]",
+                "(-0.5, 0]", "(0, 0.5]", "(0.5, 1]",
+                "(1, 2]", "(2, 4]", "> 4")
+    palette <- c(
+        "< -2"        = "#08306b",
+        "(-2, -1]"    = "#2171b5",
+        "(-1, -0.5]"  = "#6baed6",
+        "(-0.5, 0]"   = "#c6dbef",
+        "(0, 0.5]"    = "#fddbc7",
+        "(0.5, 1]"    = "#f4a582",
+        "(1, 2]"      = "#d6604d",
+        "(2, 4]"      = "#b2182b",
+        "> 4"         = "#67001f"
+    )
+
+    for (fmt in c("pdf", "png")) {
+        out <- file.path(
+            dir_figures,
+            sprintf("figure_c13_ma_counterfactual_trio.%s", fmt)
+        )
+        open_device(out, fmt)
+        layout(matrix(c(1, 2, 3, 4), nrow = 1),
+               widths = c(1, 1, 1, 0.4))
+        par(mar = c(0.5, 0.5, 3, 0.5), oma = c(0, 0, 0, 0))
+
+        draw_panel(d, "chg_logMA_86_60_s0_elow",
+                   "(a) Total 1960\u20131986",
+                   breaks, labels, palette)
+        draw_panel(d, "chg_logMA_only_rail_s0_elow",
+                   "(b) Rail-only counterfactual",
+                   breaks, labels, palette)
+        draw_panel(d, "chg_logMA_only_road_s0_elow",
+                   "(c) Road-only counterfactual",
+                   breaks, labels, palette)
+
+        # Shared legend panel
+        par(mar = c(0.5, 0, 3, 0))
+        plot.new()
+        graphics::legend(
+            "center",
+            legend = labels,
+            fill   = palette,
+            bty    = "n",
+            cex    = 0.85,
+            y.intersp = 1.1,
+            title  = expression(paste(Delta, "log MA"))
+        )
+
+        dev.off()
+        message("Saved: ", out)
+    }
+}
+
+open_device <- function(path, fmt) {
+    if (fmt == "pdf") {
+        grDevices::pdf(path, width = 18, height = 8)
+    } else if (fmt == "png") {
+        grDevices::png(path, width = 3600, height = 1600, res = 200)
+    }
+}
+
+load_panel_with_geometry <- function() {
+    shp <- sf::st_read(
+        file.path(dir_raw_geo, "geo2_ar1970_2010.shp"), quiet = TRUE
+    )
+    shp <- sf::st_make_valid(shp)
+    names(shp)[names(shp) == "GEOLEVEL2"] <- "geolev2"
+    shp$geolev2 <- sub("^0+", "", as.character(shp$geolev2))
+    shp <- shp[!sf::st_is_empty(shp), ]
+    shp <- shp[!(shp$geolev2 %in% geolev2_exclude), ]
+    shp <- shp[!grepl("0000$", shp$geolev2), ]
+
+    panel <- arrow::read_parquet(
+        file.path(dir_derived_panel, "departments_wide_panel.parquet")
+    )
+    panel <- ensure_geolev2_char(panel)
+
+    cols <- c("geolev2",
+              "chg_logMA_86_60_s0_elow",
+              "chg_logMA_only_rail_s0_elow",
+              "chg_logMA_only_road_s0_elow")
+    stopifnot(all(cols %in% names(panel)))
+    merge(shp, panel[, cols], by = "geolev2")
+}
+
+draw_panel <- function(d, col, title, breaks, labels, palette) {
+    x <- d[[col]]
+    cat_x <- cut(x, breaks = breaks, labels = labels, right = TRUE)
+    cat_x <- factor(as.character(cat_x), levels = labels)
+
+    plot(sf::st_geometry(d),
+         col = palette[cat_x],
+         border = "grey50",
+         lwd = 0.3,
+         main = title)
+
+    subtitle <- sprintf(
+        "Mean %+.2f, SD %.2f",
+        mean(x, na.rm = TRUE), sd(x, na.rm = TRUE)
+    )
+    graphics::mtext(subtitle, side = 1, line = -1, cex = 0.75)
+}
+
+main()

--- a/paper/README.md
+++ b/paper/README.md
@@ -1,0 +1,50 @@
+# Paper
+
+Self-contained LaTeX source for the paper. Each section lives in its
+own `.tex` file and is `\input{}`ed from `paper.tex` when that master
+file is eventually written.
+
+## Current contents
+
+| File | Section | Status |
+|---|---|---|
+| `section_3_data.tex` | Section 3 (Data) | First draft, 2026-05-10 |
+
+## Writing conventions (Shapiro Robot mode, see `Plan/foursteps.pdf`)
+
+- State facts, do not argue. Interpretation and discussion go in later
+  sections.
+- Define every concept before using it.
+- No forward references to constructs that haven't been introduced yet.
+- Plain precise language, no fancy talk.
+
+## Numbers and tables
+
+All quantitative claims in the section files should eventually be
+pulled from `results/scalars.tex` via AutoFill macros so no number is
+ever hand-typed. For the current first draft, numbers are inlined with
+source comments at the top of each file pointing to the script and
+file that generated them.
+
+TODOs flagged as `[PLACEHOLDER: ...]` are bracketed decisions or open
+tasks in `Plan/tasks.md`.
+
+## Missing references
+
+`references.bib` will be populated when all sections are drafted. For
+Section 3, the citation keys used are:
+
+- `argentina1981politica`
+- `baumgartnerpalazzo1969`
+- `donaldsonhornbeck2016`
+- `eatonkortum2002`
+- `faoiiasa2012gaez`
+- `galorozak2016`
+- `nunn2012ruggedness`
+- `ozak2018`
+- `usgs1996gtopo30`
+
+## Compilation
+
+Not yet set up. The first compilable target will be when the intro,
+Section 3, and Section 4 are all drafted plus `references.bib` exists.

--- a/paper/section_3_data.tex
+++ b/paper/section_3_data.tex
@@ -98,9 +98,7 @@ Three districts, all in Patagonia, lack any segment in the road
 shapefile and contribute missing values in the district-level road
 variables. 11 districts lost rail without gaining roads and 141 districts
 both lost rail and gained roads. The cross-district correlation between
-$\Delta$(rail km) and $\Delta$(road km) is $-0.25$; the two network shocks
-are spatially partially decoupled, which supports using them as
-separately-instrumented treatments.
+$\Delta$(rail km) and $\Delta$(road km) is $-0.25$.
 
 \paragraph{Hypothetical road networks.}
 We also construct four hypothetical road networks that connect Argentina's

--- a/paper/section_3_data.tex
+++ b/paper/section_3_data.tex
@@ -1,0 +1,311 @@
+% ===========================================================================
+% Section 3: Data
+%
+% Per Shapiro Robot-mode writing conventions:
+%   - State facts; do not argue. Interpretation belongs in Section 5.
+%   - Define every concept before using it.
+%   - No forward references to undefined constructs.
+%   - Plain, precise language.
+%
+% All numerical claims in this section trace to either:
+%   - code/base/*/clean_*.R                (raw network / census totals)
+%   - code/pipeline/03a_build_cost_raster.R (cost-surface parameters)
+%   - code/pipeline/04_market_access.R     (MA computation)
+%   - data/derived/05_panel/departments_wide_panel.parquet (panel stats)
+%
+% Numbers marked "FROM PANEL" are pulled directly from the estimation
+% panel's manifest; those marked "FROM NETWORK" come from
+% rails_by_district.parquet or roads_by_district.parquet.
+%
+% Eventually these should be replaced with \input{results/scalars.tex}
+% AutoFill macros. For now they are inline for readability in the first
+% draft.
+% ===========================================================================
+
+\section{Data}
+\label{sec:data}
+
+The empirical analysis combines three data components. Section~\ref{ssec:networks}
+describes the transport network geometries and their changes between
+1960 and 1986. Section~\ref{ssec:census} describes the district-level
+population and economic outcomes. Section~\ref{ssec:ma} describes how
+we construct market access from transport cost surfaces.
+
+\subsection{Transport networks}
+\label{ssec:networks}
+
+We combine two georeferenced networks: the railway network at its 1979
+status, which we map to 1960 and 1986 via documented closure dates, and
+the paved-and-gravel road network at three cross sections (1954, 1970,
+1986).
+
+\paragraph{Railways.}
+The rail network comes from Argentina's 1979 \emph{Política Ferroviaria}
+report \citep{argentina1981politica}, Figure~V--5, scanned and
+digitised in QGIS using IGN shapefiles as geographic references. The
+resulting shapefile contains 565 MULTILINESTRING segments
+in WGS~84, each carrying three attributes that identify its operating
+status:
+\begin{itemize}
+  \item \texttt{status1979} with three values. Value 1 indicates the
+  segment was active in both 1979 and 1986 and is therefore counted
+  in both the 1960 and 1986 rail stocks. Value 2 indicates the segment
+  was closed during the military dictatorship (1976--1983). Value 3
+  indicates closure between 1960 and 1966; we count these segments in
+  the 1960 stock but not the 1986 stock.
+  \item \texttt{studied\_co} with two values. Value 1 indicates the
+  segment was one of the 237 rail segments studied in the 1962 Larkin
+  Plan, which recommended closures on the basis of freight-density and
+  operating-cost criteria. Value 0 indicates the remaining 328 segments
+  that the Larkin Plan did not evaluate.
+  \item \texttt{recom\_code} with three values (1, 2, 3) encoding the
+  Larkin Plan's three operating recommendations for the studied
+  segments.
+\end{itemize}
+We intersect the rail segments with the 312 district polygons from the
+IPUMS time-invariant geography (described in Section~\ref{ssec:census}),
+compute per-district length in kilometres in EPSG:4326 using
+\texttt{sf::st\_length} with s2 geometry, and obtain \texttt{tot\_rails\_1960} and
+\texttt{tot\_rails\_1986} for each district. Total rail km falls from 42{,}780
+in 1960 to 33{,}303 in 1986, a 22\% reduction. Of the 9{,}477~km lost,
+5{,}563~km (59\%) were closed during the dictatorship and 3{,}914~km (41\%)
+were closed between 1960 and 1966. Figure~\ref{fig:networks}a shows the
+geography of the rail network and highlights the dictatorship closures
+in red. 30 of the 312 districts have zero rail km in all periods;
+these are concentrated in Patagonia and Tierra del Fuego.
+
+\paragraph{Roads.}
+The road network comes from a digitised cross-panel of
+Automóvil~Club~Argentino maps for 1954, 1970, and 1986. The resulting
+shapefile (\texttt{comparacion\_54\_70\_86.shp}) contains 1{,}741
+MULTILINESTRING segments classified into seven \texttt{type2}
+categories by their period-specific presence:
+\begin{itemize}\setlength\itemsep{0pt}
+  \item \texttt{type2}~$\in\{1,5\}$: present in 1954 and 1986 (type 5 is
+    absent from the 1970 map and treated as a cartographic error).
+  \item \texttt{type2}~$\in\{2,3\}$: added between 1954 and 1986
+    (type 2 appears in 1970, type 3 appears in 1986).
+  \item \texttt{type2}~$\in\{4,6,7\}$: present only in a subset of
+    periods and absent in 1986; these segments are excluded from
+    period-total road km.
+\end{itemize}
+The paved-and-gravel road network (the union of types 1, 2, 3, and 5)
+grows from 27{,}513~km in 1954 to 79{,}820~km in 1986, a 190\% increase.
+Figure~\ref{fig:networks}b shows the road network and highlights the
+segments added between 1954 and 1986 in red.
+
+Three districts, all in Patagonia, lack any segment in the road
+shapefile and contribute missing values in the district-level road
+variables. 11 districts lost rail without gaining roads and 141 districts
+both lost rail and gained roads. The cross-district correlation between
+$\Delta$(rail km) and $\Delta$(road km) is $-0.25$; the two network shocks
+are spatially partially decoupled, which supports using them as
+separately-instrumented treatments.
+
+\paragraph{Hypothetical road networks.}
+We also construct four hypothetical road networks that connect Argentina's
+largest cities under stylised routing rules. Starting from a node set of
+54~cities (all provincial capitals plus all cities with population
+$\geq 15{,}000$ in 1960), we compute:
+\begin{itemize}\setlength\itemsep{0pt}
+  \item \texttt{euc}: all $\binom{54}{2}=1{,}431$ straight-line
+    (Euclidean) segments between city pairs.
+  \item \texttt{euc\_mst}: the Euclidean minimum spanning tree
+    (53 edges).
+  \item \texttt{lcp}: all bilateral least-cost paths between city
+    pairs, routed on a Faber-2014 construction-cost raster that
+    penalises slope, wetland, urban areas, and water crossings.
+  \item \texttt{lcp\_mst}: the minimum spanning tree of the LCP
+    weights.
+\end{itemize}
+These networks serve as instruments for the actual road network in
+Section~\ref{sec:identification}.
+
+\subsection{Census data and outcomes}
+\label{ssec:census}
+
+\paragraph{Geographic unit.}
+We work at the district level using IPUMS International's
+time-invariant \texttt{geolev2} geography for Argentina, covering 312
+mainland districts including Capital Federal and the two Tierra~del~Fuego
+jurisdictions. The same polygons are used across the five IPUMS sample
+years (1970, 1980, 1991, 2001, 2010), the 1960 and 1947 census
+publications, and the agricultural and industrial censuses. The
+\texttt{geolev2} identifier is stored as a character string throughout
+the analysis to avoid type-coercion bugs on leading zeros.
+
+\paragraph{Population.}
+Population in 1960 comes from the digitised \emph{IV Censo Nacional de
+Población 1960} tables, reconciled to the IPUMS district geography
+through a crosswalk that handles pre-1960 splits and name changes. The
+mean 1960 district population is 43{,}856 with a national total of
+13.6~million. Population in 1991 comes from the IPUMS microdata
+aggregated to \texttt{geolev2}; the mean 1991 district population is
+114{,}723 with a national total of 35.8~million. Log population change
+$\Delta\log(\mathrm{pop}_{91/60})$ has mean $+1.02$ and standard deviation
+$0.53$.
+
+\paragraph{Urban population.}
+Urban population shares at the district level come from the 1960
+census (classification per INDEC) and from the IPUMS 1991 microdata.
+Urban population is not coded consistently in the 1970 and 2010 IPUMS
+microdata for Argentina; those years are recorded as missing in the
+panel and are not used for urban-outcome regressions. 1960 and 1991 give
+us the post-reform window with consistent urban/rural classification.
+
+\paragraph{Pre-reform placebo.}
+We supplement the baseline with the 1947 national census, which covers
+240 of the 312 districts. A log population change
+$\Delta\log(\mathrm{pop}_{60/47})$ for this subsample serves as a placebo
+outcome: it measures population growth before any of the 1960--1986
+network changes, and should be uncorrelated with the instruments if the
+instruments isolate post-1960 network-induced variation.
+
+\paragraph{Industrial and agricultural outcomes.}
+Four additional data components carry sectoral outcomes. The 1954 and
+1985 industrial censuses (\emph{Censo Industrial} and \emph{Censo
+Económico}) provide district-level establishment counts, salaries, and
+production values. Only \texttt{nestab} (establishments), \texttt{massal}
+(wages), and \texttt{valprod} (production value) are present in both
+census years; \texttt{nemp} (workers, 1954) and \texttt{npers} (persons,
+1985) are defined differently and are not directly comparable. The 1960
+and 1988 agricultural censuses provide \texttt{nexp} (farm operations)
+and \texttt{areatot\_ha} (total agricultural area). All monetary
+variables are nominal pesos of their census year; real comparisons
+across years require a deflator that we defer to robustness.
+
+\paragraph{Geographic controls.}
+District-level controls come from external sources. Area in~km$^2$ is
+computed from the IPUMS polygon. Mean elevation comes from GTOPO30
+\citep{usgs1996gtopo30}. Terrain ruggedness uses the Nunn--Puga TRI
+raster \citep{nunn2012ruggedness} derived from GTOPO30. Wheat potential
+yield comes from FAO--GAEZ~3.0 \citep{faoiiasa2012gaez}. Caloric
+potential (pre-~and post-1500) comes from \citet{galorozak2016}.
+Distance to Buenos Aires is the great-circle distance from the centroid
+of the Gran~Buenos~Aires polygon in the IGN settlements shapefile.
+All continuous controls are standardised (zero mean, unit variance) for
+use in the regressions.
+
+\subsection{Market access}
+\label{ssec:ma}
+
+\paragraph{Definition.}
+Following \citet{donaldsonhornbeck2016},
+we define district $i$'s market access in period $t$ for sector
+$s$ under elasticity $\theta$ as:
+\begin{equation}
+  \mathrm{MA}_{i,t,s,\theta} = \sum_{j \neq i}
+     \frac{\mathrm{pop}_{j,1960}}{(\tau_{ij,t,s})^{\theta}},
+  \label{eq:ma}
+\end{equation}
+where $\tau_{ij,t,s}$ is the origin--destination transport cost between
+the centroids of districts~$i$ and~$j$ under network configuration~$t$
+and sector~$s$. Population weights are held fixed at their 1960 values
+across all $t$ so that variation in~$\mathrm{MA}_{i,t,s,\theta}$ comes
+entirely from variation in transport costs rather than from endogenous
+population responses to the network changes.
+
+\paragraph{Cost surface.}
+Transport costs $\tau_{ij,t,s}$ are the least-cost-path distances on
+a $2{,}399 \times 3{,}090$ raster covering mainland Argentina in the
+ESRI:54034 equal-area projection (approximately 1.2~km per cell). The
+per-pixel cost $c_i(t,s)$ is:
+\begin{equation*}
+c_i(t, s) =
+\begin{cases}
+\text{cost}_{\mathrm{nav}}(s)                      & \text{if pixel $i$ is navigable water,} \\
+\text{cost}_{\mathrm{mininfra}}(s)                 & \text{if pixel $i$ has both rail and road,} \\
+\text{cost}_{\mathrm{rail}}(s)                     & \text{if pixel $i$ has rail only,} \\
+\text{cost}_{\mathrm{road}}(s)                     & \text{if pixel $i$ has road only,} \\
+\text{cost}_{\mathrm{land}} \cdot \mathrm{HMI}_i   & \text{if pixel $i$ is off-network land in Argentina,} \\
+\text{NA}                                          & \text{otherwise (hard barrier).} \\
+\end{cases}
+\end{equation*}
+Network layers (rail, road, and navigation) are rasterised from the
+respective shapefiles after a 1~km buffer to guarantee at least one
+full raster cell per linear segment. The Strait of Magellan is buffered
+by 5~km so that at least one raster cell per shore becomes navigable,
+which lets Dijkstra cross the strait and keeps Tierra~del~Fuego
+connected to the mainland. Off-network pixels outside Argentina are
+set to NA, which acts as a hard barrier for the least-cost path
+algorithm except where a navigable-water pixel overrides the country
+mask (e.g.\ the Paraná river border).
+
+\paragraph{Cost parameters.}
+Sector-specific cost parameters come from \citet{baumgartnerpalazzo1969}
+Table~II. Three sectors $s \in \{0, 1, 2\}$ correspond to three cargo
+density scenarios (medium, high, low); the mapping to units and values
+is reported in Table~\ref{tab:cost_params} [PLACEHOLDER TABLE].
+In particular, rail is cheaper than road at high cargo density
+(\texttt{cost\_rail}$_1 = 0.465 < \text{cost\_road}_1 = 1.000$) but more
+expensive at low density
+(\texttt{cost\_rail}$_2 = 13.490 > \text{cost\_road}_2 = 8.266$), which
+is the scale-economies channel that motivates sector-specific analysis.
+The off-network cost $\text{cost}_{\mathrm{land}}$ is $17.9 \times
+\text{cost\_road}_2 / \overline{\mathrm{HMI}}$, where $\overline{\mathrm{HMI}}
+= 0.2018$ is the national mean of the Özak~\citeyearpar{ozak2018} Human
+Mobility Index, giving $\text{cost}_{\mathrm{land}} \approx 733.2$. The
+per-pixel off-network cost scales with the local HMI value and is one
+to two orders of magnitude above on-network cost.
+
+\paragraph{Least-cost path and elasticity.}
+We compute $\tau_{ij,t,s}$ by running Dijkstra's algorithm on an
+eight-connected grid transition object (\texttt{gdistance::costDistance})
+between the 312 IPUMS centroid points. $\tau_{ii,t,s}=0$ by construction
+and $\tau$ is symmetric. Dijkstra is run independently for each
+(period, sector) combination; a single end-to-end run of the four
+main networks (actual~1960, actual~1986, \texttt{stu} instrument,
+\texttt{lcp\_mst} instrument) at three sectors takes approximately
+45~minutes on a laptop with four cores.
+
+The elasticity $\theta$ controls how sharply distant destinations are
+discounted in the MA sum. We follow the applied-trade literature
+(\citealt{donaldsonhornbeck2016}; \citealt{eatonkortum2002}) and report
+two values, $\theta_{\mathrm{low}} = 4.55$ and $\theta_{\mathrm{high}} =
+8.11$. Main results use $\theta_{\mathrm{low}}$; $\theta_{\mathrm{high}}$
+appears in the sensitivity tables. [PLACEHOLDER: confirm citations and
+whether to add a literature-review paragraph here per the
+\texttt{Plan/tasks.md} pending-decision item.]
+
+\paragraph{Change in log MA.}
+The main treatment variable is
+$\Delta\log\mathrm{MA}_i \equiv \log\mathrm{MA}_{i,1986,s=0,\theta_{\mathrm{low}}}
+  - \log\mathrm{MA}_{i,1960,s=0,\theta_{\mathrm{low}}}$.
+Across the 312~districts,
+$\Delta\log\mathrm{MA}_i$ has mean $+1.56$, standard deviation $2.48$,
+minimum $-7.18$ and maximum $+9.58$; 91\% of districts see a positive
+change. Figure~\ref{fig:ma_choropleth} maps $\Delta\log\mathrm{MA}_i$
+across districts.
+
+\paragraph{Counterfactual decomposition.}
+We additionally construct two counterfactual cost surfaces that freeze
+one network mode at its baseline while letting the other change:
+\begin{itemize}\setlength\itemsep{0pt}
+  \item \emph{only-rail}: 1986 rails combined with 1954 roads.
+  $\Delta\log\mathrm{MA}^{\text{only-rail}}_i = \log\mathrm{MA}(\text{only-rail})_i
+    - \log\mathrm{MA}_{i,1960}$.
+  \item \emph{only-road}: 1960 rails combined with 1986 roads.
+  $\Delta\log\mathrm{MA}^{\text{only-road}}_i$ defined analogously.
+\end{itemize}
+At sector~0 and $\theta_{\mathrm{low}}$, $\Delta\log\mathrm{MA}^{\text{only-rail}}$
+has mean $-0.40$ (rail contraction is a small market-access loss) and
+$\Delta\log\mathrm{MA}^{\text{only-road}}$ has mean $+1.75$ (road
+expansion is a large gain). The sum of the two isolated components
+($+1.35$) is slightly below the total
+$\Delta\log\mathrm{MA} = +1.56$, reflecting a positive complementarity
+between the two network shocks. Figure~\ref{fig:ma_counterfactual}
+compares the three maps side by side.
+
+\paragraph{Limitations.}
+The cost-surface construction imposes three modelling choices that the
+Section~\ref{sec:identification} discussion of identification returns to.
+First, mode switches are free: Dijkstra can step from a rail pixel to a
+road pixel at any grid boundary, whereas in reality such switches
+occur at stations or terminals and incur transshipment costs. Second,
+the algorithm selects a single cheapest path, not a probability
+distribution over routes; in equilibrium firms use multiple parallel
+routes. Third, cost parameters are constant across space and time; we
+do not model congestion or regional cost heterogeneity. Each of these
+simplifications follows the approach in
+\citet{donaldsonhornbeck2016} and is common in the market-access
+literature.


### PR DESCRIPTION
Closes #40

Delivers three figures and the first draft of Section 3 (Data) of the paper.

## Figures

### Figure 2 — Δlog MA choropleth (task C11)

District-level map of the main treatment variable, \`chg_logMA_86_60_s0_elow\`.

- Divergent colour scale centered at 0 (colorblind-safe RdBu).
- 7-bin classification: shows the distribution without washing out small-change districts.
- 91% of districts have positive Δ log MA; mean +1.56, SD 2.48.
- Output: \`results/figures/figure_2_ma_change_choropleth.{pdf,png}\`.

### Figure 4 — Infrastructure vs MA scatter (task C12b)

Two-panel scatter showing what drives MA variation.

- **Panel A (Roads)**: Δ paved+gravel road km vs Δ log MA. N=309, **r = +0.28**.
- **Panel B (Rails)**: Δ rail km vs Δ log MA. N=312, **r = +0.14**.
- OLS fit line and coefficients on each panel.
- Positive correlations in both: rail-losing districts see smaller MA gains; road-gaining districts see larger MA gains.
- Output: \`results/figures/figure_4_infra_vs_ma_scatter.{pdf,png}\`.

### Figure C13 — Counterfactual MA trio (task C13, bonus)

Three-panel choropleth using the Phase 3 counterfactual MAs.

- Panel A: actual total Δ log MA (mean +1.56).
- Panel B: only-rail counterfactual (mean −0.40 — rail contraction effect).
- Panel C: only-road counterfactual (mean +1.75 — road expansion effect).
- Shared colour scale across panels for visual comparability.
- Output: \`results/figures/figure_c13_ma_counterfactual_trio.{pdf,png}\`.

## Section 3 (Data)

\`paper/section_3_data.tex\` — ~2k words, first draft.

Three subsections:

### 3.1 Transport networks

- Railways: 565 MULTILINESTRING segments from \`lp_1979.shp\`; \`status1979\` and \`studied_co\` fields. Total rail km 42,780 (1960) → 33,303 (1986), −22%. 59% of loss during dictatorship, 41% pre-dictatorship.
- Roads: 1,741 segments from \`comparacion_54_70_86.shp\`; type2 taxonomy. Paved+gravel 27,513 → 79,820 km (+190%).
- Hypothetical networks: four variants (EUC, LCP, with and without MST).

### 3.2 Census data and outcomes

- 312-district IPUMS time-invariant geography, \`geolev2\` as character.
- Population: 1960 → 1991 main window. Mean 1960 pop 43,856; total 13.6M → 35.8M.
- Placebo: 1947 pre-reform subsample (240 districts).
- Industrial + agricultural censuses: 1954/1985 and 1960/1988.
- Geographic controls: elevation, ruggedness, wheat, caloric potential, distance to BA.

### 3.3 Market access construction

- MA formula (Donaldson & Hornbeck 2016 convention), 1960 population weights fixed.
- Cost surface: 2,399×3,090 at ESRI:54034, six-case formula (nav, rail+road, rail, road, off-network, NA).
- Cost parameters: Baumgartner & Palazzo 1969, three sectors. Off-network = 17.9 × cost_road[manuf] / avg HMI × HMI.
- Dijkstra on 8-connected grid via gdistance. Symmetric, tau(i,i)=0.
- Two elasticities reported (4.55 low, 8.11 high).
- Main Δ log MA summary: mean +1.56, SD 2.48, 91% positive.
- Counterfactual decomposition: rail-only mean −0.40, road-only mean +1.75. Positive complementarity (sum < total).
- Limitations paragraph: no transshipment, single-path, constant cost params.

Two PLACEHOLDER markers for:
- Cost-parameter table (Section 3.3).
- θ justification literature review (pending per \`Plan/tasks.md\`).

All numerical claims trace to code in \`code/base/\`, \`code/pipeline/\`, or the panel manifest. Inline numbers for this first draft; AutoFill macros will replace them once \`results/scalars.tex\` is wired up.

## Convention setup

Creates \`code/analysis/\` for plot scripts consuming the panel (as distinct from \`code/base/networks/\` which plots raw network shapefiles) and \`paper/\` for LaTeX source.

## Out of scope

- Figure 3 (rail-vs-road correlation) was already done in PR #28.
- Table of cost parameters (PLACEHOLDER in Section 3.3).
- Writing of Sections 4 (identification), 5 (results), etc. — separate tasks.