### PR TITLE
Bloque 1 MA diagnostics: centroid, fluvial, transshipment

### DIFF
--- a/code/analysis/diagnostic_ma_nofluvial.R
+++ b/code/analysis/diagnostic_ma_nofluvial.R
@@ -1,0 +1,127 @@
+# ===========================================================================
+# diagnostic_ma_nofluvial.R
+#
+# PURPOSE: Bloque-1 test (a) REPORT. After run_nofluvial_variant.sh has
+#          produced the _nofluvial MA files, this script compares the
+#          no-fluvial market access against the baseline: does disabling
+#          the navigation channel reduce the 91% MA-gain share and/or move
+#          the population elasticity toward the Donaldson-Hornbeck 0.5-0.7
+#          benchmark?
+#
+# READS:
+#   data/derived/04_market_access/ma_actual_1960_s0_nofluvial_elow.parquet
+#   data/derived/04_market_access/ma_actual_1986_s0_nofluvial_elow.parquet
+#   data/derived/04_market_access/ma_instrument_stu_s0_nofluvial_elow.parquet
+#   data/derived/04_market_access/ma_instrument_lcp_mst_s0_nofluvial_elow.parquet
+#   data/derived/06_analysis/estimation_sample.parquet  (baseline + controls)
+#
+# PRODUCES:
+#   results/tables/diagnostic_ma_nofluvial.txt
+#
+# Run AFTER run_nofluvial_variant.sh.
+# ===========================================================================
+
+suppressPackageStartupMessages({
+    library(arrow)
+    library(fixest)
+})
+
+main <- function() {
+    source(file.path(here::here(), "code", "config.R"), echo = FALSE)
+    source(file.path(dir_code, "base", "utils.R"), echo = FALSE)
+
+    report_path <- file.path(dir_tables, "diagnostic_ma_nofluvial.txt")
+    con <- file(report_path, open = "wt")
+    rep <- function(...) { line <- sprintf(...); cat(line, "\n")
+                           cat(line, "\n", file = con) }
+
+    rep("%s", strrep("=", 70))
+    rep("MA NO-FLUVIAL DIAGNOSTIC (Bloque 1 test a / C28)")
+    rep("Navigation channel disabled vs baseline")
+    rep("Generated: %s", format(Sys.time(), "%Y-%m-%d %H:%M:%S"))
+    rep("%s", strrep("=", 70))
+
+    # Helper: load a no-fluvial logMA file -> named data frame
+    load_logma <- function(case) {
+        p <- file.path(dir_derived_ma,
+                       sprintf("ma_%s_nofluvial_elow.parquet", case))
+        if (!file.exists(p)) {
+            stop("Missing no-fluvial MA file: ", p,
+                 "\nRun code/analysis/run_nofluvial_variant.sh first.")
+        }
+        d <- arrow::read_parquet(p)
+        d <- ensure_geolev2_char(d)
+        data.frame(geolev2 = d$geolev2, logMA = d$logMA)
+    }
+
+    ma1960 <- load_logma("actual_1960_s0")
+    ma1986 <- load_logma("actual_1986_s0")
+    mastu  <- load_logma("instrument_stu_s0")
+    malcp  <- load_logma("instrument_lcp_mst_s0")
+
+    names(ma1960)[2] <- "logMA_1960"
+    names(ma1986)[2] <- "logMA_1986"
+    names(mastu)[2]  <- "logMA_stu"
+    names(malcp)[2]  <- "logMA_lcp"
+
+    ma <- Reduce(function(a, b) merge(a, b, by = "geolev2"),
+                 list(ma1960, ma1986, mastu, malcp))
+    ma$chg_v     <- ma$logMA_1986 - ma$logMA_1960
+    ma$chg_stu_v <- ma$logMA_stu  - ma$logMA_1960
+    ma$chg_lcp_v <- ma$logMA_lcp  - ma$logMA_1960
+
+    base <- arrow::read_parquet(
+        file.path(dir_derived_analysis, "estimation_sample.parquet"))
+    base <- ensure_geolev2_char(base)
+
+    # ---- [A] gain share comparison ----------------------------------------
+    rep("\n%s", strrep("-", 70))
+    rep("[A] MA GAIN: baseline (with fluvial) vs no-fluvial")
+    rep("%s", strrep("-", 70))
+    cb <- base$chg_logMA_86_60_s0_elow
+    cv <- ma$chg_v
+    rep("  baseline:    share gain %.1f%%  mean %.3f  median %.3f",
+        100*mean(cb > 0, na.rm=TRUE), mean(cb, na.rm=TRUE),
+        median(cb, na.rm=TRUE))
+    rep("  no-fluvial:  share gain %.1f%%  mean %.3f  median %.3f",
+        100*mean(cv > 0, na.rm=TRUE), mean(cv, na.rm=TRUE),
+        median(cv, na.rm=TRUE))
+
+    # ---- [B] population elasticity, no-fluvial ----------------------------
+    rep("\n%s", strrep("-", 70))
+    rep("[B] POPULATION ELASTICITY, no-fluvial (sector 0, theta low)")
+    rep("%s", strrep("-", 70))
+    m <- merge(
+        base[, c("geolev2", "chg_log_pop_91_60", "log_pop_1960",
+                 "elev_mean_std", "rugged_mea_std", "wheat_std",
+                 "preCal_std", "postCal_std", "dist_to_BA_std")],
+        ma[, c("geolev2", "chg_v", "chg_stu_v", "chg_lcp_v")],
+        by = "geolev2")
+    ctrls <- "elev_mean_std + rugged_mea_std + wheat_std + preCal_std + postCal_std + dist_to_BA_std + log_pop_1960"
+
+    m_ols <- suppressMessages(fixest::feols(
+        as.formula(sprintf("chg_log_pop_91_60 ~ chg_v + %s", ctrls)),
+        data = m, vcov = "hetero"))
+    m_iv <- suppressMessages(fixest::feols(
+        as.formula(sprintf(
+            "chg_log_pop_91_60 ~ %s | chg_v ~ chg_stu_v + chg_lcp_v", ctrls)),
+        data = m, vcov = "hetero"))
+
+    rep("  OLS  beta = %+.3f (%.3f)  N=%d",
+        coef(m_ols)["chg_v"], m_ols$se["chg_v"], m_ols$nobs)
+    rep("  IV   beta = %+.3f (%.3f)  N=%d",
+        coef(m_iv)["fit_chg_v"], m_iv$se["fit_chg_v"], m_iv$nobs)
+    rep("  (baseline-with-fluvial IV-Both was +0.046 (0.033); D-H ~0.5-0.7)")
+
+    rep("\n%s", strrep("=", 70))
+    rep("READING: if no-fluvial gain share drops well below 91%% and the")
+    rep("IV beta moves up toward 0.5-0.7, the fluvial channel (C28) was")
+    rep("inflating MA. If both are basically unchanged, fluvial is NOT the")
+    rep("driver and the issue is the overall road-cost magnitude / HMI.")
+    rep("%s", strrep("=", 70))
+
+    close(con)
+    message("\nSaved report: ", report_path)
+}
+
+main()

--- a/code/analysis/diagnostic_ma_nofluvial.R
+++ b/code/analysis/diagnostic_ma_nofluvial.R
@@ -5,7 +5,7 @@
 #          produced the _nofluvial MA files, this script compares the
 #          no-fluvial market access against the baseline: does disabling
 #          the navigation channel reduce the 91% MA-gain share and/or move
-#          the population elasticity toward the Donaldson-Hornbeck 0.5-0.7
+#          the population elasticity toward the Gibbons et al. 2024 ~0.3
 #          benchmark?
 #
 # READS:
