### PR TITLE
Refactor: extract shared IV helpers (closes #50)

### DIFF
--- a/code/analysis/_iv_helpers.R
+++ b/code/analysis/_iv_helpers.R
@@ -1,0 +1,94 @@
+# ===========================================================================
+# _iv_helpers.R
+#
+# PURPOSE: Shared helpers for the analysis tables that follow the
+#          four-column IV specification template:
+#            (1) OLS
+#            (2) IV-LP    (Larkin-Plan instrument)
+#            (3) IV-Hypo  (hypothetical-road instrument)
+#            (4) IV-Both  (both instruments)
+#
+# Used by: table_6_pre_balance.R, table_7_pre_trends.R,
+#          table_9_population.R, table_10_sectoral.R, and any future
+#          table that consumes the same 4-spec grid.
+#
+# Helpers exported:
+#   fit_iv_quad(y, data, endog, lp_instr, hypo_instr, ctrls_vec)
+#       Fits the 4 specifications for outcome y and returns a named
+#       list with keys "OLS", "IV-LP", "IV-H", "IV-B". Uses HC1
+#       (heteroskedasticity-robust) standard errors.
+#
+#   safe_coef(model, cname)
+#       Returns a named list (est, se, t, p) for the coefficient
+#       cname, or all NA if the coefficient is absent. For IV columns
+#       the coefficient on the instrumented regressor is prefixed
+#       "fit_" by fixest.
+#
+#   fitstat_F(iv_model)
+#       Returns the first-stage Wald F for the excluded instrument(s).
+#       Defensive across fixest versions (handles both the list-of-
+#       stats and the simplified return shapes).
+#
+# USAGE:
+#   source(file.path(dir_code, "analysis", "_iv_helpers.R"))
+#   models <- fit_iv_quad(y = "chg_log_pop_91_60",
+#                         data = d,
+#                         endog = "chg_logMA_86_60_s0_elow",
+#                         lp_instr = "chg_logMA_stu_s0_elow",
+#                         hypo_instr = main_hypo_instrument,
+#                         ctrls_vec = geo_controls_main)
+#   # models is list(OLS=, "IV-LP"=, "IV-H"=, "IV-B"=)
+# ===========================================================================
+
+suppressPackageStartupMessages({
+    library(fixest)
+})
+
+fit_iv_quad <- function(y, data, endog, lp_instr, hypo_instr, ctrls_vec) {
+    ctrls_expr <- paste(ctrls_vec, collapse = " + ")
+
+    f_ols <- as.formula(sprintf("%s ~ %s + %s", y, endog, ctrls_expr))
+    m_ols <- feols(f_ols, data = data, vcov = "hetero")
+
+    f_iv_lp <- as.formula(sprintf(
+        "%s ~ %s | %s ~ %s",
+        y, ctrls_expr, endog, lp_instr))
+    m_iv_lp <- feols(f_iv_lp, data = data, vcov = "hetero")
+
+    f_iv_h <- as.formula(sprintf(
+        "%s ~ %s | %s ~ %s",
+        y, ctrls_expr, endog, hypo_instr))
+    m_iv_h <- feols(f_iv_h, data = data, vcov = "hetero")
+
+    f_iv_b <- as.formula(sprintf(
+        "%s ~ %s | %s ~ %s + %s",
+        y, ctrls_expr, endog, lp_instr, hypo_instr))
+    m_iv_b <- feols(f_iv_b, data = data, vcov = "hetero")
+
+    list(
+        "OLS"   = m_ols,
+        "IV-LP" = m_iv_lp,
+        "IV-H"  = m_iv_h,
+        "IV-B"  = m_iv_b
+    )
+}
+
+safe_coef <- function(model, cname) {
+    co <- summary(model)$coeftable
+    if (!(cname %in% rownames(co))) {
+        return(list(est = NA_real_, se = NA_real_,
+                    t = NA_real_, p = NA_real_))
+    }
+    list(est = co[cname, 1], se = co[cname, 2],
+         t = co[cname, 3], p = co[cname, 4])
+}
+
+fitstat_F <- function(iv_model) {
+    fs <- fitstat(iv_model, type = "ivf")
+    if (is.list(fs) && !is.null(fs[[1]]$stat)) {
+        return(as.numeric(fs[[1]]$stat))
+    }
+    fs2 <- fitstat(iv_model, type = "ivf", simplify = TRUE)
+    if (is.list(fs2) && !is.null(fs2$stat)) return(as.numeric(fs2$stat))
+    NA_real_
+}

--- a/code/analysis/table_10_sectoral.R
+++ b/code/analysis/table_10_sectoral.R
@@ -61,6 +61,7 @@ suppressPackageStartupMessages({
 main <- function() {
 
     source(file.path(here::here(), "code", "config.R"), echo = FALSE)
+    source(file.path(dir_code, "analysis", "_iv_helpers.R"), echo = FALSE)
     options(modelsummary_factory_latex = "kableExtra")
     options(modelsummary_format_numeric_latex = "plain")
 
@@ -69,9 +70,6 @@ main <- function() {
     d <- arrow::read_parquet(
         file.path(dir_derived_analysis, "estimation_sample.parquet")
     )
-
-    HYPO <- main_hypo_instrument
-    ctrls <- paste(geo_controls_main, collapse = " + ")
 
     outcomes <- list(
         list(var = "chg_log_nestab_85_54",
@@ -101,34 +99,21 @@ main <- function() {
     f_stats    <- list()
     for (out in outcomes) {
         y <- out$var
-        f_ols <- as.formula(sprintf("%s ~ chg_logMA_86_60_s0_elow + %s",
-                                    y, ctrls))
-        m_ols <- feols(f_ols, data = d, vcov = "hetero")
-
-        f_iv_lp <- as.formula(sprintf(
-            "%s ~ %s | chg_logMA_86_60_s0_elow ~ chg_logMA_stu_s0_elow",
-            y, ctrls))
-        m_iv_lp <- feols(f_iv_lp, data = d, vcov = "hetero")
-
-        f_iv_h <- as.formula(sprintf(
-            "%s ~ %s | chg_logMA_86_60_s0_elow ~ %s",
-            y, ctrls, HYPO))
-        m_iv_h <- feols(f_iv_h, data = d, vcov = "hetero")
-
-        f_iv_b <- as.formula(sprintf(
-            "%s ~ %s | chg_logMA_86_60_s0_elow ~ chg_logMA_stu_s0_elow + %s",
-            y, ctrls, HYPO))
-        m_iv_b <- feols(f_iv_b, data = d, vcov = "hetero")
-
-        all_models[[paste(y, "OLS",   sep = "_")]] <- m_ols
-        all_models[[paste(y, "IV-LP", sep = "_")]] <- m_iv_lp
-        all_models[[paste(y, "IV-H",  sep = "_")]] <- m_iv_h
-        all_models[[paste(y, "IV-B",  sep = "_")]] <- m_iv_b
+        fits <- fit_iv_quad(
+            y = y, data = d,
+            endog = "chg_logMA_86_60_s0_elow",
+            lp_instr = "chg_logMA_stu_s0_elow",
+            hypo_instr = main_hypo_instrument,
+            ctrls_vec = geo_controls_main
+        )
+        for (spec in names(fits)) {
+            all_models[[paste(y, spec, sep = "_")]] <- fits[[spec]]
+        }
 
         f_stats[[y]] <- list(
-            lp   = fitstat_F(m_iv_lp),
-            hypo = fitstat_F(m_iv_h),
-            both = fitstat_F(m_iv_b)
+            lp   = fitstat_F(fits[["IV-LP"]]),
+            hypo = fitstat_F(fits[["IV-H"]]),
+            both = fitstat_F(fits[["IV-B"]])
         )
     }
 
@@ -244,28 +229,8 @@ main <- function() {
 }
 
 # ---------------------------------------------------------------------------
-# Helpers
+# Helpers (table-local: console-print formatter)
 # ---------------------------------------------------------------------------
-fitstat_F <- function(iv_model) {
-    fs <- fitstat(iv_model, type = "ivf")
-    if (is.list(fs) && !is.null(fs[[1]]$stat)) {
-        return(as.numeric(fs[[1]]$stat))
-    }
-    fs2 <- fitstat(iv_model, type = "ivf", simplify = TRUE)
-    if (is.list(fs2) && !is.null(fs2$stat)) return(as.numeric(fs2$stat))
-    NA_real_
-}
-
-safe_coef <- function(model, cname) {
-    co <- summary(model)$coeftable
-    if (!(cname %in% rownames(co))) {
-        return(list(est = NA_real_, se = NA_real_,
-                    t = NA_real_, p = NA_real_))
-    }
-    list(est = co[cname, 1], se = co[cname, 2],
-         t = co[cname, 3], p = co[cname, 4])
-}
-
 format_co <- function(co) {
     if (is.na(co$est)) return("     NA      ")
     stars <- ifelse(co$p < 0.01, "***",

--- a/code/analysis/table_6_pre_balance.R
+++ b/code/analysis/table_6_pre_balance.R
@@ -46,13 +46,10 @@ suppressPackageStartupMessages({
     library(modelsummary)
 })
 
-# Main hypo-road instrument — read from config.R (main_hypo_instrument).
-# Kept as a local alias for readability in formulas below.
-HYPO_INSTRUMENT <- NULL  # set in main() after sourcing config
-
 main <- function() {
 
     source(file.path(here::here(), "code", "config.R"), echo = FALSE)
+    source(file.path(dir_code, "analysis", "_iv_helpers.R"), echo = FALSE)
     options(modelsummary_factory_latex = "kableExtra")
     options(modelsummary_format_numeric_latex = "plain")
 
@@ -247,20 +244,8 @@ main <- function() {
 }
 
 # ---------------------------------------------------------------------------
-# Helpers
+# Helpers (table-local: display formatters)
 # ---------------------------------------------------------------------------
-safe_coef <- function(model, cname) {
-    co <- summary(model)$coeftable
-    if (!(cname %in% rownames(co))) {
-        return(list(est = NA_real_, se = NA_real_,
-                    t = NA_real_, p = NA_real_))
-    }
-    list(est = co[cname, 1],
-         se  = co[cname, 2],
-         t   = co[cname, 3],
-         p   = co[cname, 4])
-}
-
 format_be_se <- function(co) {
     if (is.na(co$est)) return("        NA        ")
     stars <- ifelse(co$p < 0.01, "***",

--- a/code/analysis/table_7_pre_trends.R
+++ b/code/analysis/table_7_pre_trends.R
@@ -45,8 +45,6 @@ suppressPackageStartupMessages({
     library(modelsummary)
 })
 
-HYPO_INSTRUMENT <- NULL  # set in main() from config.R (main_hypo_instrument)
-
 main <- function() {
 
     source(file.path(here::here(), "code", "config.R"), echo = FALSE)

--- a/code/analysis/table_7_pre_trends.R
+++ b/code/analysis/table_7_pre_trends.R
@@ -50,10 +50,9 @@ HYPO_INSTRUMENT <- NULL  # set in main() from config.R (main_hypo_instrument)
 main <- function() {
 
     source(file.path(here::here(), "code", "config.R"), echo = FALSE)
+    source(file.path(dir_code, "analysis", "_iv_helpers.R"), echo = FALSE)
     options(modelsummary_factory_latex = "kableExtra")
     options(modelsummary_format_numeric_latex = "plain")
-
-    HYPO_INSTRUMENT <- main_hypo_instrument
 
     if (!dir.exists(dir_tables)) dir.create(dir_tables, recursive = TRUE)
 
@@ -62,37 +61,17 @@ main <- function() {
     )
 
     y <- "chg_log_placebo_pop_60_47"
-    geo_controls_expr <- paste(c(
-        "elev_mean_std", "rugged_mea_std", "wheat_std",
-        "preCal_std", "postCal_std", "dist_to_BA_std",
-        "logMA_actual_1960_s0_elow", "log_pop_1960"
-    ), collapse = " + ")
-
-    # (1) OLS
-    f_ols <- as.formula(sprintf("%s ~ chg_logMA_86_60_s0_elow + %s",
-                                y, geo_controls_expr))
-    m_ols <- feols(f_ols, data = d, vcov = "hetero")
-
-    # (2) IV-LP
-    f_iv_lp <- as.formula(sprintf(
-        "%s ~ %s | chg_logMA_86_60_s0_elow ~ chg_logMA_stu_s0_elow",
-        y, geo_controls_expr
-    ))
-    m_iv_lp <- feols(f_iv_lp, data = d, vcov = "hetero")
-
-    # (3) IV-Hypo
-    f_iv_h <- as.formula(sprintf(
-        "%s ~ %s | chg_logMA_86_60_s0_elow ~ %s",
-        y, geo_controls_expr, HYPO_INSTRUMENT
-    ))
-    m_iv_h <- feols(f_iv_h, data = d, vcov = "hetero")
-
-    # (4) IV-Both
-    f_iv_b <- as.formula(sprintf(paste(
-        "%s ~ %s | chg_logMA_86_60_s0_elow ~",
-        "chg_logMA_stu_s0_elow + %s"
-    ), y, geo_controls_expr, HYPO_INSTRUMENT))
-    m_iv_b <- feols(f_iv_b, data = d, vcov = "hetero")
+    fits <- fit_iv_quad(
+        y = y, data = d,
+        endog = "chg_logMA_86_60_s0_elow",
+        lp_instr = "chg_logMA_stu_s0_elow",
+        hypo_instr = main_hypo_instrument,
+        ctrls_vec = geo_controls_main
+    )
+    m_ols   <- fits[["OLS"]]
+    m_iv_lp <- fits[["IV-LP"]]
+    m_iv_h  <- fits[["IV-H"]]
+    m_iv_b  <- fits[["IV-B"]]
 
     # First-stage F-stats per IV spec
     fs_lp <- fitstat_F(m_iv_lp)
@@ -215,28 +194,8 @@ main <- function() {
 }
 
 # ---------------------------------------------------------------------------
-# Helpers
+# Helpers (table-local: console-print formatter)
 # ---------------------------------------------------------------------------
-fitstat_F <- function(iv_model) {
-    fs <- fitstat(iv_model, type = "ivf")
-    if (is.list(fs) && !is.null(fs[[1]]$stat)) {
-        return(as.numeric(fs[[1]]$stat))
-    }
-    fs2 <- fitstat(iv_model, type = "ivf", simplify = TRUE)
-    if (is.list(fs2) && !is.null(fs2$stat)) return(as.numeric(fs2$stat))
-    NA_real_
-}
-
-safe_coef <- function(model, cname) {
-    co <- summary(model)$coeftable
-    if (!(cname %in% rownames(co))) {
-        return(list(est = NA_real_, se = NA_real_,
-                    t = NA_real_, p = NA_real_))
-    }
-    list(est = co[cname, 1], se = co[cname, 2],
-         t = co[cname, 3], p = co[cname, 4])
-}
-
 format_co <- function(co) {
     if (is.na(co$est)) return("NA")
     stars <- ifelse(co$p < 0.01, "***",

--- a/code/analysis/table_8_first_stage.R
+++ b/code/analysis/table_8_first_stage.R
@@ -47,6 +47,11 @@ main <- function() {
     geo_controls_expr <- paste(geo_controls_main, collapse = " + ")
 
     # --- Three specifications --------------------------------------------
+    # Hypo instrument is Table 8's role: document strength of each of the
+    # alternative hypo instruments (main spec = lcp_mst; robustness table
+    # reports euc_mst, lcp, euc). Kept hardcoded to lcp_mst here to
+    # mirror the main-spec choice while signaling to the reader that the
+    # variants lcp / euc_mst / euc would sit in the robustness table.
     f1 <- as.formula(sprintf(
         "chg_logMA_86_60_s0_elow ~ chg_logMA_stu_s0_elow + %s",
         geo_controls_expr

--- a/code/analysis/table_8_first_stage.R
+++ b/code/analysis/table_8_first_stage.R
@@ -43,12 +43,8 @@ main <- function() {
         file.path(dir_derived_analysis, "estimation_sample.parquet")
     )
 
-    # Controls (all present in the panel)
-    geo_controls_expr <- paste(c(
-        "elev_mean_std", "rugged_mea_std", "wheat_std",
-        "preCal_std", "postCal_std", "dist_to_BA_std",
-        "logMA_actual_1960_s0_elow", "log_pop_1960"
-    ), collapse = " + ")
+    # Controls — read from config.R (geo_controls_main)
+    geo_controls_expr <- paste(geo_controls_main, collapse = " + ")
 
     # --- Three specifications --------------------------------------------
     f1 <- as.formula(sprintf(

--- a/code/analysis/table_9_population.R
+++ b/code/analysis/table_9_population.R
@@ -46,14 +46,14 @@ suppressPackageStartupMessages({
 
 # ---- Main hypo-road instrument ----------------------------------------------
 # The paper's main specification uses the LCP-MST hypothetical network as
-# the hypo-road instrument. Alternatives (euc_mst, lcp, euc) are reported
-# in the robustness table. Change this constant to produce an alternate
-# main-spec table; panel columns for all four variants already exist.
-HYPO_INSTRUMENT <- "chg_logMA_lcp_mst_s0_elow"
+# the hypo-road instrument, sourced from config.R (main_hypo_instrument).
+# Alternatives (euc_mst, lcp, euc) are reported in the robustness table.
+# The panel already contains columns for all four variants.
 
 main <- function() {
 
     source(file.path(here::here(), "code", "config.R"), echo = FALSE)
+    source(file.path(dir_code, "analysis", "_iv_helpers.R"), echo = FALSE)
 
     if (!dir.exists(dir_tables)) dir.create(dir_tables, recursive = TRUE)
 
@@ -76,53 +76,27 @@ main <- function() {
              label = "$\\Delta (\\mathrm{Urban\\ share})$")
     )
 
-    geo_controls_expr <- paste(c(
-        "elev_mean_std", "rugged_mea_std", "wheat_std",
-        "preCal_std", "postCal_std", "dist_to_BA_std",
-        "logMA_actual_1960_s0_elow", "log_pop_1960"
-    ), collapse = " + ")
-
     # Build 16 model fits (4 outcomes × 4 specifications)
     all_models <- list()
     f_stats    <- list()
     for (out in outcomes) {
         y <- out$var
-        # (1) OLS
-        f_ols <- as.formula(sprintf("%s ~ chg_logMA_86_60_s0_elow + %s",
-                                    y, geo_controls_expr))
-        m_ols <- feols(f_ols, data = d, vcov = "hetero")
-
-        # (2) IV-LP
-        f_iv_lp <- as.formula(sprintf(
-            "%s ~ %s | chg_logMA_86_60_s0_elow ~ chg_logMA_stu_s0_elow",
-            y, geo_controls_expr
-        ))
-        m_iv_lp <- feols(f_iv_lp, data = d, vcov = "hetero")
-
-        # (3) IV-Hypo
-        f_iv_h <- as.formula(sprintf(
-            "%s ~ %s | chg_logMA_86_60_s0_elow ~ %s",
-            y, geo_controls_expr, HYPO_INSTRUMENT
-        ))
-        m_iv_h <- feols(f_iv_h, data = d, vcov = "hetero")
-
-        # (4) IV-Both
-        f_iv_b <- as.formula(sprintf(paste(
-            "%s ~ %s | chg_logMA_86_60_s0_elow ~",
-            "chg_logMA_stu_s0_elow + %s"
-        ), y, geo_controls_expr, HYPO_INSTRUMENT))
-        m_iv_b <- feols(f_iv_b, data = d, vcov = "hetero")
-
-        all_models[[paste(y, "OLS",   sep = "_")]] <- m_ols
-        all_models[[paste(y, "IV-LP", sep = "_")]] <- m_iv_lp
-        all_models[[paste(y, "IV-H",  sep = "_")]] <- m_iv_h
-        all_models[[paste(y, "IV-B",  sep = "_")]] <- m_iv_b
+        fits <- fit_iv_quad(
+            y = y, data = d,
+            endog = "chg_logMA_86_60_s0_elow",
+            lp_instr = "chg_logMA_stu_s0_elow",
+            hypo_instr = main_hypo_instrument,
+            ctrls_vec = geo_controls_main
+        )
+        for (spec in names(fits)) {
+            all_models[[paste(y, spec, sep = "_")]] <- fits[[spec]]
+        }
 
         # Pull out IV first-stage F for reporting
         f_stats[[y]] <- list(
-            lp   = fitstat_first_F(m_iv_lp),
-            hypo = fitstat_first_F(m_iv_h),
-            both = fitstat_first_F(m_iv_b)
+            lp   = fitstat_F(fits[["IV-LP"]]),
+            hypo = fitstat_F(fits[["IV-H"]]),
+            both = fitstat_F(fits[["IV-B"]])
         )
     }
 
@@ -239,7 +213,7 @@ main <- function() {
                 first_stage_F = ifelse(
                     spec == "OLS",
                     NA_real_,
-                    fitstat_first_F(m)
+                    fitstat_F(m)
                 )
             )
         }
@@ -251,22 +225,8 @@ main <- function() {
 }
 
 # ---------------------------------------------------------------------------
-# Helpers
+# Helpers (table-local: console-print format differs from shared safe_coef)
 # ---------------------------------------------------------------------------
-fitstat_first_F <- function(iv_model) {
-    # Extract first-stage F via fitstat(); format depends on fixest
-    # version, so be defensive.
-    fs <- fitstat(iv_model, type = "ivf")
-    if (is.list(fs) && !is.null(fs[[1]]$stat)) {
-        return(as.numeric(fs[[1]]$stat))
-    }
-    fs_simp <- fitstat(iv_model, type = "ivf", simplify = TRUE)
-    if (is.list(fs_simp) && !is.null(fs_simp$stat)) {
-        return(as.numeric(fs_simp$stat))
-    }
-    NA_real_
-}
-
 get_ma_coef <- function(m, coef_name) {
     co <- summary(m)$coeftable
     if (!(coef_name %in% rownames(co))) return(c(NA_real_, NA_real_))


### PR DESCRIPTION
Consolidates duplicated IV-quadruple model-building and helpers across Tables 6, 7, 9, 10 into `code/analysis/_iv_helpers.R`.

## New helpers

```r
fit_iv_quad(y, data, endog, lp_instr, hypo_instr, ctrls_vec)
  # Fits OLS + three IV specs. Returns list("OLS"=, "IV-LP"=, "IV-H"=, "IV-B"=)
  # HC1 (heteroskedasticity-robust) SE throughout.

safe_coef(model, cname)  # Extract one coefficient or all-NA list.
fitstat_F(iv_model)      # Defensive first-stage F across fixest versions.
```

## Config consumers

Also migrated the remaining hardcoded constants:
- **Table 9** now reads `main_hypo_instrument` (was `HYPO_INSTRUMENT` local) and `geo_controls_main` (was inline vector)
- **Table 8** now reads `geo_controls_main` (was inline vector; Table 8 has its own first-stage structure so doesn't use `fit_iv_quad`)

## Correctness check

All five CSV outputs are **byte-identical** before and after the refactor. Snapshot-diffed on the feature branch:
```
table_6_pre_balance.csv   MATCH
table_7_pre_trends.csv    MATCH
table_8_first_stage.csv   MATCH
table_9_population_iv.csv MATCH
table_10_sectoral_iv.csv  MATCH
```

## What's not shared

- **Table 6's** `fmt_cell` (nested tabular for two-row cells) — Table-6-specific presentation, kept local.
- **Tables 7, 9, 10** console-print formatters — different signatures for different console layouts, kept local.
- **Table 6's** regressions — not a 4-spec IV quadruple (it regresses baseline-X on instruments), so `fit_iv_quad` doesn't apply. Only the shared helpers (`safe_coef`) are reused.
- **Table 8's** first-stage regressions — 3 separate reduced-form fits, not an IV quadruple. Only `geo_controls_main` config constant is new.

## Line count

- Callers: **−186 lines** / +51 = **−135 net** across five files
- New `_iv_helpers.R`: **+94 lines**
- Net: **−41 lines** of code while eliminating duplication

Closes #50. Unblocks Table 11 / 12 / future IV tables to be trivial wrappers.