### PR TITLE
Wire tables and figures into paper.tex (fix Cote's ?? bug)

### DIFF
--- a/code/analysis/_iv_helpers.R
+++ b/code/analysis/_iv_helpers.R
@@ -92,3 +92,12 @@ fitstat_F <- function(iv_model) {
     if (is.list(fs2) && !is.null(fs2$stat)) return(as.numeric(fs2$stat))
     NA_real_
 }
+
+# Insert a \label{...} right after the FIRST \caption{...} in a tex string.
+# Used by multi-panel tables (e.g. Tables 9, 10, 11) so that paper-side
+# \ref{tab:foo} resolves to the first panel rather than going undefined.
+inject_first_label <- function(tex_text, label) {
+    pattern  <- "(\\\\caption\\{[^}]*\\})"
+    replace  <- sprintf("\\1\n\\\\label{%s}", label)
+    sub(pattern, replace, tex_text, perl = TRUE)
+}

--- a/code/analysis/table_10_sectoral.R
+++ b/code/analysis/table_10_sectoral.R
@@ -149,6 +149,7 @@ main <- function() {
     )
 
     tex_chunks <- character()
+    is_first_panel <- TRUE
     for (out in outcomes) {
         y <- out$var
         models_this <- list(
@@ -175,7 +176,12 @@ main <- function() {
             add_rows = add_rows,
             title    = sprintf("%s. Outcome: %s", out$panel_title, out$label)
         )
-        tex_chunks <- c(tex_chunks, as.character(tbl), "", "\\bigskip", "")
+        tbl_txt <- as.character(tbl)
+        if (is_first_panel) {
+            tbl_txt <- inject_first_label(tbl_txt, "tab:sectoral_iv")
+            is_first_panel <- FALSE
+        }
+        tex_chunks <- c(tex_chunks, tbl_txt, "", "\\bigskip", "")
     }
 
     out_tex <- file.path(dir_tables, "table_10_sectoral_iv.tex")

--- a/code/analysis/table_11_other_outcomes.R
+++ b/code/analysis/table_11_other_outcomes.R
@@ -124,6 +124,7 @@ main <- function() {
     )
 
     tex_chunks <- character()
+    is_first_panel <- TRUE
     for (out in outcomes) {
         y <- out$var
         models_this <- list(
@@ -150,7 +151,12 @@ main <- function() {
             add_rows = add_rows,
             title    = sprintf("Outcome: %s", out$label)
         )
-        tex_chunks <- c(tex_chunks, as.character(tbl), "", "\\bigskip", "")
+        tbl_txt <- as.character(tbl)
+        if (is_first_panel) {
+            tbl_txt <- inject_first_label(tbl_txt, "tab:other_outcomes_iv")
+            is_first_panel <- FALSE
+        }
+        tex_chunks <- c(tex_chunks, tbl_txt, "", "\\bigskip", "")
     }
 
     out_tex <- file.path(dir_tables, "table_11_other_outcomes_iv.tex")

--- a/code/analysis/table_7_pre_trends.R
+++ b/code/analysis/table_7_pre_trends.R
@@ -148,6 +148,7 @@ main <- function() {
     # Inject the notes just before \end{table}. Use gsub with fixed = TRUE
     # on the replacement to avoid backreference interpretation of backslashes.
     tbl_txt <- as.character(tbl)
+    tbl_txt <- inject_first_label(tbl_txt, "tab:pre_trends")
     end_marker <- "\\end{table}"
     tbl_txt <- sub(end_marker, paste0(notes_tex, "\n", end_marker),
                    tbl_txt, fixed = TRUE)

--- a/code/analysis/table_8_first_stage.R
+++ b/code/analysis/table_8_first_stage.R
@@ -36,6 +36,7 @@ suppressPackageStartupMessages({
 main <- function() {
 
     source(file.path(here::here(), "code", "config.R"), echo = FALSE)
+    source(file.path(dir_code, "analysis", "_iv_helpers.R"), echo = FALSE)
 
     if (!dir.exists(dir_tables)) dir.create(dir_tables, recursive = TRUE)
 
@@ -150,7 +151,8 @@ main <- function() {
     )
 
     out_tex <- file.path(dir_tables, "table_8_first_stage.tex")
-    writeLines(as.character(tbl), out_tex)
+    tbl_txt <- inject_first_label(as.character(tbl), "tab:first_stage")
+    writeLines(tbl_txt, out_tex)
     message("Saved: ", out_tex)
 
     # CSV with the coefficient matrix for convenience

--- a/code/analysis/table_9_population.R
+++ b/code/analysis/table_9_population.R
@@ -135,8 +135,10 @@ main <- function() {
     )
 
     # One table per outcome, concatenated into a single .tex file with
-    # a \bigskip between panels.
+    # a \bigskip between panels. The first panel carries the canonical
+    # \label{tab:population_iv} so paper-side \ref{} resolves cleanly.
     tex_chunks <- character()
+    is_first_panel <- TRUE
     for (out in outcomes) {
         y <- out$var
         models_this <- list(
@@ -166,7 +168,12 @@ main <- function() {
             add_rows = add_rows,
             title    = sprintf("Outcome: %s", out$label)
         )
-        tex_chunks <- c(tex_chunks, as.character(tbl), "", "\\bigskip", "")
+        tbl_txt <- as.character(tbl)
+        if (is_first_panel) {
+            tbl_txt <- inject_first_label(tbl_txt, "tab:population_iv")
+            is_first_panel <- FALSE
+        }
+        tex_chunks <- c(tex_chunks, tbl_txt, "", "\\bigskip", "")
     }
 
     out_tex <- file.path(dir_tables, "table_9_population_iv.tex")

--- a/paper/paper.tex
+++ b/paper/paper.tex
@@ -96,7 +96,7 @@ Argentina
 
 % ---- Pending sections (stubs) ---------------------------------------------
 \section{Mode-Specific Patterns via Counterfactuals}
-\label{sec:mode_specific}
+\label{sec:counterfactuals}
 \placeholder{Section 6 pending (Block 2). Counterfactual MA measures
 (rail-only, road-only) not yet computed; deferred until Block 1 is
 stable.}
@@ -109,6 +109,60 @@ regressions (stations, depots) and heterogeneity analysis.}
 \section{Conclusion}
 \label{sec:conclusion}
 \placeholder{Section 8 pending -- write last.}
+
+% ---- Figures and Tables (appended at end) ---------------------------------
+% In a final manuscript these would be placed in-text near their first
+% reference. For the current draft, we collect them at the end so the
+% prose reads cleanly without floats interrupting it. \ref{} resolves
+% to these objects regardless of position.
+
+\clearpage
+\section*{Figures}
+
+\begin{figure}[htbp]
+\centering
+\includegraphics[width=\textwidth]{figure_1_network_changes.pdf}
+\caption{Transport network changes, 1960--1986.}
+\label{fig:networks}
+\end{figure}
+
+\begin{figure}[htbp]
+\centering
+\includegraphics[width=0.85\textwidth]{figure_2_ma_change_choropleth.pdf}
+\caption{Change in log market access, 1960--1986.}
+\label{fig:ma_choropleth}
+\end{figure}
+
+\begin{figure}[htbp]
+\centering
+\includegraphics[width=\textwidth]{figure_c13_ma_counterfactual_trio.pdf}
+\caption{Market access changes under three scenarios: full, only-rail
+counterfactual, only-road counterfactual.}
+\label{fig:ma_counterfactual}
+\end{figure}
+
+\clearpage
+\section*{Tables}
+
+\input{../results/tables/table_1_network_changes.tex}
+
+\input{../results/tables/table_6_pre_balance.tex}
+
+\input{../results/tables/table_7_pre_trends.tex}
+
+\input{../results/tables/table_8_first_stage.tex}
+
+\input{../results/tables/table_9_population_iv.tex}
+
+\input{../results/tables/table_10_sectoral_iv.tex}
+
+\input{../results/tables/table_11_other_outcomes_iv.tex}
+
+\input{../results/tables/table_12_robustness.tex}
+
+\input{../results/tables/table_13_counterfactual.tex}
+
+\input{../results/tables/table_14_mechanisms.tex}
 
 % ---- References -----------------------------------------------------------
 \bibliographystyle{plainnat}

--- a/paper/section_4_empirical_strategy.tex
+++ b/paper/section_4_empirical_strategy.tex
@@ -86,7 +86,7 @@ the two instruments. Section~\ref{sec:first_stage_tab} reports the
 first stage. A third validation exercise, the over-identification
 test, is reported alongside Section~\ref{sec:results}.
 
-\subsubsection{Table 6 --- Pre-Period Balance}
+\subsubsection{Pre-Period Balance}
 \label{sec:pre_balance}
 
 Table~\ref{tab:pre_balance} reports regressions of each baseline
@@ -118,7 +118,7 @@ baseline characteristics at conventional significance levels: none of
 the column~2 coefficients has $p<0.05$. The joint specification in
 column~3 yields similar results to the single-instrument columns.
 
-\subsubsection{Table 7 --- Pre-Trends}
+\subsubsection{Pre-Trends}
 \label{sec:pre_trends}
 
 Table~\ref{tab:pre_trends} reports a placebo test. The dependent
@@ -170,7 +170,7 @@ post-reform main-spec coefficient on the same subset. We retain the
 main specification on the full sample as the headline estimate and
 report the placebo-subsample result in the robustness panel.
 
-\subsubsection{Table 8 --- First-Stage Results}
+\subsubsection{First-Stage Results}
 \label{sec:first_stage_tab}
 
 Table~\ref{tab:first_stage} reports the first-stage regressions.


### PR DESCRIPTION
Cote read the committed paper.pdf and got broken table/figure references throughout. Root cause: the section prose used `\ref{tab:...}` and `\ref{fig:...}` but paper.tex never inputted the table .tex files or included the figures, and most table files had no `\label{}` to anchor cross-references.

## What's fixed

- **Labels added** to every IV table on the first panel of multi-panel tables. New helper `inject_first_label()` in `_iv_helpers.R` injects `\label{}` right after the first `\caption{}`. Tables 7-11 patched; Tables 6, 12, 13, 14 already had labels.
- **Tables and Figures appended** to paper.tex: `\includegraphics` for figures 1, 2, c13 and `\input` for all 10 numbered table files. They sit at the end of the document; in-text floats are a polish step for the final manuscript.
- **§4 subsubsection titles** that hardcoded 'Table 6/7/8 ---' in their headings renamed to drop the table number (LaTeX assigns numbers by document order, and they may not match a hand-typed title).
- **§6 label** synced from `sec:mode_specific` to `sec:counterfactuals` so cross-refs from §1 and §2 resolve.
- **Table 8** now sources `_iv_helpers.R` (was the only IV table that didn't; now needs `inject_first_label`).

## Verification

paper.pdf: **30 pages**, **zero undefined references** in the LaTeX log. Every Table/Figure reference in the prose resolves to a visible number.

```
LaTeX compiled with no warnings of the form 'Reference X undefined'.
```

## Numbering note

Numbers Cote sees in the rendered PDF will not match the paper-skeleton plan numbers (e.g., 'Table 9' in plan = 'Table 5' in actual document, because LaTeX numbers tables in the order they're `\input`'d). The references in the prose resolve correctly; only the numerical label differs. Final renumbering is a polish step.