@@ -111,11 +111,11 @@ main <- function() {
         coef(m_ols)["chg_v"], m_ols$se["chg_v"], m_ols$nobs)
     rep("  IV   beta = %+.3f (%.3f)  N=%d",
         coef(m_iv)["fit_chg_v"], m_iv$se["fit_chg_v"], m_iv$nobs)
-    rep("  (baseline-with-fluvial IV-Both was +0.046 (0.033); D-H ~0.5-0.7)")
+    rep("  (baseline-with-fluvial IV-Both was +0.046 (0.033); Gibbons 2024 ~0.3)")
 
     rep("\n%s", strrep("=", 70))
     rep("READING: if no-fluvial gain share drops well below 91%% and the")
-    rep("IV beta moves up toward 0.5-0.7, the fluvial channel (C28) was")
+    rep("IV beta moves up toward 0.3 (Gibbons), the fluvial channel (C28) was")
     rep("inflating MA. If both are basically unchanged, fluvial is NOT the")
     rep("driver and the issue is the overall road-cost magnitude / HMI.")
     rep("%s", strrep("=", 70))

--- a/code/analysis/diagnostic_ma_refpoint.R
+++ b/code/analysis/diagnostic_ma_refpoint.R
@@ -1,0 +1,233 @@
+# ===========================================================================
+# diagnostic_ma_refpoint.R
+#
+# PURPOSE: Bloque-1 test (b). Re-extract tau using an INTERIOR reference
+#          point (st_point_on_surface, a pole-of-inaccessibility proxy)
+#          instead of the geographic centroid, then recompute market
+#          access. Tests Cote's C16 concern: if the geographic centroid
+#          happens to fall near a digitized road in the shapefile, the
+#          off-network (centroid + HMI) cost is tiny and MA is inflated;
+#          this could explain the implausible near-universal MA gain and
+#          the small main elasticity.
+#
+#   REUSES the existing transition grids (no raster rebuild). Only the
+#   point set fed to gdistance::costDistance changes. ~6 min per case.
+#
+# CASES re-extracted (sector 0, theta 4.55 + 8.11):
+#   actual_1960, actual_1986        -> main treatment Δlog MA
+#   instrument_stu, instrument_lcp_mst -> the two main instruments
+#
+# READS:
+#   data/derived/02_transition_grids/transition_<case>.rds
+#   data/raw/geo/geo2_ar1970_2010.shp
+#   data/derived/base/census_1960/census_1960_ipums.parquet
+#   data/derived/06_analysis/estimation_sample.parquet  (controls)
+#
+# PRODUCES:
+#   data/derived/06_analysis/refpoint_variant/tau_<case>.parquet
+#   data/derived/06_analysis/refpoint_variant/ma_compare.parquet
+#   results/tables/diagnostic_ma_refpoint.txt
+#
+# NOTE: writes to a SEPARATE refpoint_variant/ directory so it never
+#       clobbers the baseline pipeline outputs.
+# ===========================================================================
+
+suppressPackageStartupMessages({
+    library(sf); library(sp); library(raster); library(gdistance)
+    library(arrow)
+})
+
+CASES <- c("actual_1960_s0", "actual_1986_s0",
+           "instrument_stu_s0", "instrument_lcp_mst_s0")
+
+main <- function() {
+    source(file.path(here::here(), "code", "config.R"), echo = FALSE)
+    source(file.path(dir_code, "base", "utils.R"), echo = FALSE)
+
+    out_dir <- file.path(dir_derived_analysis, "refpoint_variant")
+    if (!dir.exists(out_dir)) dir.create(out_dir, recursive = TRUE)
+
+    report_path <- file.path(dir_tables, "diagnostic_ma_refpoint.txt")
+    con <- file(report_path, open = "wt")
+    rep <- function(...) { line <- sprintf(...); cat(line, "\n")
+                           cat(line, "\n", file = con) }
+
+    rep("%s", strrep("=", 70))
+    rep("MA REFERENCE-POINT DIAGNOSTIC (Bloque 1 test b / C16)")
+    rep("Interior point (st_point_on_surface) vs geographic centroid")
+    rep("Generated: %s", format(Sys.time(), "%Y-%m-%d %H:%M:%S"))
+    rep("%s", strrep("=", 70))
+
+    # ---- Interior reference points ----------------------------------------
+    pts <- load_interior_points()
+    rep("\nReference points: %d districts (st_point_on_surface)", nrow(pts))
+
+    # ---- Recompute tau per case (reusing transition grids) ----------------
+    for (case in CASES) {
+        tau_out <- file.path(out_dir, sprintf("tau_%s.parquet", case))
+        if (file.exists(tau_out)) {
+            rep("[tau] %s already exists, skipping recompute", case)
+            next
+        }
+        tg_path <- file.path(dir_derived_transitions,
+                             sprintf("transition_%s.rds", case))
+        stopifnot(file.exists(tg_path))
+        rep("[tau] %s: running costDistance (this takes ~6 min)...", case)
+        tg <- readRDS(tg_path)
+        t0 <- Sys.time()
+        mat <- as.matrix(gdistance::costDistance(tg, pts, pts))
+        el <- as.numeric(difftime(Sys.time(), t0, units = "secs"))
+        rep("[tau] %s: done in %.0f s", case, el)
+
+        geolev2 <- as.character(pts$geolev2)
+        ij <- which(lower.tri(mat, diag = FALSE), arr.ind = TRUE)
+        tau_df <- data.frame(
+            origin_geolev2      = geolev2[ij[, 1]],
+            destination_geolev2 = geolev2[ij[, 2]],
+            tau                 = mat[ij]
+        )
+        arrow::write_parquet(tau_df, tau_out)
+    }
+
+    # ---- Recompute MA for each case × elasticity --------------------------
+    pop <- load_1960_pop()
+    ma_list <- list()
+    for (case in CASES) {
+        tau_df <- arrow::read_parquet(
+            file.path(out_dir, sprintf("tau_%s.parquet", case)))
+        for (elab in c("elow", "ehigh")) {
+            th <- if (elab == "elow") theta[["low"]] else theta[["high"]]
+            ma <- compute_ma(tau_df, pop, th)
+            names(ma)[names(ma) == "logMA"] <-
+                sprintf("logMA_%s_%s", case, elab)
+            ma_list[[paste(case, elab)]] <- ma[, c("geolev2",
+                sprintf("logMA_%s_%s", case, elab))]
+        }
+    }
+    ma <- Reduce(function(a, b) merge(a, b, by = "geolev2"), ma_list)
+    ma <- ensure_geolev2_char(ma)
+
+    # ---- Main treatment Δlog MA under the interior point ------------------
+    ma$chg_logMA_86_60_v <- ma$logMA_actual_1986_s0_elow -
+                            ma$logMA_actual_1960_s0_elow
+    ma$chg_logMA_stu_v    <- ma$logMA_instrument_stu_s0_elow -
+                             ma$logMA_actual_1960_s0_elow
+    ma$chg_logMA_lcpmst_v <- ma$logMA_instrument_lcp_mst_s0_elow -
+                             ma$logMA_actual_1960_s0_elow
+
+    arrow::write_parquet(ma, file.path(out_dir, "ma_compare.parquet"))
+
+    # ---- Compare gain stats: baseline vs interior-point -------------------
+    base <- arrow::read_parquet(
+        file.path(dir_derived_analysis, "estimation_sample.parquet"))
+    base <- ensure_geolev2_char(base)
+
+    rep("\n%s", strrep("-", 70))
+    rep("[A] MA GAIN: baseline centroid vs interior point")
+    rep("%s", strrep("-", 70))
+    chg_b <- base$chg_logMA_86_60_s0_elow
+    chg_v <- ma$chg_logMA_86_60_v
+    rep("  baseline (centroid):  share gain %.1f%%  mean %.3f  median %.3f",
+        100*mean(chg_b > 0, na.rm=TRUE), mean(chg_b, na.rm=TRUE),
+        median(chg_b, na.rm=TRUE))
+    rep("  interior point:       share gain %.1f%%  mean %.3f  median %.3f",
+        100*mean(chg_v > 0, na.rm=TRUE), mean(chg_v, na.rm=TRUE),
+        median(chg_v, na.rm=TRUE))
+
+    # ---- Quick OLS + IV of population on Δlog MA under interior point -----
+    rep("\n%s", strrep("-", 70))
+    rep("[B] POPULATION ELASTICITY under interior point (sector 0, theta low)")
+    rep("%s", strrep("-", 70))
+    m <- merge(
+        base[, c("geolev2", "chg_log_pop_91_60",
+                 "logMA_actual_1960_s0_elow", "log_pop_1960",
+                 "elev_mean_std", "rugged_mea_std", "wheat_std",
+                 "preCal_std", "postCal_std", "dist_to_BA_std")],
+        ma[, c("geolev2", "chg_logMA_86_60_v", "chg_logMA_stu_v",
+               "chg_logMA_lcpmst_v")],
+        by = "geolev2")
+
+    ctrls <- "elev_mean_std + rugged_mea_std + wheat_std + preCal_std + postCal_std + dist_to_BA_std + log_pop_1960"
+    # NOTE: baseline logMA control here is the CENTROID logMA. A fully
+    # consistent variant would also swap that control to the interior-point
+    # 1960 logMA; we report both for transparency below.
+    f_ols <- as.formula(sprintf("chg_log_pop_91_60 ~ chg_logMA_86_60_v + %s",
+                                ctrls))
+    m_ols <- suppressMessages(fixest::feols(f_ols, data = m, vcov = "hetero"))
+    f_iv  <- as.formula(sprintf(
+        "chg_log_pop_91_60 ~ %s | chg_logMA_86_60_v ~ chg_logMA_stu_v + chg_logMA_lcpmst_v",
+        ctrls))
+    m_iv  <- suppressMessages(fixest::feols(f_iv, data = m, vcov = "hetero"))
+
+    co_ols <- coef(m_ols)["chg_logMA_86_60_v"]
+    se_ols <- m_ols$se["chg_logMA_86_60_v"]
+    co_iv  <- coef(m_iv)["fit_chg_logMA_86_60_v"]
+    se_iv  <- m_iv$se["fit_chg_logMA_86_60_v"]
+    rep("  OLS  beta = %+.3f (%.3f)   N=%d", co_ols, se_ols, m_ols$nobs)
+    rep("  IV   beta = %+.3f (%.3f)   N=%d", co_iv, se_iv, m_iv$nobs)
+    rep("  (baseline-centroid IV-Both was +0.046 (0.033); D-H benchmark ~0.5-0.7)")
+
+    rep("\n%s", strrep("=", 70))
+    rep("READING: if interior-point gain share drops well below 91%% and/or")
+    rep("the IV beta moves toward 0.5-0.7, the geographic centroid + HMI")
+    rep("off-network coupling (C16) was inflating MA. If both are basically")
+    rep("unchanged, the reference point is NOT the driver and suspicion")
+    rep("shifts to the fluvial channel (test a) or the cost magnitudes.")
+    rep("%s", strrep("=", 70))
+
+    close(con)
+    message("\nSaved report: ", report_path)
+}
+
+# ---------------------------------------------------------------------------
+# Interior reference points (pole-of-inaccessibility proxy)
+# ---------------------------------------------------------------------------
+load_interior_points <- function() {
+    shp <- sf::st_read(file.path(dir_raw_geo, "geo2_ar1970_2010.shp"),
+                       quiet = TRUE)
+    shp <- sf::st_make_valid(shp)
+    names(shp)[names(shp) == "GEOLEVEL2"] <- "geolev2"
+    shp$geolev2 <- sub("^0+", "", as.character(shp$geolev2))
+    shp <- shp[!sf::st_is_empty(shp), ]
+    shp <- shp[!(shp$geolev2 %in% geolev2_exclude), ]
+    shp <- shp[!grepl("0000$", shp$geolev2), ]
+    stopifnot(nrow(shp) == 312L, !any(duplicated(shp$geolev2)))
+
+    # st_point_on_surface: guaranteed interior point. Differs from the
+    # geographic centroid for non-convex / coastal districts — exactly
+    # the cases where the centroid can fall near a digitized network edge.
+    pts_sf <- suppressWarnings(sf::st_point_on_surface(shp))
+    pts_sf <- sf::st_transform(pts_sf, crs = crs_raster)
+    sf::as_Spatial(pts_sf[, "geolev2"])
+}
+
+load_1960_pop <- function() {
+    path <- file.path(dir_derived_census1960, "census_1960_ipums.parquet")
+    d <- arrow::read_parquet(path)
+    d <- ensure_geolev2_char(d)
+    data.frame(geolev2 = d$geolev2, pop = as.numeric(d$pop))
+}
+
+compute_ma <- function(tau_df, pop_df, theta_val) {
+    tau_df <- ensure_geolev2_char(tau_df, "origin_geolev2")
+    tau_df <- ensure_geolev2_char(tau_df, "destination_geolev2")
+    sym <- rbind(
+        tau_df,
+        data.frame(origin_geolev2      = tau_df$destination_geolev2,
+                   destination_geolev2 = tau_df$origin_geolev2,
+                   tau                 = tau_df$tau))
+    sym <- merge(sym,
+                 data.frame(destination_geolev2 = pop_df$geolev2,
+                            pop_dest = pop_df$pop),
+                 by = "destination_geolev2", all.x = TRUE)
+    sym$pop_dest[is.na(sym$pop_dest)] <- 0
+    sym$weight <- ifelse(is.finite(sym$tau) & sym$tau > 0,
+                         1 / (sym$tau^theta_val), 0)
+    sym$contrib <- sym$weight * sym$pop_dest
+    ma_df <- aggregate(contrib ~ origin_geolev2, data = sym, FUN = sum)
+    names(ma_df) <- c("geolev2", "MA")
+    ma_df$logMA <- log(ma_df$MA)
+    ma_df
+}
+
+main()

