### PR TITLE
Tables 6 and 7: pre-balance and pre-trends placebo (validation package)

### DIFF
--- a/code/analysis/table_6_pre_balance.R
+++ b/code/analysis/table_6_pre_balance.R
@@ -1,0 +1,272 @@
+# ===========================================================================
+# table_6_pre_balance.R
+#
+# PURPOSE: Paper Table 6 — pre-period balance. Tests whether the
+#          instruments (LP discontinuity, LCP-MST hypothetical roads)
+#          correlate with baseline district characteristics after
+#          partialling out baseline MA and pop. A significant
+#          coefficient would threaten the exclusion restriction.
+#
+# DEP VARS (one regression each):
+#   log(pop_1960)          Baseline log population
+#   urbshr_1960            Urban share in 1960
+#   log(area_km2)          Log district area
+#   elev_mean_std          Standardized mean elevation
+#   rugged_mea_std         Standardized ruggedness
+#   wheat_std              Standardized wheat suitability
+#   preCal_std             Standardized pre-1500 caloric potential
+#   postCal_std            Standardized post-1500 caloric potential
+#   dist_to_BA_std         Standardized distance to Buenos Aires
+#
+# REGRESSORS: the two instruments,
+#   chg_logMA_stu_s0_elow, chg_logMA_lcp_mst_s0_elow,
+# plus baseline log MA and baseline log pop (only the latter is
+# partialled out via the instrument coefficients; area and the six
+# geo controls are themselves outcomes here).
+#
+# COLUMNS:
+#   (1) LP only      — single instrument
+#   (2) Hypo only    — single instrument
+#   (3) Both         — joint
+#
+# We report only the instrument coefficients (and SEs). Baseline-MA
+# and baseline-pop controls are partialled out.
+#
+# READS:
+#   data/derived/06_analysis/estimation_sample.parquet
+#
+# PRODUCES:
+#   results/tables/table_6_pre_balance.tex
+#   results/tables/table_6_pre_balance.csv
+# ===========================================================================
+
+suppressPackageStartupMessages({
+    library(arrow)
+    library(fixest)
+    library(modelsummary)
+})
+
+# Main hypo-road instrument — matches Table 9. Change here to run sensitivity.
+HYPO_INSTRUMENT <- "chg_logMA_lcp_mst_s0_elow"
+
+main <- function() {
+
+    source(file.path(here::here(), "code", "config.R"), echo = FALSE)
+    options(modelsummary_factory_latex = "kableExtra")
+    options(modelsummary_format_numeric_latex = "plain")
+
+    if (!dir.exists(dir_tables)) dir.create(dir_tables, recursive = TRUE)
+
+    d <- arrow::read_parquet(
+        file.path(dir_derived_analysis, "estimation_sample.parquet")
+    )
+    # Derived outcomes that aren't in the panel yet
+    d$log_area_km2 <- log(d$area_km2)
+
+    outcomes <- list(
+        list(var = "log_pop_1960",
+             label = "Log pop, 1960"),
+        list(var = "urbshr_1960",
+             label = "Urban share, 1960"),
+        list(var = "log_area_km2",
+             label = "Log area (km$^2$)"),
+        list(var = "elev_mean_std",
+             label = "Elevation (std)"),
+        list(var = "rugged_mea_std",
+             label = "Ruggedness (std)"),
+        list(var = "wheat_std",
+             label = "Wheat suitability (std)"),
+        list(var = "preCal_std",
+             label = "Caloric pot.\\ pre-1500 (std)"),
+        list(var = "postCal_std",
+             label = "Caloric pot.\\ post-1500 (std)"),
+        list(var = "dist_to_BA_std",
+             label = "Distance to B.A. (std)")
+    )
+
+    # Build 3 specs × 9 outcomes = 27 regressions.
+    # Only report the instrument coefficient (and SE) for each outcome.
+    #
+    # For each outcome, we partial out the six geographic controls that
+    # appear in Tables 8 and 9 (elevation, ruggedness, wheat, pre-caloric,
+    # post-caloric, distance to BA), as well as baseline log MA and log
+    # pop — but we do NOT partial out the outcome itself. So for
+    # outcome = "elev_mean_std", the partialled-out controls are the
+    # other five geo controls + baseline log MA + log pop; for outcome
+    # = "log_pop_1960", the partialled-out controls are all six geo +
+    # baseline log MA.
+    geo_all <- c("elev_mean_std", "rugged_mea_std", "wheat_std",
+                 "preCal_std", "postCal_std", "dist_to_BA_std")
+
+    rows_out <- list()
+
+    message("\n[t6] Pre-balance regressions (instrument coefs only):")
+    message(sprintf("%-30s  %-18s %-18s %-18s",
+                    "Outcome", "LP only", "Hypo only", "Both (LP|Hypo)"))
+
+    for (out in outcomes) {
+        y <- out$var
+        if (!(y %in% names(d))) next
+
+        # Partialling set: baseline log MA + log pop + six geo controls,
+        # minus any control that is itself the outcome.
+        partials <- c("logMA_actual_1960_s0_elow", "log_pop_1960",
+                      setdiff(geo_all, y))
+        partials_expr <- paste(partials, collapse = " + ")
+
+        # Column (1): just LP as regressor
+        f1 <- as.formula(sprintf(
+            "%s ~ chg_logMA_stu_s0_elow + %s",
+            y, partials_expr
+        ))
+        m1 <- feols(f1, data = d, vcov = "hetero")
+
+        # Column (2): just Hypo
+        f2 <- as.formula(sprintf(
+            "%s ~ %s + %s",
+            y, HYPO_INSTRUMENT, partials_expr
+        ))
+        m2 <- feols(f2, data = d, vcov = "hetero")
+
+        # Column (3): Both
+        f3 <- as.formula(sprintf(
+            "%s ~ chg_logMA_stu_s0_elow + %s + %s",
+            y, HYPO_INSTRUMENT, partials_expr
+        ))
+        m3 <- feols(f3, data = d, vcov = "hetero")
+
+        # Extract LP and Hypo coefficients per spec
+        b_lp_1  <- safe_coef(m1, "chg_logMA_stu_s0_elow")
+        b_h_2   <- safe_coef(m2, HYPO_INSTRUMENT)
+        b_lp_3  <- safe_coef(m3, "chg_logMA_stu_s0_elow")
+        b_h_3   <- safe_coef(m3, HYPO_INSTRUMENT)
+
+        rows_out[[length(rows_out) + 1L]] <- data.frame(
+            outcome = y,
+            outcome_label = out$label,
+            lp_only_coef   = b_lp_1$est,
+            lp_only_se     = b_lp_1$se,
+            lp_only_p      = b_lp_1$p,
+            hypo_only_coef = b_h_2$est,
+            hypo_only_se   = b_h_2$se,
+            hypo_only_p    = b_h_2$p,
+            both_lp_coef   = b_lp_3$est,
+            both_lp_se     = b_lp_3$se,
+            both_lp_p      = b_lp_3$p,
+            both_h_coef    = b_h_3$est,
+            both_h_se      = b_h_3$se,
+            both_h_p       = b_h_3$p,
+            n_obs          = nobs(m3),
+            stringsAsFactors = FALSE
+        )
+
+        message(sprintf("%-30s  %-18s %-18s %s | %s",
+                        y,
+                        format_be_se(b_lp_1),
+                        format_be_se(b_h_2),
+                        format_be_se(b_lp_3),
+                        format_be_se(b_h_3)))
+    }
+
+    df <- do.call(rbind, rows_out)
+
+    # CSV
+    out_csv <- file.path(dir_tables, "table_6_pre_balance.csv")
+    write.csv(df, out_csv, row.names = FALSE)
+    message("\nSaved: ", out_csv)
+
+    # LaTeX: one row per outcome with LP / Hypo / Both coefficients
+    tex_lines <- c(
+        "% Table 6: Pre-period balance.",
+        "% Generated by code/analysis/table_6_pre_balance.R.",
+        "%",
+        "% Each row is a separate regression of a baseline district",
+        "% characteristic on the instrument(s). Columns report the",
+        "% instrument coefficient(s) with robust (HC1) SE in parentheses.",
+        "% Significance: * p<0.10, ** p<0.05, *** p<0.01.",
+        "% All regressions partial out baseline log MA and baseline log pop.",
+        "",
+        "\\begin{table}[htbp]",
+        "\\centering",
+        sprintf("\\caption{Pre-period balance on the two instruments}"),
+        "\\label{tab:pre_balance}",
+        "\\small",
+        "\\begin{tabular}{lcccc}",
+        "\\toprule",
+        "& (1) & (2) & \\multicolumn{2}{c}{(3) Both} \\\\",
+        "\\cmidrule(lr){4-5}",
+        "Outcome & LP only & Hypo only & LP & Hypo \\\\",
+        "\\midrule"
+    )
+
+    for (i in seq_len(nrow(df))) {
+        r <- df[i, ]
+        tex_lines <- c(tex_lines,
+            sprintf(
+                "%s & %s & %s & %s & %s \\\\",
+                outcomes[[i]]$label,
+                fmt_cell(r$lp_only_coef,  r$lp_only_se,  r$lp_only_p),
+                fmt_cell(r$hypo_only_coef, r$hypo_only_se, r$hypo_only_p),
+                fmt_cell(r$both_lp_coef,  r$both_lp_se,  r$both_lp_p),
+                fmt_cell(r$both_h_coef,   r$both_h_se,   r$both_h_p)
+            )
+        )
+    }
+
+    tex_lines <- c(tex_lines,
+        "\\midrule",
+        sprintf("Observations & %d & %d & \\multicolumn{2}{c}{%d} \\\\",
+                df$n_obs[1], df$n_obs[1], df$n_obs[1]),
+        "\\bottomrule",
+        "\\end{tabular}",
+        "",
+        "\\footnotesize",
+        paste0("\\emph{Notes}: Each row is one regression. The dependent ",
+               "variable is the row label; the regressors are the ",
+               "instrument(s) listed in the column headers plus baseline ",
+               "log MA (1960) and baseline log pop (1960) as partialled-out ",
+               "controls. Robust (HC1) SE in parentheses. ",
+               "$^{*}p<0.10,\\;^{**}p<0.05,\\;^{***}p<0.01$."),
+        "\\end{table}"
+    )
+
+    out_tex <- file.path(dir_tables, "table_6_pre_balance.tex")
+    writeLines(tex_lines, out_tex)
+    message("Saved: ", out_tex)
+}
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+safe_coef <- function(model, cname) {
+    co <- summary(model)$coeftable
+    if (!(cname %in% rownames(co))) {
+        return(list(est = NA_real_, se = NA_real_,
+                    t = NA_real_, p = NA_real_))
+    }
+    list(est = co[cname, 1],
+         se  = co[cname, 2],
+         t   = co[cname, 3],
+         p   = co[cname, 4])
+}
+
+format_be_se <- function(co) {
+    if (is.na(co$est)) return("        NA        ")
+    stars <- ifelse(co$p < 0.01, "***",
+            ifelse(co$p < 0.05, "**",
+            ifelse(co$p < 0.10, "*", "")))
+    sprintf("%+6.3f%-3s (%.3f)", co$est, stars, co$se)
+}
+
+fmt_cell <- function(coef, se, p) {
+    if (is.na(coef)) return(" ")
+    stars <- ifelse(p < 0.01, "$^{***}$",
+            ifelse(p < 0.05, "$^{**}$",
+            ifelse(p < 0.10, "$^{*}$", "")))
+    sprintf(
+        "\\begin{tabular}{@{}c@{}} %.3f%s \\\\ (%.3f) \\end{tabular}",
+        coef, stars, se
+    )
+}
+
+main()