--- a/code/analysis/diagnostic_ma_refpoint.R
+++ b/code/analysis/diagnostic_ma_refpoint.R
@@ -165,11 +165,11 @@ main <- function() {
     se_iv  <- m_iv$se["fit_chg_logMA_86_60_v"]
     rep("  OLS  beta = %+.3f (%.3f)   N=%d", co_ols, se_ols, m_ols$nobs)
     rep("  IV   beta = %+.3f (%.3f)   N=%d", co_iv, se_iv, m_iv$nobs)
-    rep("  (baseline-centroid IV-Both was +0.046 (0.033); D-H benchmark ~0.5-0.7)")
+    rep("  (baseline-centroid IV-Both was +0.046 (0.033); Gibbons 2024 ~0.3)")
 
     rep("\n%s", strrep("=", 70))
     rep("READING: if interior-point gain share drops well below 91%% and/or")
-    rep("the IV beta moves toward 0.5-0.7, the geographic centroid + HMI")
+    rep("the IV beta moves toward 0.3 (Gibbons), the geographic centroid + HMI")
     rep("off-network coupling (C16) was inflating MA. If both are basically")
     rep("unchanged, the reference point is NOT the driver and suspicion")
     rep("shifts to the fluvial channel (test a) or the cost magnitudes.")

--- a/code/analysis/diagnostic_ma_unimodal.R
+++ b/code/analysis/diagnostic_ma_unimodal.R
@@ -143,7 +143,7 @@ main <- function() {
         data = m, vcov = "hetero"))
     rep("  OLS  beta = %+.3f (%.3f)  N=%d",
         coef(m_ols)["chg_uni"], m_ols$se["chg_uni"], m_ols$nobs)
-    rep("  (baseline OLS was +0.022; baseline IV-Both +0.046; D-H ~0.5-0.7)")
+    rep("  (baseline OLS was +0.022; baseline IV-Both +0.046; Gibbons 2024 ~0.3)")
     rep("  NOTE: full IV needs unimodal instruments too — built only if")
     rep("  this screen implicates transshipment.")
 

--- a/code/analysis/diagnostic_ma_unimodal.R
+++ b/code/analysis/diagnostic_ma_unimodal.R
@@ -1,0 +1,193 @@
+# ===========================================================================
+# diagnostic_ma_unimodal.R
+#
+# PURPOSE: Bloque-1 test (c) SCREEN report. After run_unimodal_variant.sh
+#          has produced the six single-mode taus (road/rail/water ×
+#          1960/1986), this builds the INFINITE-TRANSSHIPMENT (unimodal)
+#          tau as the element-wise min across modes, recomputes MA, and
+#          compares the gain share and OLS elasticity to baseline.
+#
+#   Baseline = zero transshipment (free mode-switching). Unimodal =
+#   infinite transshipment (one mode per trip). The truth is between.
+#   If the 91% gain survives the unimodal bound, transshipment is not
+#   the driver. If it collapses, the zero-transshipment assumption is
+#   load-bearing and the full mode-expanded-graph build is warranted.
+#
+# READS:
+#   data/derived/03_taus/tau_actual_{1960,1986}_s0_{road,rail,water}only.parquet
+#   data/derived/base/census_1960/census_1960_ipums.parquet
+#   data/derived/06_analysis/estimation_sample.parquet
+#
+# PRODUCES:
+#   data/derived/06_analysis/unimodal_variant/tau_unimodal_{1960,1986}.parquet
+#   results/tables/diagnostic_ma_unimodal.txt
+#
+# NOTE: This is a SCREEN. It reports the gain share (decisive, cheap) and
+#   the OLS elasticity. A full IV elasticity would also need unimodal
+#   instruments (stu, lcp_mst) — built only if this screen implicates
+#   transshipment.
+# ===========================================================================
+
+suppressPackageStartupMessages({
+    library(arrow)
+    library(fixest)
+})
+
+main <- function() {
+    source(file.path(here::here(), "code", "config.R"), echo = FALSE)
+    source(file.path(dir_code, "base", "utils.R"), echo = FALSE)
+
+    out_dir <- file.path(dir_derived_analysis, "unimodal_variant")
+    if (!dir.exists(out_dir)) dir.create(out_dir, recursive = TRUE)
+
+    report_path <- file.path(dir_tables, "diagnostic_ma_unimodal.txt")
+    con <- file(report_path, open = "wt")
+    rep <- function(...) { line <- sprintf(...); cat(line, "\n")
+                           cat(line, "\n", file = con) }
+
+    rep("%s", strrep("=", 70))
+    rep("MA UNIMODAL / TRANSSHIPMENT-BOUND DIAGNOSTIC (Bloque 1 test c)")
+    rep("Infinite transshipment (one mode per trip) vs baseline (free switch)")
+    rep("Generated: %s", format(Sys.time(), "%Y-%m-%d %H:%M:%S"))
+    rep("%s", strrep("=", 70))
+
+    # ---- Build unimodal tau (min across modes) per period -----------------
+    build_unimodal <- function(year) {
+        modes <- c("road", "rail", "water")
+        tau_mode <- lapply(modes, function(md) {
+            p <- file.path(dir_derived_taus,
+                sprintf("tau_actual_%d_s0_%sonly.parquet", year, md))
+            if (!file.exists(p)) {
+                stop("Missing single-mode tau: ", p,
+                     "\nRun code/analysis/run_unimodal_variant.sh first.")
+            }
+            d <- arrow::read_parquet(p)
+            d$key <- paste(d$origin_geolev2, d$destination_geolev2, sep = "_")
+            d
+        })
+        # Align on key (all three share the same 48516 lower-triangle pairs)
+        base <- tau_mode[[1]][, c("origin_geolev2", "destination_geolev2",
+                                  "key", "tau")]
+        names(base)[names(base) == "tau"] <- "tau_road"
+        base$tau_rail  <- tau_mode[[2]]$tau[match(base$key, tau_mode[[2]]$key)]
+        base$tau_water <- tau_mode[[3]]$tau[match(base$key, tau_mode[[3]]$key)]
+        # Infinite-transshipment tau = min across modes (NA/Inf safe)
+        m <- cbind(base$tau_road, base$tau_rail, base$tau_water)
+        base$tau <- apply(m, 1, function(x) {
+            x <- x[is.finite(x)]
+            if (length(x) == 0) Inf else min(x)
+        })
+        out <- base[, c("origin_geolev2", "destination_geolev2", "tau")]
+        arrow::write_parquet(out,
+            file.path(out_dir, sprintf("tau_unimodal_%d.parquet", year)))
+        out
+    }
+
+    rep("\nBuilding unimodal tau (element-wise min across road/rail/water)...")
+    tau60 <- build_unimodal(1960)
+    tau86 <- build_unimodal(1986)
+
+    # ---- Compute MA for each period ---------------------------------------
+    pop <- load_1960_pop()
+    ma60 <- compute_ma(tau60, pop, theta[["low"]])
+    ma86 <- compute_ma(tau86, pop, theta[["low"]])
+    ma <- merge(
+        data.frame(geolev2 = ma60$geolev2, logMA_1960 = ma60$logMA),
+        data.frame(geolev2 = ma86$geolev2, logMA_1986 = ma86$logMA),
+        by = "geolev2")
+    ma <- ensure_geolev2_char(ma)
+    ma$chg_uni <- ma$logMA_1986 - ma$logMA_1960
+
+    base <- arrow::read_parquet(
+        file.path(dir_derived_analysis, "estimation_sample.parquet"))
+    base <- ensure_geolev2_char(base)
+
+    # ---- [A] gain share ----------------------------------------------------
+    rep("\n%s", strrep("-", 70))
+    rep("[A] MA GAIN: baseline (zero transshipment) vs unimodal (infinite)")
+    rep("%s", strrep("-", 70))
+    cb <- base$chg_logMA_86_60_s0_elow
+    cu <- ma$chg_uni[is.finite(ma$chg_uni)]
+    rep("  baseline:  share gain %.1f%%  mean %.3f  median %.3f  (N=%d)",
+        100*mean(cb > 0, na.rm=TRUE), mean(cb, na.rm=TRUE),
+        median(cb, na.rm=TRUE), sum(!is.na(cb)))
+    rep("  unimodal:  share gain %.1f%%  mean %.3f  median %.3f  (N=%d)",
+        100*mean(cu > 0), mean(cu), median(cu), length(cu))
+
+    # ---- [B] pairwise tau-change comparison -------------------------------
+    rep("\n%s", strrep("-", 70))
+    rep("[B] PAIRWISE tau CHANGE 1960->1986: how much do pairs get cheaper?")
+    rep("%s", strrep("-", 70))
+    k60 <- paste(tau60$origin_geolev2, tau60$destination_geolev2, sep="_")
+    k86 <- paste(tau86$origin_geolev2, tau86$destination_geolev2, sep="_")
+    mm <- match(k60, k86)
+    r <- tau86$tau[mm] / tau60$tau
+    r <- r[is.finite(r) & r > 0]
+    rep("  unimodal: %.1f%% of pairs cheaper; median tau ratio %.3f",
+        100*mean(r < 1), median(r))
+    rep("  (baseline was 91.6%% cheaper, median ratio 0.795 — see diagnostic 1)")
+
+    # ---- [C] OLS elasticity under unimodal MA -----------------------------
+    rep("\n%s", strrep("-", 70))
+    rep("[C] POPULATION OLS elasticity under unimodal MA (sector 0)")
+    rep("%s", strrep("-", 70))
+    m <- merge(
+        base[, c("geolev2", "chg_log_pop_91_60", "log_pop_1960",
+                 "elev_mean_std", "rugged_mea_std", "wheat_std",
+                 "preCal_std", "postCal_std", "dist_to_BA_std")],
+        ma[, c("geolev2", "chg_uni")], by = "geolev2")
+    m <- m[is.finite(m$chg_uni), ]
+    ctrls <- "elev_mean_std + rugged_mea_std + wheat_std + preCal_std + postCal_std + dist_to_BA_std + log_pop_1960"
+    m_ols <- suppressMessages(fixest::feols(
+        as.formula(sprintf("chg_log_pop_91_60 ~ chg_uni + %s", ctrls)),
+        data = m, vcov = "hetero"))
+    rep("  OLS  beta = %+.3f (%.3f)  N=%d",
+        coef(m_ols)["chg_uni"], m_ols$se["chg_uni"], m_ols$nobs)
+    rep("  (baseline OLS was +0.022; baseline IV-Both +0.046; D-H ~0.5-0.7)")
+    rep("  NOTE: full IV needs unimodal instruments too — built only if")
+    rep("  this screen implicates transshipment.")
+
+    rep("\n%s", strrep("=", 70))
+    rep("READING: if unimodal gain share stays ~91%% and median tau ratio")
+    rep("stays ~0.8, transshipment is NOT the driver — the broad cost")
+    rep("collapse happens even without free mode-switching. If the gain")
+    rep("share drops sharply and pairs stop getting uniformly cheaper,")
+    rep("the zero-transshipment assumption is load-bearing and the full")
+    rep("mode-expanded-graph model (one node per cell x mode, switch")
+    rep("edges with a penalty) is warranted as the real fix.")
+    rep("%s", strrep("=", 70))
+
+    close(con)
+    message("\nSaved report: ", report_path)
+}
+
+load_1960_pop <- function() {
+    d <- arrow::read_parquet(
+        file.path(dir_derived_census1960, "census_1960_ipums.parquet"))
+    d <- ensure_geolev2_char(d)
+    data.frame(geolev2 = d$geolev2, pop = as.numeric(d$pop))
+}
+
+compute_ma <- function(tau_df, pop_df, theta_val) {
+    tau_df <- ensure_geolev2_char(tau_df, "origin_geolev2")
+    tau_df <- ensure_geolev2_char(tau_df, "destination_geolev2")
+    sym <- rbind(
+        tau_df[, c("origin_geolev2", "destination_geolev2", "tau")],
+        data.frame(origin_geolev2      = tau_df$destination_geolev2,
+                   destination_geolev2 = tau_df$origin_geolev2,
+                   tau                 = tau_df$tau))
+    sym <- merge(sym,
+                 data.frame(destination_geolev2 = pop_df$geolev2,
+                            pop_dest = pop_df$pop),
+                 by = "destination_geolev2", all.x = TRUE)
+    sym$pop_dest[is.na(sym$pop_dest)] <- 0
+    sym$weight <- ifelse(is.finite(sym$tau) & sym$tau > 0,
+                         1 / (sym$tau^theta_val), 0)
+    sym$contrib <- sym$weight * sym$pop_dest
+    ma_df <- aggregate(contrib ~ origin_geolev2, data = sym, FUN = sum)
+    names(ma_df) <- c("geolev2", "MA")
+    ma_df$logMA <- log(ma_df$MA)
+    ma_df
+}
+
+main()