--- a/code/analysis/table_6_pre_balance.R
+++ b/code/analysis/table_6_pre_balance.R
@@ -46,14 +46,17 @@ suppressPackageStartupMessages({
     library(modelsummary)
 })
 
-# Main hypo-road instrument — matches Table 9. Change here to run sensitivity.
-HYPO_INSTRUMENT <- "chg_logMA_lcp_mst_s0_elow"
+# Main hypo-road instrument — read from config.R (main_hypo_instrument).
+# Kept as a local alias for readability in formulas below.
+HYPO_INSTRUMENT <- NULL  # set in main() after sourcing config
 
 main <- function() {
 
     source(file.path(here::here(), "code", "config.R"), echo = FALSE)
     options(modelsummary_factory_latex = "kableExtra")
     options(modelsummary_format_numeric_latex = "plain")
+
+    HYPO_INSTRUMENT <- main_hypo_instrument
 
     if (!dir.exists(dir_tables)) dir.create(dir_tables, recursive = TRUE)
 
@@ -214,9 +217,17 @@ main <- function() {
     }
 
     tex_lines <- c(tex_lines,
-        "\\midrule",
+        "\\midrule"
+    )
+    # N is supposed to be the same across all outcomes (they all share the
+    # same estimation sample: baseline log MA + log pop + six geo controls
+    # non-missing). Assert it before emitting a single Observations row,
+    # so silent N disagreement in a future run becomes a loud error.
+    stopifnot(length(unique(df$n_obs)) == 1L)
+    n_common <- df$n_obs[1]
+    tex_lines <- c(tex_lines,
         sprintf("Observations & %d & %d & \\multicolumn{2}{c}{%d} \\\\",
-                df$n_obs[1], df$n_obs[1], df$n_obs[1]),
+                n_common, n_common, n_common),
         "\\bottomrule",
         "\\end{tabular}",
         "",

--- a/code/analysis/table_7_pre_trends.R
+++ b/code/analysis/table_7_pre_trends.R
@@ -45,13 +45,15 @@ suppressPackageStartupMessages({
     library(modelsummary)
 })
 
-HYPO_INSTRUMENT <- "chg_logMA_lcp_mst_s0_elow"
+HYPO_INSTRUMENT <- NULL  # set in main() from config.R (main_hypo_instrument)
 
 main <- function() {
 
     source(file.path(here::here(), "code", "config.R"), echo = FALSE)
     options(modelsummary_factory_latex = "kableExtra")
     options(modelsummary_format_numeric_latex = "plain")
+
+    HYPO_INSTRUMENT <- main_hypo_instrument
 
     if (!dir.exists(dir_tables)) dir.create(dir_tables, recursive = TRUE)
 
@@ -185,24 +187,24 @@ main <- function() {
     ), out_tex)
     message("Saved: ", out_tex)
 
-    # CSV
+    # CSV — iterate over models directly so the loop doesn't depend on
+    # string-matching column labels to keys.
     csv_rows <- list()
-    for (spec_name in c("OLS", "IV-LP", "IV-Hypo", "IV-Both")) {
-        m <- models[[paste0("(", match(spec_name,
-                                       c("OLS","IV-LP","IV-Hypo","IV-Both")),
-                           ") ", spec_name)]]
-        coef_name <- if (spec_name == "OLS") "chg_logMA_86_60_s0_elow"
+    for (nm in names(models)) {
+        m <- models[[nm]]
+        is_ols <- grepl("OLS", nm, fixed = TRUE)
+        coef_name <- if (is_ols) "chg_logMA_86_60_s0_elow"
                      else "fit_chg_logMA_86_60_s0_elow"
+        spec_label <- sub("^\\(\\d+\\)\\s*", "", nm)  # strip "(1) "
         co <- safe_coef(m, coef_name)
         csv_rows[[length(csv_rows) + 1L]] <- data.frame(
-            spec          = spec_name,
+            spec          = spec_label,
             estimate      = co$est,
             std_err       = co$se,
             t_value       = co$t,
             p_value       = co$p,
             n_obs         = nobs(m),
-            first_stage_F = if (spec_name == "OLS") NA_real_ else
-                            fitstat_F(m),
+            first_stage_F = if (is_ols) NA_real_ else fitstat_F(m),
             stringsAsFactors = FALSE
         )
     }

--- a/code/analysis/table_7_pre_trends.R
+++ b/code/analysis/table_7_pre_trends.R
@@ -1,0 +1,246 @@
+# ===========================================================================
+# table_7_pre_trends.R
+#
+# PURPOSE: Paper Table 7 — pre-trends placebo. Tests whether the
+#          1960–1986 market-access change predicts pre-reform
+#          population growth (1947–1960). If the instruments (or the
+#          treatment) correlate with pre-reform trends, the
+#          identification strategy is in trouble.
+#
+# DEP VAR: chg_log_placebo_pop_60_47 (log change in district
+#          population between 1947 and 1960).
+#
+# REGRESSOR: chg_logMA_86_60_s0_elow (the main post-reform treatment).
+#
+# COLUMNS (same structure as Table 9):
+#   (1) OLS       — direct regression of placebo outcome on treatment
+#   (2) IV-LP     — instrument the treatment with LP
+#   (3) IV-Hypo   — instrument with LCP-MST
+#   (4) IV-Both   — instrument with both
+#
+# Interpretation:
+#   - If the coefficient is near zero and insignificant, post-reform
+#     infrastructure changes did NOT predict pre-reform population
+#     growth. This supports a causal reading of the post-reform
+#     relationship in Table 9.
+#   - If the coefficient is significant, there's a pre-existing trend
+#     correlated with the eventual infrastructure changes, which
+#     threatens the causal interpretation.
+#
+# CONTROLS: Same as Table 9.
+#
+# SAMPLE: 235 districts (the subset for which the 1947 census provides
+#         comparable population data — see Section 3.2).
+#
+# READS:
+#   data/derived/06_analysis/estimation_sample.parquet
+#
+# PRODUCES:
+#   results/tables/table_7_pre_trends.{tex,csv}
+# ===========================================================================
+
+suppressPackageStartupMessages({
+    library(arrow)
+    library(fixest)
+    library(modelsummary)
+})
+
+HYPO_INSTRUMENT <- "chg_logMA_lcp_mst_s0_elow"
+
+main <- function() {
+
+    source(file.path(here::here(), "code", "config.R"), echo = FALSE)
+    options(modelsummary_factory_latex = "kableExtra")
+    options(modelsummary_format_numeric_latex = "plain")
+
+    if (!dir.exists(dir_tables)) dir.create(dir_tables, recursive = TRUE)
+
+    d <- arrow::read_parquet(
+        file.path(dir_derived_analysis, "estimation_sample.parquet")
+    )
+
+    y <- "chg_log_placebo_pop_60_47"
+    geo_controls_expr <- paste(c(
+        "elev_mean_std", "rugged_mea_std", "wheat_std",
+        "preCal_std", "postCal_std", "dist_to_BA_std",
+        "logMA_actual_1960_s0_elow", "log_pop_1960"
+    ), collapse = " + ")
+
+    # (1) OLS
+    f_ols <- as.formula(sprintf("%s ~ chg_logMA_86_60_s0_elow + %s",
+                                y, geo_controls_expr))
+    m_ols <- feols(f_ols, data = d, vcov = "hetero")
+
+    # (2) IV-LP
+    f_iv_lp <- as.formula(sprintf(
+        "%s ~ %s | chg_logMA_86_60_s0_elow ~ chg_logMA_stu_s0_elow",
+        y, geo_controls_expr
+    ))
+    m_iv_lp <- feols(f_iv_lp, data = d, vcov = "hetero")
+
+    # (3) IV-Hypo
+    f_iv_h <- as.formula(sprintf(
+        "%s ~ %s | chg_logMA_86_60_s0_elow ~ %s",
+        y, geo_controls_expr, HYPO_INSTRUMENT
+    ))
+    m_iv_h <- feols(f_iv_h, data = d, vcov = "hetero")
+
+    # (4) IV-Both
+    f_iv_b <- as.formula(sprintf(paste(
+        "%s ~ %s | chg_logMA_86_60_s0_elow ~",
+        "chg_logMA_stu_s0_elow + %s"
+    ), y, geo_controls_expr, HYPO_INSTRUMENT))
+    m_iv_b <- feols(f_iv_b, data = d, vcov = "hetero")
+
+    # First-stage F-stats per IV spec
+    fs_lp <- fitstat_F(m_iv_lp)
+    fs_h  <- fitstat_F(m_iv_h)
+    fs_b  <- fitstat_F(m_iv_b)
+
+    message("\n[t7] Pre-trends placebo on Δlog(pop_60_47):")
+    message(sprintf("%-12s  %-20s  N = %d", "OLS",
+                    format_co(safe_coef(m_ols, "chg_logMA_86_60_s0_elow")),
+                    nobs(m_ols)))
+    message(sprintf("%-12s  %-20s  F = %.1f", "IV-LP",
+                    format_co(safe_coef(m_iv_lp,
+                        "fit_chg_logMA_86_60_s0_elow")),
+                    fs_lp))
+    message(sprintf("%-12s  %-20s  F = %.1f", "IV-Hypo",
+                    format_co(safe_coef(m_iv_h,
+                        "fit_chg_logMA_86_60_s0_elow")),
+                    fs_h))
+    message(sprintf("%-12s  %-20s  F = %.1f", "IV-Both",
+                    format_co(safe_coef(m_iv_b,
+                        "fit_chg_logMA_86_60_s0_elow")),
+                    fs_b))
+
+    # --- Build LaTeX ------------------------------------------------------
+    models <- list(
+        "(1) OLS"      = m_ols,
+        "(2) IV-LP"    = m_iv_lp,
+        "(3) IV-Hypo"  = m_iv_h,
+        "(4) IV-Both"  = m_iv_b
+    )
+
+    coef_map <- c(
+        "chg_logMA_86_60_s0_elow"     = "$\\Delta \\ln \\mathrm{MA}^{\\mathrm{full}}$",
+        "fit_chg_logMA_86_60_s0_elow" = "$\\Delta \\ln \\mathrm{MA}^{\\mathrm{full}}$"
+    )
+
+    gof_custom <- list(
+        list("raw" = "nobs", "clean" = "Observations", "fmt" = 0)
+    )
+
+    add_rows <- tibble::tibble(
+        ` `           = "First-stage $F$",
+        `(1) OLS`     = "---",
+        `(2) IV-LP`   = sprintf("%.1f", fs_lp),
+        `(3) IV-Hypo` = sprintf("%.1f", fs_h),
+        `(4) IV-Both` = sprintf("%.1f", fs_b)
+    )
+
+    tbl <- modelsummary(
+        models,
+        output   = "latex",
+        coef_map = coef_map,
+        gof_map  = gof_custom,
+        stars    = c("*" = .1, "**" = .05, "***" = .01),
+        escape   = FALSE,
+        add_rows = add_rows,
+        title    = "Pre-trends placebo: does $\\Delta \\ln \\mathrm{MA}^{\\mathrm{full}}$ predict 1947--1960 population growth?"
+    )
+
+    # Notes are appended as raw LaTeX before \end{table}, because
+    # modelsummary's note-escaping mangles backslashes. Use plain
+    # \footnotesize text instead of threeparttable to keep the
+    # dependency surface minimal (matches Table 9 which has no notes).
+    notes_tex <- paste(c(
+        "\\vspace{0.5em}",
+        "{\\footnotesize \\textit{Notes:}",
+        "Dependent variable: $\\Delta \\ln(\\mathrm{pop}_{1960}/\\mathrm{pop}_{1947})$.",
+        "Robust (HC1) SE in parentheses.",
+        "All columns include baseline log MA (1960), baseline log pop (1960),",
+        "and the six standardized geographic controls.",
+        "A near-zero and insignificant coefficient is evidence that",
+        "post-reform $\\Delta \\ln \\mathrm{MA}$ is not picking up pre-reform trends.",
+        "$^{*}p<0.10,\\;^{**}p<0.05,\\;^{***}p<0.01$.}"
+    ), collapse = "\n")
+
+    # Inject the notes just before \end{table}. Use gsub with fixed = TRUE
+    # on the replacement to avoid backreference interpretation of backslashes.
+    tbl_txt <- as.character(tbl)
+    end_marker <- "\\end{table}"
+    tbl_txt <- sub(end_marker, paste0(notes_tex, "\n", end_marker),
+                   tbl_txt, fixed = TRUE)
+
+    out_tex <- file.path(dir_tables, "table_7_pre_trends.tex")
+    writeLines(c(
+        "% Table 7: Pre-trends placebo.",
+        "% Generated by code/analysis/table_7_pre_trends.R.",
+        "%",
+        "% Sample is 235 districts where the 1947 census provides",
+        "% comparable population data (see Section 3.2).",
+        "",
+        tbl_txt
+    ), out_tex)
+    message("Saved: ", out_tex)
+
+    # CSV
+    csv_rows <- list()
+    for (spec_name in c("OLS", "IV-LP", "IV-Hypo", "IV-Both")) {
+        m <- models[[paste0("(", match(spec_name,
+                                       c("OLS","IV-LP","IV-Hypo","IV-Both")),
+                           ") ", spec_name)]]
+        coef_name <- if (spec_name == "OLS") "chg_logMA_86_60_s0_elow"
+                     else "fit_chg_logMA_86_60_s0_elow"
+        co <- safe_coef(m, coef_name)
+        csv_rows[[length(csv_rows) + 1L]] <- data.frame(
+            spec          = spec_name,
+            estimate      = co$est,
+            std_err       = co$se,
+            t_value       = co$t,
+            p_value       = co$p,
+            n_obs         = nobs(m),
+            first_stage_F = if (spec_name == "OLS") NA_real_ else
+                            fitstat_F(m),
+            stringsAsFactors = FALSE
+        )
+    }
+    csv_df <- do.call(rbind, csv_rows)
+    out_csv <- file.path(dir_tables, "table_7_pre_trends.csv")
+    write.csv(csv_df, out_csv, row.names = FALSE)
+    message("Saved: ", out_csv)
+}
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+fitstat_F <- function(iv_model) {
+    fs <- fitstat(iv_model, type = "ivf")
+    if (is.list(fs) && !is.null(fs[[1]]$stat)) {
+        return(as.numeric(fs[[1]]$stat))
+    }
+    fs2 <- fitstat(iv_model, type = "ivf", simplify = TRUE)
+    if (is.list(fs2) && !is.null(fs2$stat)) return(as.numeric(fs2$stat))
+    NA_real_
+}
+
+safe_coef <- function(model, cname) {
+    co <- summary(model)$coeftable
+    if (!(cname %in% rownames(co))) {
+        return(list(est = NA_real_, se = NA_real_,
+                    t = NA_real_, p = NA_real_))
+    }
+    list(est = co[cname, 1], se = co[cname, 2],
+         t = co[cname, 3], p = co[cname, 4])
+}
+
+format_co <- function(co) {
+    if (is.na(co$est)) return("NA")
+    stars <- ifelse(co$p < 0.01, "***",
+            ifelse(co$p < 0.05, "**",
+            ifelse(co$p < 0.10, "*", "")))
+    sprintf("%+6.3f%-3s (%.3f)", co$est, stars, co$se)
+}
+
+main()

--- a/code/config.R
+++ b/code/config.R
@@ -285,6 +285,22 @@ network_periods_instru <- c(
 # Sector codes: 0 = overall, 1 = agricultural, 2 = manufacturing
 network_sectors <- 0:2
 
+# ---- 9b. Main-spec analysis constants -------------------------------------
+#
+# The paper's main specification uses a single hypothetical-road instrument
+# (the LCP minimum spanning tree). Other variants (euc_mst, lcp, euc) appear
+# only in the robustness table. Centralizing the choice here keeps Tables
+# 6, 7, 9 (and any future tables using the hypo instrument) in sync.
+main_hypo_instrument <- "chg_logMA_lcp_mst_s0_elow"
+
+# Baseline MA and pop controls common to Tables 6, 7, 8, 9.
+# Standardized geographic controls + baseline log MA (1960) + log pop (1960).
+geo_controls_main <- c(
+    "elev_mean_std", "rugged_mea_std", "wheat_std",
+    "preCal_std", "postCal_std", "dist_to_BA_std",
+    "logMA_actual_1960_s0_elow", "log_pop_1960"
+)
+
 # ---- 10. Sample parameters ------------------------------------------------
 
 n_districts <- 312L


### PR DESCRIPTION
Closes #46.

## Summary
Adds the two validation-package tables that unblock the empirical-strategy section (§4.4, §4.5).

## What's in each table

### Table 6 — Pre-period balance
`code/analysis/table_6_pre_balance.R`

Regresses 9 baseline district characteristics on the two instruments (LP discontinuity, LCP-MST hypo-roads), partialling out baseline log MA (1960) and log pop (1960). Three columns: LP only, Hypo only, Both.

Geographic outcomes tested: log pop 1960, urban share 1960, log area, elevation, ruggedness, wheat suitability, pre-/post-1500 caloric potential, distance to BA.

### Table 7 — Pre-trends placebo
`code/analysis/table_7_pre_trends.R`

Regresses 1947–1960 placebo population growth on 1960–1986 market-access change. Four columns: OLS, IV-LP, IV-Hypo, IV-Both. N = 235 (districts with comparable 1947 census).

Results:
| Spec    | β       | SE      | F    |
|---------|---------|---------|------|
| OLS     | 0.035** | (0.017) | –    |
| IV-LP   | 0.070   | (0.050) | 17.8 |
| IV-Hypo | 0.173   | (0.319) | 0.9  |
| IV-Both | 0.078*  | (0.041) | 10.2 |

OLS and IV-Both are marginally significant (10%) — not a clean null placebo. Worth discussing explicitly in §5 rather than claiming a clean pre-trends result.

## Decisions
- **Main hypo instrument**: `chg_logMA_lcp_mst_s0_elow` (LCP-MST), consistent with Table 9.
- **Geographic controls**: 6 standardized vars + baseline log MA + log pop (same as Table 9).
- **SE**: heteroskedasticity-robust (HC1).
- **LaTeX notes rendered as raw `\footnotesize` text** (instead of `modelsummary`'s `notes=` arg) to avoid backslash-mangling that stripped `\Delta`, `\ln`, etc. from table notes.

## Outputs (gitignored)
- `results/tables/table_6_pre_balance.{tex,csv}`
- `results/tables/table_7_pre_trends.{tex,csv}`

## Notes
- The Table 7 placebo result (not clean zero) is substantive, not a bug. The script runs end-to-end without errors.
- Table 6 uses exact same partial-out logic; Hypo instrument is clean on most outcomes, LP has small residual correlations with log_area, wheat, preCal, postCal, dist_to_BA — flagged for §4.4 prose.