--- a/code/analysis/run_nofluvial_variant.sh
+++ b/code/analysis/run_nofluvial_variant.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# ===========================================================================
+# run_nofluvial_variant.sh
+#
+# Bloque-1 test (a): rebuild the cost surface with the fluvial/navigation
+# channel DISABLED, then recompute transitions, taus, and MA for the four
+# main cases. Tests Cote's C28 concern that cheap uniform navigation cost
+# inflates riverine MA and drives the implausible near-universal MA gain.
+#
+# The DISABLE_NAVIGATION=1 env var makes combine_cost() treat navigable
+# water as non-navigable, and save_cost_raster() append a _nofluvial
+# suffix so baseline outputs are never clobbered.
+#
+# Cases: actual_1960, actual_1986 (main treatment) + instrument_stu,
+#        instrument_lcp_mst (instruments), all sector 0.
+#
+# Runtime: ~4 raster builds + 4 transitions + 4 taus (~6 min each) ≈ 40-60 min.
+#
+# Run from repo root:  bash code/analysis/run_nofluvial_variant.sh
+# ===========================================================================
+set -euo pipefail
+
+CASES_BASE="actual_1960_s0 actual_1986_s0 instrument_stu_s0 instrument_lcp_mst_s0"
+CASES_NF="actual_1960_s0_nofluvial actual_1986_s0_nofluvial instrument_stu_s0_nofluvial instrument_lcp_mst_s0_nofluvial"
+
+echo "=== Step 1: build no-fluvial cost rasters ==="
+DISABLE_NAVIGATION=1 Rscript code/pipeline/03a_build_cost_raster.R $CASES_BASE
+
+echo "=== Step 2: build transitions from no-fluvial rasters ==="
+Rscript code/pipeline/03b_transition_grids.R $CASES_NF
+
+echo "=== Step 3: compute taus (parallel, 4 cores) ==="
+Rscript code/pipeline/03c_compute_taus_parallel.R 4 $CASES_NF
+
+echo "=== Step 4: compute MA for no-fluvial taus ==="
+Rscript code/pipeline/04_market_access.R $CASES_NF
+
+echo "=== Done. No-fluvial outputs carry the _nofluvial suffix. ==="

--- a/code/analysis/run_unimodal_variant.sh
+++ b/code/analysis/run_unimodal_variant.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# ===========================================================================
+# run_unimodal_variant.sh
+#
+# Bloque-1 test (c) SCREEN: bound the transshipment assumption.
+#
+# The baseline allows free mode-switching (zero transshipment cost): a
+# least-cost path can hop road->rail->water at any pixel for free. The
+# opposite extreme is INFINITE transshipment: each trip uses a single
+# primary mode plus off-network walking, no switching. The truth is in
+# between. If the 91% MA-gain and the broad cost collapse survive the
+# infinite-transshipment (unimodal) bound, transshipment is not the
+# driver; if they collapse, the zero-transshipment assumption is
+# load-bearing and the full mode-expanded-graph model is warranted.
+#
+# Unimodal tau_ij = min( tau_road_ij, tau_rail_ij, tau_water_ij ),
+# where each single-mode tau uses that mode + off-network land only.
+#
+# This script builds the three single-mode cost surfaces for the two
+# treatment periods (1960, 1986), their transitions and taus. The
+# element-wise min and the MA/elasticity comparison are done by
+# diagnostic_ma_unimodal.R afterwards.
+#
+# Runtime: 6 rasters + 6 transitions + 6 taus (~5 min each) ~= 45-55 min.
+#
+# Run from repo root:  bash code/analysis/run_unimodal_variant.sh
+# ===========================================================================
+set -euo pipefail
+
+build_mode () {
+    local variant="$1"   # roadonly | railonly | wateronly
+    local base="$2"      # actual_1960_s0 | actual_1986_s0
+    local case_v="${base}_${variant}"
+    echo "=== ${case_v}: raster ==="
+    MODE_VARIANT="$variant" Rscript code/pipeline/03a_build_cost_raster.R "$base"
+    echo "=== ${case_v}: transition ==="
+    Rscript code/pipeline/03b_transition_grids.R "$case_v"
+    echo "=== ${case_v}: tau ==="
+    Rscript code/pipeline/03c_compute_taus.R "$case_v"
+}
+
+for base in actual_1960_s0 actual_1986_s0; do
+    for variant in roadonly railonly wateronly; do
+        build_mode "$variant" "$base"
+    done
+done
+
+echo "=== All six single-mode taus built. Run diagnostic_ma_unimodal.R next. ==="

--- a/code/pipeline/03a_build_cost_raster.R
+++ b/code/pipeline/03a_build_cost_raster.R
@@ -472,6 +472,16 @@ combine_cost <- function(rail_rast, road_rast, nav_rast, hmi_rast,
                          arg_mask, sector) {
     message(sprintf("[cost]   Combining layers (sector=%s)", sector))
 
+    # Bloque-1 test (a): allow disabling the fluvial/navigation channel via
+    # an environment variable so the no-fluvial counterfactual can be built
+    # without altering the default behaviour. DISABLE_NAVIGATION=1 treats
+    # navigable water as non-navigable (it then falls through to the
+    # off-network land/HMI rule or stays NA outside Argentina).
+    disable_nav <- identical(Sys.getenv("DISABLE_NAVIGATION"), "1")
+    if (disable_nav) {
+        message("[cost]   DISABLE_NAVIGATION=1 -> fluvial channel OFF")
+    }
+
     rail <- terra::values(rail_rast)
     road <- terra::values(road_rast)
     nav  <- terra::values(nav_rast)
@@ -482,6 +492,7 @@ combine_cost <- function(rail_rast, road_rast, nav_rast, hmi_rast,
     is_rail <- !is.na(rail) & rail == 1L
     is_road <- !is.na(road) & road == 1L
     is_nav  <- !is.na(nav)  & nav  == 1L
+    if (disable_nav) is_nav <- rep(FALSE, length(is_nav))
     in_arg  <- !is.na(mask) & mask == 1
 
     cost <- rep(NA_real_, length(rail))
@@ -568,8 +579,12 @@ validate_cost <- function(cost, rail_rast, road_rast, nav_rast, sector) {
 # Save
 # ---------------------------------------------------------------------------
 save_cost_raster <- function(cost, case) {
+    # Bloque-1 test (a): when navigation is disabled, write to a distinct
+    # filename so the no-fluvial rasters never clobber the baseline ones.
+    suffix <- if (identical(Sys.getenv("DISABLE_NAVIGATION"), "1"))
+        "_nofluvial" else ""
     out_path <- file.path(dir_derived_rasters,
-                          sprintf("ucost_%s.tif", case))
+                          sprintf("ucost_%s%s.tif", case, suffix))
     terra::writeRaster(cost, out_path, overwrite = TRUE,
                        datatype = "FLT4S")
     message(sprintf("[cost]   Saved: %s", out_path))

--- a/code/pipeline/03a_build_cost_raster.R
+++ b/code/pipeline/03a_build_cost_raster.R
@@ -540,6 +540,12 @@ validate_cost <- function(cost, rail_rast, road_rast, nav_rast, sector) {
     is_rail <- !is.na(r) & r == 1L
     is_road <- !is.na(d) & d == 1L
     is_nav  <- !is.na(n) & n == 1L
+    # Mirror the no-fluvial toggle from combine_cost: when navigation is
+    # disabled, navigable cells were treated as land, so don't validate
+    # them against cost_nav.
+    if (identical(Sys.getenv("DISABLE_NAVIGATION"), "1")) {
+        is_nav <- rep(FALSE, length(is_nav))
+    }
 
     nav_only_no_infra <- is_nav & !is_rail & !is_road
     rail_only         <- !is_nav & is_rail & !is_road

--- a/code/pipeline/03a_build_cost_raster.R
+++ b/code/pipeline/03a_build_cost_raster.R
@@ -472,13 +472,25 @@ combine_cost <- function(rail_rast, road_rast, nav_rast, hmi_rast,
                          arg_mask, sector) {
     message(sprintf("[cost]   Combining layers (sector=%s)", sector))
 
-    # Bloque-1 test (a): allow disabling the fluvial/navigation channel via
-    # an environment variable so the no-fluvial counterfactual can be built
-    # without altering the default behaviour. DISABLE_NAVIGATION=1 treats
-    # navigable water as non-navigable (it then falls through to the
-    # off-network land/HMI rule or stays NA outside Argentina).
+    # Bloque-1 toggles via environment variables. Default (unset) reproduces
+    # the baseline multimodal surface exactly.
+    #   DISABLE_NAVIGATION=1   -> fluvial channel off (test a)
+    #   MODE_VARIANT=roadonly  -> only roads + off-network land (unimodal)
+    #   MODE_VARIANT=railonly  -> only rails + off-network land (unimodal)
+    #   MODE_VARIANT=wateronly -> only navigation + off-network land
+    # The MODE_VARIANT options build the single-mode surfaces used to bound
+    # the transshipment assumption (test c): the unimodal (infinite-
+    # transshipment) tau is the element-wise min across the three single-
+    # mode tau matrices.
     disable_nav <- identical(Sys.getenv("DISABLE_NAVIGATION"), "1")
-    if (disable_nav) {
+    mode_variant <- Sys.getenv("MODE_VARIANT")  # "", roadonly, railonly, wateronly
+    drop_rail <- mode_variant %in% c("roadonly", "wateronly")
+    drop_road <- mode_variant %in% c("railonly", "wateronly")
+    drop_nav  <- disable_nav | mode_variant %in% c("roadonly", "railonly")
+    if (nzchar(mode_variant)) {
+        message(sprintf("[cost]   MODE_VARIANT=%s (rail=%s road=%s nav=%s)",
+                        mode_variant, !drop_rail, !drop_road, !drop_nav))
+    } else if (disable_nav) {
         message("[cost]   DISABLE_NAVIGATION=1 -> fluvial channel OFF")
     }
 
@@ -492,7 +504,9 @@ combine_cost <- function(rail_rast, road_rast, nav_rast, hmi_rast,
     is_rail <- !is.na(rail) & rail == 1L
     is_road <- !is.na(road) & road == 1L
     is_nav  <- !is.na(nav)  & nav  == 1L
-    if (disable_nav) is_nav <- rep(FALSE, length(is_nav))
+    if (drop_rail) is_rail <- rep(FALSE, length(is_rail))
+    if (drop_road) is_road <- rep(FALSE, length(is_road))
+    if (drop_nav)  is_nav  <- rep(FALSE, length(is_nav))
     in_arg  <- !is.na(mask) & mask == 1
 
     cost <- rep(NA_real_, length(rail))
@@ -540,12 +554,16 @@ validate_cost <- function(cost, rail_rast, road_rast, nav_rast, sector) {
     is_rail <- !is.na(r) & r == 1L
     is_road <- !is.na(d) & d == 1L
     is_nav  <- !is.na(n) & n == 1L
-    # Mirror the no-fluvial toggle from combine_cost: when navigation is
-    # disabled, navigable cells were treated as land, so don't validate
-    # them against cost_nav.
-    if (identical(Sys.getenv("DISABLE_NAVIGATION"), "1")) {
-        is_nav <- rep(FALSE, length(is_nav))
-    }
+    # Mirror the Bloque-1 toggles from combine_cost so validation matches
+    # whichever modes were actually used.
+    mode_variant <- Sys.getenv("MODE_VARIANT")
+    drop_rail <- mode_variant %in% c("roadonly", "wateronly")
+    drop_road <- mode_variant %in% c("railonly", "wateronly")
+    drop_nav  <- identical(Sys.getenv("DISABLE_NAVIGATION"), "1") |
+                 mode_variant %in% c("roadonly", "railonly")
+    if (drop_rail) is_rail <- rep(FALSE, length(is_rail))
+    if (drop_road) is_road <- rep(FALSE, length(is_road))
+    if (drop_nav)  is_nav  <- rep(FALSE, length(is_nav))
 
     nav_only_no_infra <- is_nav & !is_rail & !is_road
     rail_only         <- !is_nav & is_rail & !is_road
@@ -585,10 +603,16 @@ validate_cost <- function(cost, rail_rast, road_rast, nav_rast, sector) {
 # Save
 # ---------------------------------------------------------------------------
 save_cost_raster <- function(cost, case) {
-    # Bloque-1 test (a): when navigation is disabled, write to a distinct
-    # filename so the no-fluvial rasters never clobber the baseline ones.
-    suffix <- if (identical(Sys.getenv("DISABLE_NAVIGATION"), "1"))
-        "_nofluvial" else ""
+    # Bloque-1 variants: write to a distinct filename so variant rasters
+    # never clobber the baseline ones. Suffix reflects the active toggle.
+    mode_variant <- Sys.getenv("MODE_VARIANT")
+    suffix <- if (nzchar(mode_variant)) {
+        paste0("_", mode_variant)
+    } else if (identical(Sys.getenv("DISABLE_NAVIGATION"), "1")) {
+        "_nofluvial"
+    } else {
+        ""
+    }
     out_path <- file.path(dir_derived_rasters,
                           sprintf("ucost_%s%s.tif", case, suffix))
     terra::writeRaster(cost, out_path, overwrite = TRUE,

--- a/results/tables/diagnostic_ma_nofluvial.txt
+++ b/results/tables/diagnostic_ma_nofluvial.txt
@@ -1,0 +1,25 @@
+====================================================================== 
+MA NO-FLUVIAL DIAGNOSTIC (Bloque 1 test a / C28) 
+Navigation channel disabled vs baseline 
+Generated: 2026-05-30 11:35:33 
+====================================================================== 
+
+---------------------------------------------------------------------- 
+[A] MA GAIN: baseline (with fluvial) vs no-fluvial 
+---------------------------------------------------------------------- 
+  baseline:    share gain 91.0%  mean 1.559  median 0.639 
+  no-fluvial:  share gain 91.0%  mean 1.837  median 0.778 
+
+---------------------------------------------------------------------- 
+[B] POPULATION ELASTICITY, no-fluvial (sector 0, theta low) 
+---------------------------------------------------------------------- 
+  OLS  beta = +0.026 (0.010)  N=309 
+  IV   beta = +0.016 (0.020)  N=309 
+  (baseline-with-fluvial IV-Both was +0.046 (0.033); D-H ~0.5-0.7) 
+
+====================================================================== 
+READING: if no-fluvial gain share drops well below 91% and the 
+IV beta moves up toward 0.5-0.7, the fluvial channel (C28) was 
+inflating MA. If both are basically unchanged, fluvial is NOT the 
+driver and the issue is the overall road-cost magnitude / HMI. 
+====================================================================== 

--- a/results/tables/diagnostic_ma_nofluvial.txt
+++ b/results/tables/diagnostic_ma_nofluvial.txt
@@ -1,7 +1,7 @@
 ====================================================================== 
 MA NO-FLUVIAL DIAGNOSTIC (Bloque 1 test a / C28) 
 Navigation channel disabled vs baseline 
-Generated: 2026-05-30 11:35:33 
+Generated: 2026-05-31 12:28:11 
 ====================================================================== 
 
 ---------------------------------------------------------------------- 
@@ -15,11 +15,11 @@ Generated: 2026-05-30 11:35:33
 ---------------------------------------------------------------------- 
   OLS  beta = +0.026 (0.010)  N=309 
   IV   beta = +0.016 (0.020)  N=309 
-  (baseline-with-fluvial IV-Both was +0.046 (0.033); D-H ~0.5-0.7) 
+  (baseline-with-fluvial IV-Both was +0.046 (0.033); Gibbons 2024 ~0.3) 
 
 ====================================================================== 
 READING: if no-fluvial gain share drops well below 91% and the 
-IV beta moves up toward 0.5-0.7, the fluvial channel (C28) was 
+IV beta moves up toward 0.3 (Gibbons), the fluvial channel (C28) was 
 inflating MA. If both are basically unchanged, fluvial is NOT the 
 driver and the issue is the overall road-cost magnitude / HMI. 
 ====================================================================== 

--- a/results/tables/diagnostic_ma_refpoint.txt
+++ b/results/tables/diagnostic_ma_refpoint.txt
@@ -1,18 +1,14 @@
 ====================================================================== 
 MA REFERENCE-POINT DIAGNOSTIC (Bloque 1 test b / C16) 
 Interior point (st_point_on_surface) vs geographic centroid 
-Generated: 2026-05-30 10:55:47 
+Generated: 2026-05-31 12:28:06 
 ====================================================================== 
 
 Reference points: 312 districts (st_point_on_surface) 
-[tau] actual_1960_s0: running costDistance (this takes ~6 min)... 
-[tau] actual_1960_s0: done in 300 s 
-[tau] actual_1986_s0: running costDistance (this takes ~6 min)... 
-[tau] actual_1986_s0: done in 250 s 
-[tau] instrument_stu_s0: running costDistance (this takes ~6 min)... 
-[tau] instrument_stu_s0: done in 210 s 
-[tau] instrument_lcp_mst_s0: running costDistance (this takes ~6 min)... 
-[tau] instrument_lcp_mst_s0: done in 208 s 
+[tau] actual_1960_s0 already exists, skipping recompute 
+[tau] actual_1986_s0 already exists, skipping recompute 
+[tau] instrument_stu_s0 already exists, skipping recompute 
+[tau] instrument_lcp_mst_s0 already exists, skipping recompute 
 
 ---------------------------------------------------------------------- 
 [A] MA GAIN: baseline centroid vs interior point 
@@ -25,11 +21,11 @@ Reference points: 312 districts (st_point_on_surface)
 ---------------------------------------------------------------------- 
   OLS  beta = +0.010 (0.008)   N=309 
   IV   beta = +0.036 (0.031)   N=309 
-  (baseline-centroid IV-Both was +0.046 (0.033); D-H benchmark ~0.5-0.7) 
+  (baseline-centroid IV-Both was +0.046 (0.033); Gibbons 2024 ~0.3) 
 
 ====================================================================== 
 READING: if interior-point gain share drops well below 91% and/or 
-the IV beta moves toward 0.5-0.7, the geographic centroid + HMI 
+the IV beta moves toward 0.3 (Gibbons), the geographic centroid + HMI 
 off-network coupling (C16) was inflating MA. If both are basically 
 unchanged, the reference point is NOT the driver and suspicion 
 shifts to the fluvial channel (test a) or the cost magnitudes. 

--- a/results/tables/diagnostic_ma_refpoint.txt
+++ b/results/tables/diagnostic_ma_refpoint.txt
@@ -1,0 +1,36 @@
+====================================================================== 
+MA REFERENCE-POINT DIAGNOSTIC (Bloque 1 test b / C16) 
+Interior point (st_point_on_surface) vs geographic centroid 
+Generated: 2026-05-30 10:55:47 
+====================================================================== 
+
+Reference points: 312 districts (st_point_on_surface) 
+[tau] actual_1960_s0: running costDistance (this takes ~6 min)... 
+[tau] actual_1960_s0: done in 300 s 
+[tau] actual_1986_s0: running costDistance (this takes ~6 min)... 
+[tau] actual_1986_s0: done in 250 s 
+[tau] instrument_stu_s0: running costDistance (this takes ~6 min)... 
+[tau] instrument_stu_s0: done in 210 s 
+[tau] instrument_lcp_mst_s0: running costDistance (this takes ~6 min)... 
+[tau] instrument_lcp_mst_s0: done in 208 s 
+
+---------------------------------------------------------------------- 
+[A] MA GAIN: baseline centroid vs interior point 
+---------------------------------------------------------------------- 
+  baseline (centroid):  share gain 91.0%  mean 1.559  median 0.639 
+  interior point:       share gain 89.1%  mean 1.429  median 0.523 
+
+---------------------------------------------------------------------- 
+[B] POPULATION ELASTICITY under interior point (sector 0, theta low) 
+---------------------------------------------------------------------- 
+  OLS  beta = +0.010 (0.008)   N=309 
+  IV   beta = +0.036 (0.031)   N=309 
+  (baseline-centroid IV-Both was +0.046 (0.033); D-H benchmark ~0.5-0.7) 
+
+====================================================================== 
+READING: if interior-point gain share drops well below 91% and/or 
+the IV beta moves toward 0.5-0.7, the geographic centroid + HMI 
+off-network coupling (C16) was inflating MA. If both are basically 
+unchanged, the reference point is NOT the driver and suspicion 
+shifts to the fluvial channel (test a) or the cost magnitudes. 
+====================================================================== 

--- a/results/tables/diagnostic_ma_unimodal.txt
+++ b/results/tables/diagnostic_ma_unimodal.txt
@@ -1,0 +1,37 @@
+====================================================================== 
+MA UNIMODAL / TRANSSHIPMENT-BOUND DIAGNOSTIC (Bloque 1 test c) 
+Infinite transshipment (one mode per trip) vs baseline (free switch) 
+Generated: 2026-05-30 12:11:26 
+====================================================================== 
+
+Building unimodal tau (element-wise min across road/rail/water)... 
+
+---------------------------------------------------------------------- 
+[A] MA GAIN: baseline (zero transshipment) vs unimodal (infinite) 
+---------------------------------------------------------------------- 
+  baseline:  share gain 91.0%  mean 1.559  median 0.639  (N=312) 
+  unimodal:  share gain 78.2%  mean 2.005  median 1.115  (N=312) 
+
+---------------------------------------------------------------------- 
+[B] PAIRWISE tau CHANGE 1960->1986: how much do pairs get cheaper? 
+---------------------------------------------------------------------- 
+  unimodal: 79.0% of pairs cheaper; median tau ratio 0.606 
+  (baseline was 91.6% cheaper, median ratio 0.795 — see diagnostic 1) 
+
+---------------------------------------------------------------------- 
+[C] POPULATION OLS elasticity under unimodal MA (sector 0) 
+---------------------------------------------------------------------- 
+  OLS  beta = +0.018 (0.010)  N=309 
+  (baseline OLS was +0.022; baseline IV-Both +0.046; D-H ~0.5-0.7) 
+  NOTE: full IV needs unimodal instruments too — built only if 
+  this screen implicates transshipment. 
+
+====================================================================== 
+READING: if unimodal gain share stays ~91% and median tau ratio 
+stays ~0.8, transshipment is NOT the driver — the broad cost 
+collapse happens even without free mode-switching. If the gain 
+share drops sharply and pairs stop getting uniformly cheaper, 
+the zero-transshipment assumption is load-bearing and the full 
+mode-expanded-graph model (one node per cell x mode, switch 
+edges with a penalty) is warranted as the real fix. 
+====================================================================== 

--- a/results/tables/diagnostic_ma_unimodal.txt
+++ b/results/tables/diagnostic_ma_unimodal.txt
@@ -1,7 +1,7 @@
 ====================================================================== 
 MA UNIMODAL / TRANSSHIPMENT-BOUND DIAGNOSTIC (Bloque 1 test c) 
 Infinite transshipment (one mode per trip) vs baseline (free switch) 
-Generated: 2026-05-30 12:11:26 
+Generated: 2026-05-31 12:28:12 
 ====================================================================== 
 
 Building unimodal tau (element-wise min across road/rail/water)... 
@@ -22,7 +22,7 @@ Building unimodal tau (element-wise min across road/rail/water)...
 [C] POPULATION OLS elasticity under unimodal MA (sector 0) 
 ---------------------------------------------------------------------- 
   OLS  beta = +0.018 (0.010)  N=309 
-  (baseline OLS was +0.022; baseline IV-Both +0.046; D-H ~0.5-0.7) 
+  (baseline OLS was +0.022; baseline IV-Both +0.046; Gibbons 2024 ~0.3) 
   NOTE: full IV needs unimodal instruments too — built only if 
   this screen implicates transshipment. 
 


### PR DESCRIPTION
Follow-up to Cote's review (C16, C18, C28, P1-P4). Tests the three MA-construction assumptions that could explain the implausible near-universal MA gain (91%) and the tiny population elasticity (0.046 vs Donaldson-Hornbeck 0.5-0.7).

## Results — all three tests

| Test | MA gain share | Population β | Verdict |
|---|---|---|---|
| **Baseline** | 91.0% | +0.046 IV (0.022 OLS) | — |
| **(b) Interior reference point** (C16) | 89.1% | +0.036 IV | not the driver |
| **(a) No fluvial channel** (C28) | 91.0% | +0.016 IV | not the driver |
| **(c) Infinite transshipment / unimodal** (C18 L2) | **78.2%** | +0.018 OLS | shapes distribution, not elasticity |
| _D-H benchmark_ | — | _~0.5-0.7_ | — |

## The key takeaway: two separate problems

The diagnostics **separate two questions Cote had merged**:

1. **The MA distribution has a real, fixable issue — transshipment.** The baseline assumes zero transshipment cost (Dijkstra switches road↔rail↔water for free at any pixel). Disabling that (infinite-transshipment bound) drops the gain share from 91% → 78% and the cheaper-pair share from 92% → 79%. So free mode-switching genuinely inflates how many districts look like winners. Cote's C18-Level-2 instinct is validated; the MA construction should eventually use a mode-expanded graph with a finite switch penalty.

2. **The small elasticity is a SEPARATE, deeper problem.** None of the three construction levers recovers a large effect — the population coefficient stays ~0.02-0.05 across all of them. So fixing transshipment makes MA more defensible but does **not** rescue a Donaldson-Hornbeck-sized elasticity. The puzzle points elsewhere: cost magnitudes (P3), θ, or identification/setting fundamentals.

Tests (a) and (b) come back null, which is itself informative — the centroid+HMI coupling and the cheap-water channel are not the artefact.

## What's a screen vs. a real fix

- (a) and (b) are exact interventions (reused/rebuilt the actual pipeline).
- (c) is the **infinite-transshipment bound** — a screen, not the model. Baseline (zero transshipment) and unimodal (infinite) bracket the truth. The proper fix is a mode-expanded graph (one node per cell × mode, switch edges with a finite penalty), a dedicated multi-hour igraph build, scoped but not attempted pre-meeting.

## Implementation

- One env-var toggle in 03a (`DISABLE_NAVIGATION`, `MODE_VARIANT=roadonly|railonly|wateronly`), honored by combine_cost / validate_cost / save_cost_raster. Variant outputs carry a suffix so baseline is never clobbered. Default behaviour unchanged.
- Determinism confirmed (re-running an existing tau reproduced it exactly).
- Driver scripts: run_nofluvial_variant.sh, run_unimodal_variant.sh. Reports: diagnostic_ma_refpoint.R, diagnostic_ma_nofluvial.R, diagnostic_ma_unimodal.R.

## Outputs
- results/tables/diagnostic_ma_refpoint.txt
- results/tables/diagnostic_ma_nofluvial.txt
- results/tables/diagnostic_ma_unimodal.txt

Together with diagnostic 1 (PR #65), this is the evidence package for the meeting.